### PR TITLE
Fix JDK9 compilation issue, use parser.ast.Module instead of Module

### DIFF
--- a/prism/src/parser/PrismParser.java
+++ b/prism/src/parser/PrismParser.java
@@ -375,7 +375,7 @@ ModulesFile ModulesFile() throws ParseException, PrismLangException {ModelType t
         int typeCount = 0;
         Token typeDupe = null;
         Declaration global;
-        Module m = null;
+        parser.ast.Module m = null;
         RenamedModule rm = null;
         RewardStruct rs = null;
         Expression init = null;
@@ -1027,15 +1027,15 @@ declType.setPosition(begin, getToken(0)); {if ("" != null) return declType;}
 
 // Module
   static final public 
-Module Module() throws ParseException {ExpressionIdent name = null;
+parser.ast.Module Module() throws ParseException {ExpressionIdent name = null;
         Declaration var = null;
         Expression invar;
         Command comm = null;
-        Module module = null;
+        parser.ast.Module module = null;
         Token begin = null;
     begin = jj_consume_token(MODULE);
     name = IdentifierExpression();
-module = new Module(name.getName());
+module = new parser.ast.Module(name.getName());
     label_6:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {

--- a/prism/src/parser/PrismParser.jj
+++ b/prism/src/parser/PrismParser.jj
@@ -535,7 +535,7 @@ ModulesFile ModulesFile() throws PrismLangException :
 	int typeCount = 0;
 	Token typeDupe = null;
 	Declaration global;
-	Module m = null;
+	parser.ast.Module m = null;
 	RenamedModule rm = null;
 	RewardStruct rs = null;
 	Expression init = null;
@@ -791,17 +791,17 @@ DeclarationType DeclarationVarType() :
 
 // Module
 
-Module Module() :
+parser.ast.Module Module() :
 {
 	ExpressionIdent name = null;
 	Declaration var = null;
 	Expression invar;
 	Command comm = null;
-	Module module = null;
+	parser.ast.Module module = null;
 	Token begin = null;
 }
 {
-	begin = <MODULE> name = IdentifierExpression() { module = new Module(name.getName()); }
+	begin = <MODULE> name = IdentifierExpression() { module = new parser.ast.Module(name.getName()); }
 	( var = Declaration() { module.addDeclaration(var); } )*
 	( <INVARIANT> invar = Expression(false, false) <ENDINVARIANT> { module.setInvariant(invar); } )?
 	( comm = Command() { module.addCommand(comm); } )*

--- a/prism/src/parser/VarList.java
+++ b/prism/src/parser/VarList.java
@@ -66,7 +66,7 @@ public class VarList
 		this();
 
 		int i, j, n, n2;
-		Module module;
+		parser.ast.Module module;
 		Declaration decl;
 
 		// First add all globals to the list

--- a/prism/src/parser/visitor/ASTTraverse.java
+++ b/prism/src/parser/visitor/ASTTraverse.java
@@ -196,8 +196,8 @@ public class ASTTraverse implements ASTVisitor
 	}
 	public void visitPost(DeclarationIntUnbounded e) throws PrismLangException { defaultVisitPost(e); }
 	// -----------------------------------------------------------------------------------
-	public void visitPre(Module e) throws PrismLangException { defaultVisitPre(e); }
-	public Object visit(Module e) throws PrismLangException
+	public void visitPre(parser.ast.Module e) throws PrismLangException { defaultVisitPre(e); }
+	public Object visit(parser.ast.Module e) throws PrismLangException
 	{
 		// Note: a few classes override this method (e.g. SemanticCheck)
 		// so take care to update those versions if changing this method
@@ -216,7 +216,7 @@ public class ASTTraverse implements ASTVisitor
 		visitPost(e);
 		return null;
 	}
-	public void visitPost(Module e) throws PrismLangException { defaultVisitPost(e); }
+	public void visitPost(parser.ast.Module e) throws PrismLangException { defaultVisitPost(e); }
 	// -----------------------------------------------------------------------------------
 	public void visitPre(Command e) throws PrismLangException { defaultVisitPre(e); }
 	public Object visit(Command e) throws PrismLangException

--- a/prism/src/parser/visitor/ASTTraverseModify.java
+++ b/prism/src/parser/visitor/ASTTraverseModify.java
@@ -55,7 +55,7 @@ public class ASTTraverseModify implements ASTVisitor
 		}
 		n = e.getNumModules();
 		for (i = 0; i < n; i++) {
-			if (e.getModule(i) != null) e.setModule(i, (Module)(e.getModule(i).accept(this)));
+			if (e.getModule(i) != null) e.setModule(i, (parser.ast.Module)(e.getModule(i).accept(this)));
 		}
 		n = e.getNumSystemDefns();
 		for (i = 0; i < n; i++) {
@@ -211,8 +211,8 @@ public class ASTTraverseModify implements ASTVisitor
 	}
 	public void visitPost(DeclarationIntUnbounded e) throws PrismLangException { defaultVisitPost(e); }
 	// -----------------------------------------------------------------------------------
-	public void visitPre(Module e) throws PrismLangException { defaultVisitPre(e); }
-	public Object visit(Module e) throws PrismLangException
+	public void visitPre(parser.ast.Module e) throws PrismLangException { defaultVisitPre(e); }
+	public Object visit(parser.ast.Module e) throws PrismLangException
 	{
 		visitPre(e);
 		int i, n;
@@ -229,7 +229,7 @@ public class ASTTraverseModify implements ASTVisitor
 		visitPost(e);
 		return e;
 	}
-	public void visitPost(Module e) throws PrismLangException { defaultVisitPost(e); }
+	public void visitPost(parser.ast.Module e) throws PrismLangException { defaultVisitPost(e); }
 	// -----------------------------------------------------------------------------------
 	public void visitPre(Command e) throws PrismLangException { defaultVisitPre(e); }
 	public Object visit(Command e) throws PrismLangException

--- a/prism/src/parser/visitor/ASTVisitor.java
+++ b/prism/src/parser/visitor/ASTVisitor.java
@@ -44,7 +44,7 @@ public interface ASTVisitor
 	public Object visit(DeclarationArray e) throws PrismLangException;
 	public Object visit(DeclarationClock e) throws PrismLangException;
 	public Object visit(DeclarationIntUnbounded e) throws PrismLangException;
-	public Object visit(Module e) throws PrismLangException;
+	public Object visit(parser.ast.Module e) throws PrismLangException;
 	public Object visit(Command e) throws PrismLangException;
 	public Object visit(Updates e) throws PrismLangException;
 	public Object visit(Update e) throws PrismLangException;

--- a/prism/src/parser/visitor/ModulesFileSemanticCheck.java
+++ b/prism/src/parser/visitor/ModulesFileSemanticCheck.java
@@ -54,7 +54,7 @@ public class ModulesFileSemanticCheck extends SemanticCheck
 	public void visitPost(ModulesFile e) throws PrismLangException
 	{
 		int i, j, n, n2;
-		Module m;
+		parser.ast.Module m;
 		Vector<String> v;
 
 		// Check for use of init...endinit _and_ var initial values
@@ -174,13 +174,13 @@ public class ModulesFileSemanticCheck extends SemanticCheck
 		}
 	}
 
-	public void visitPre(Module e) throws PrismLangException
+	public void visitPre(parser.ast.Module e) throws PrismLangException
 	{
 		// Register the fact we are entering a module
 		//inModule = e;
 	}
 
-	public Object visit(Module e) throws PrismLangException
+	public Object visit(parser.ast.Module e) throws PrismLangException
 	{
 		// Override this so we can keep track of when we are in an invariant
 		visitPre(e);
@@ -201,7 +201,7 @@ public class ModulesFileSemanticCheck extends SemanticCheck
 		return null;
 	}
 
-	public void visitPost(Module e) throws PrismLangException
+	public void visitPost(parser.ast.Module e) throws PrismLangException
 	{
 		// Register the fact we are leaving a module
 		//inModule = null;
@@ -230,7 +230,7 @@ public class ModulesFileSemanticCheck extends SemanticCheck
 		int i, n;
 		String s, var;
 		Command c;
-		Module m;
+		parser.ast.Module m;
 		boolean isLocal, isGlobal;
 
 		// Register the fact we are leaving an update

--- a/prism/src/parser/visitor/Rename.java
+++ b/prism/src/parser/visitor/Rename.java
@@ -67,7 +67,7 @@ public class Rename extends ASTTraverseModify
 		}
 	}
 	
-	public void visitPost(Module e) throws PrismLangException
+	public void visitPost(parser.ast.Module e) throws PrismLangException
 	{
 		// New name for module is specied in RenamedModule
 		e.setName(rm.getName());

--- a/prism/src/prism/ExplicitModel2MTBDD.java
+++ b/prism/src/prism/ExplicitModel2MTBDD.java
@@ -128,7 +128,7 @@ public class ExplicitModel2MTBDD
 			this.modulesFile = modulesFile;
 		} else {
 			this.modulesFile = modulesFile = new ModulesFile();
-			Module m = new Module("M");
+			parser.ast.Module m = new parser.ast.Module("M");
 			Declaration d = new Declaration("x", new DeclarationInt(Expression.Int(0), Expression.Int(numStates - 1)));
 			d.setStart(Expression.Int(0));
 			m.addDeclaration(d);

--- a/prism/src/prism/Modules2MTBDD.java
+++ b/prism/src/prism/Modules2MTBDD.java
@@ -902,7 +902,7 @@ public class Modules2MTBDD
 	private SystemDDs translateSystemModule(SystemModule sys, int[] synchMin) throws PrismException
 	{
 		SystemDDs sysDDs;
-		Module module;
+		parser.ast.Module module;
 		String synch;
 		int i, m;
 		
@@ -1366,7 +1366,7 @@ public class Modules2MTBDD
 	// translate a single module to a dd
 	// for a given synchronizing action ("" = none)
 	
-	private ComponentDDs translateModule(int m, Module module, String synch, int synchMin) throws PrismException
+	private ComponentDDs translateModule(int m, parser.ast.Module module, String synch, int synchMin) throws PrismException
 	{
 		ComponentDDs compDDs;
 		JDDNode guardDDs[], upDDs[], tmp;

--- a/prism/src/pta/DigitalClocks.java
+++ b/prism/src/pta/DigitalClocks.java
@@ -184,7 +184,7 @@ public class DigitalClocks
 		allInVariants = null;
 		mf = (ModulesFile) mf.accept(new ASTTraverseModify()
 		{
-			public Object visit(Module e) throws PrismLangException
+			public Object visit(parser.ast.Module e) throws PrismLangException
 			{
 				Command timeCommand;
 				Updates ups;
@@ -505,7 +505,7 @@ public class DigitalClocks
 			scaleFactor = computeGCD(allClockVals);
 		}
 
-		public void visitPre(Module e) throws PrismLangException
+		public void visitPre(parser.ast.Module e) throws PrismLangException
 		{
 			// Create new array to store clocks for this module
 			currentClockList = new ArrayList<String>();

--- a/prism/src/pta/Modules2PTA.java
+++ b/prism/src/pta/Modules2PTA.java
@@ -68,7 +68,7 @@ public class Modules2PTA extends PrismComponent
 	public PTA translate() throws PrismLangException
 	{
 		int i, numModules;
-		Module module, moduleNew;
+		parser.ast.Module module, moduleNew;
 		ArrayList<String> nonClocks;
 		ArrayList<String> allNonClocks = new ArrayList<String>();
 		ArrayList<ArrayList<State>> pcStates;
@@ -85,15 +85,15 @@ public class Modules2PTA extends PrismComponent
 		// Check for inter-module variable references 
 		modulesFile.accept(new ASTTraverse()
 		{
-			private Module inModule = null;
+			private parser.ast.Module inModule = null;
 
-			public void visitPre(Module e) throws PrismLangException
+			public void visitPre(parser.ast.Module e) throws PrismLangException
 			{
 				// Register the fact we are entering a module
 				inModule = e;
 			}
 
-			public void visitPost(Module e) throws PrismLangException
+			public void visitPost(parser.ast.Module e) throws PrismLangException
 			{
 				// Register the fact we are leaving a module
 				inModule = null;
@@ -165,7 +165,7 @@ public class Modules2PTA extends PrismComponent
 	 * Translate a single module.
 	 * (Which has been transformed using convertModuleToPCForm)
 	 */
-	private PTA translateModule(Module module, ArrayList<State> pcStates) throws PrismLangException
+	private PTA translateModule(parser.ast.Module module, ArrayList<State> pcStates) throws PrismLangException
 	{
 		// Clocks and PC variable stuff
 		ArrayList<String> clocks;
@@ -486,7 +486,7 @@ public class Modules2PTA extends PrismComponent
 	 * @param pcVars: The variables that should be converted to a PC.
 	 * @param pcStates: An empty ArrayList into which PC value states will be stored.
 	 */
-	private Module convertModuleToPCForm(Module module, List<String> pcVars, ArrayList<State> pcStates) throws PrismLangException
+	private parser.ast.Module convertModuleToPCForm(parser.ast.Module module, List<String> pcVars, ArrayList<State> pcStates) throws PrismLangException
 	{
 		// Info about variables in model to be used as program counter
 		int pcNumVars;
@@ -494,7 +494,7 @@ public class Modules2PTA extends PrismComponent
 		// info about new program counter var
 		String pc;
 		// Components of old and new module 
-		Module moduleNew;
+		parser.ast.Module moduleNew;
 		Declaration decl, declNew;
 		Command command, commandNew;
 		Expression guard, guardNew;
@@ -545,7 +545,7 @@ public class Modules2PTA extends PrismComponent
 		}
 
 		// Create a new module
-		moduleNew = new Module(module.getName());
+		moduleNew = new parser.ast.Module(module.getName());
 		
 		// Preserve alphabet of old module (might change if some commands are not enabled)
 		moduleNew.setAlphabet(module.getAllSynchs());

--- a/prism/src/userinterface/simulator/GUISimulatorPathTableModel.java
+++ b/prism/src/userinterface/simulator/GUISimulatorPathTableModel.java
@@ -112,7 +112,7 @@ public class GUISimulatorPathTableModel extends AbstractTableModel implements GU
 			}
 
 			for (int m = 0; m < parsedModel.getNumModules(); m++) {
-				Module module = parsedModel.getModule(m);
+				parser.ast.Module module = parsedModel.getModule(m);
 				for (int v = 0; v < module.getNumDeclarations(); v++) {
 					if (varNames.contains(module.getDeclaration(v).getName())) {
 						groupCount++;
@@ -182,7 +182,7 @@ public class GUISimulatorPathTableModel extends AbstractTableModel implements GU
 				}
 
 				for (int m = 0; m < parsedModel.getNumModules(); m++) {
-					Module module = parsedModel.getModule(m);
+					parser.ast.Module module = parsedModel.getModule(m);
 					for (int v = 0; v < module.getNumDeclarations(); v++) {
 						if (varNames.contains(module.getDeclaration(v).getName())) {
 							if (groupCount == groupIndex) {
@@ -248,7 +248,7 @@ public class GUISimulatorPathTableModel extends AbstractTableModel implements GU
 		}
 
 		for (int m = 0; m < parsedModel.getNumModules(); m++) {
-			Module module = parsedModel.getModule(m);
+			parser.ast.Module module = parsedModel.getModule(m);
 			for (int v = 0; v < module.getNumDeclarations(); v++) {
 				if (varNames.contains(module.getDeclaration(v).getName())) {
 					if (groupCount == groupIndex) {
@@ -336,7 +336,7 @@ public class GUISimulatorPathTableModel extends AbstractTableModel implements GU
 			}
 
 			for (int m = 0; m < parsedModel.getNumModules(); m++) {
-				Module module = parsedModel.getModule(m);
+				parser.ast.Module module = parsedModel.getModule(m);
 				boolean atLeastOne = false;
 
 				for (int v = 0; v < module.getNumDeclarations(); v++) {

--- a/prism/src/userinterface/simulator/SimulationView.java
+++ b/prism/src/userinterface/simulator/SimulationView.java
@@ -217,7 +217,7 @@ public class SimulationView extends Observable
 					canUseCurrentView = false;
 			}
 			for (int m = 0; m < parsedModel.getNumModules(); m++) {
-				Module module = parsedModel.getModule(m);
+				parser.ast.Module module = parsedModel.getModule(m);
 				for (int v = 0; v < module.getNumDeclarations(); v++) {
 					if (!allVarNames.remove(module.getDeclaration(v).getName()))
 						canUseCurrentView = false;
@@ -275,7 +275,7 @@ public class SimulationView extends Observable
 					i++;
 				}
 				for (int m = 0; m < parsedModel.getNumModules(); m++) {
-					Module module = parsedModel.getModule(m);
+					parser.ast.Module module = parsedModel.getModule(m);
 					for (int v = 0; v < module.getNumDeclarations(); v++) {
 						visibleVariables.add(new Variable(i, module.getDeclaration(v).getName(), module.getDeclaration(v).getType()));
 						i++;


### PR DESCRIPTION
In the upcoming Java 9, there is a `java.lang.Module` class which is imported automatically due to the `java.lang` package. This clashes with PRISM's `parser.ast.Module` class, leading to numerous compilation errors, as the compiler can not disambiguate between the two.

The attached fix resolves this by explicitly writing `parser.ast.Module` instead of `Module`, where required.

Question: Do we want to resolve it like this or do we rename `parser.ast.Module` to something that does not clash? I don't really have a preference.

With this fix, PRISM compiles on Java 9 (tested on Linux), with some warnings. Test suite passes.