### PR TITLE
Several fixes/improvements for parametric / exact engine.

### DIFF
--- a/prism/src/explicit/DTMCModelChecker.java
+++ b/prism/src/explicit/DTMCModelChecker.java
@@ -744,7 +744,8 @@ public class DTMCModelChecker extends ProbModelChecker
 
 		// Start precomputation
 		timer = System.currentTimeMillis();
-		mainLog.println("Starting Prob0...");
+		if (!silentPrecomputations)
+			mainLog.println("Starting Prob0...");
 
 		// Special case: no target states
 		if (target.isEmpty()) {
@@ -765,8 +766,10 @@ public class DTMCModelChecker extends ProbModelChecker
 
 		// Finished precomputation
 		timer = System.currentTimeMillis() - timer;
-		mainLog.print("Prob0");
-		mainLog.println(" took " + timer / 1000.0 + " seconds.");
+		if (!silentPrecomputations) {
+			mainLog.print("Prob0");
+			mainLog.println(" took " + timer / 1000.0 + " seconds.");
+		}
 
 		return result;
 	}
@@ -788,7 +791,8 @@ public class DTMCModelChecker extends ProbModelChecker
 
 		// Start precomputation
 		timer = System.currentTimeMillis();
-		mainLog.println("Starting Prob0...");
+		if (!silentPrecomputations)
+			mainLog.println("Starting Prob0...");
 
 		// Special case: no target states
 		if (target.cardinality() == 0) {
@@ -832,8 +836,10 @@ public class DTMCModelChecker extends ProbModelChecker
 
 		// Finished precomputation
 		timer = System.currentTimeMillis() - timer;
-		mainLog.print("Prob0");
-		mainLog.println(" took " + iters + " iterations and " + timer / 1000.0 + " seconds.");
+		if (!silentPrecomputations) {
+			mainLog.print("Prob0");
+			mainLog.println(" took " + iters + " iterations and " + timer / 1000.0 + " seconds.");
+		}
 
 		return u;
 	}
@@ -854,7 +860,8 @@ public class DTMCModelChecker extends ProbModelChecker
 
 		// Start precomputation
 		timer = System.currentTimeMillis();
-		mainLog.println("Starting Prob1...");
+		if (!silentPrecomputations)
+			mainLog.println("Starting Prob1...");
 
 		// Special case: no 'target' states
 		if (target.isEmpty()) {
@@ -899,8 +906,10 @@ public class DTMCModelChecker extends ProbModelChecker
 
 		// Finished precomputation
 		timer = System.currentTimeMillis() - timer;
-		mainLog.print("Prob1");
-		mainLog.println(" took " + timer / 1000.0 + " seconds.");
+		if (!silentPrecomputations) {
+			mainLog.print("Prob1");
+			mainLog.println(" took " + timer / 1000.0 + " seconds.");
+		}
 
 		return result;
 	}
@@ -922,7 +931,8 @@ public class DTMCModelChecker extends ProbModelChecker
 
 		// Start precomputation
 		timer = System.currentTimeMillis();
-		mainLog.println("Starting Prob1...");
+		if (!silentPrecomputations)
+			mainLog.println("Starting Prob1...");
 
 		// Special case: no target states
 		if (target.cardinality() == 0) {
@@ -974,8 +984,10 @@ public class DTMCModelChecker extends ProbModelChecker
 
 		// Finished precomputation
 		timer = System.currentTimeMillis() - timer;
-		mainLog.print("Prob1");
-		mainLog.println(" took " + iters + " iterations and " + timer / 1000.0 + " seconds.");
+		if (!silentPrecomputations) {
+			mainLog.print("Prob1");
+			mainLog.println(" took " + iters + " iterations and " + timer / 1000.0 + " seconds.");
+		}
 
 		return u;
 	}

--- a/prism/src/explicit/MDP.java
+++ b/prism/src/explicit/MDP.java
@@ -40,9 +40,13 @@ import explicit.rewards.MDPRewards;
 import prism.PrismUtils;
 
 /**
- * Interface for classes that provide (read) access to an explicit-state MDP.
+ * Interface for classes that provide (read) access to an explicit-state MDP,
+ * where the transition probabilities are stored as double floating point values.
+ * <br>
+ * For the generic methods, e.g., the prob0 / prob1 precomputations that do not
+ * care about the concrete values, see {@link explicit.MDPGeneric}.
  */
-public interface MDP extends NondetModel
+public interface MDP extends MDPGeneric<Double>
 {
 	/**
 	 * Get an iterator over the transitions from choice {@code i} of state {@code s}.
@@ -119,149 +123,6 @@ public interface MDP extends NondetModel
 		forEachTransition(s, i, sum::accept);
 
 		return sum.sum;
-	}
-
-	/**
-	 * Perform a single step of precomputation algorithm Prob0, i.e., for states i in {@code subset},
-	 * set bit i of {@code result} iff, for all/some choices,
-	 * there is a transition to a state in {@code u}.
-	 * Quantification over choices is determined by {@code forall}.
-	 * @param subset Only compute for these states
-	 * @param u Set of states {@code u}
-	 * @param forall For-all or there-exists (true=for-all, false=there-exists)
-	 * @param result Store results here
-	 */
-	public default void prob0step(final BitSet subset, final BitSet u, final boolean forall, final BitSet result)
-	{
-		for (OfInt it = new IterableStateSet(subset, getNumStates()).iterator(); it.hasNext();) {
-			final int s = it.nextInt();
-			boolean b1 = forall; // there exists or for all
-			for (int choice = 0, numChoices = getNumChoices(s); choice < numChoices; choice++) {
-				boolean b2 = someSuccessorsInSet(s, choice, u);
-				if (forall) {
-					if (!b2) {
-						b1 = false;
-						break;
-					}
-				} else {
-					if (b2) {
-						b1 = true;
-						break;
-					}
-				}
-			}
-			result.set(s, b1);
-		}
-	}
-
-	/**
-	 * Perform a single step of precomputation algorithm Prob1A, i.e., for states i in {@code subset},
-	 * set bit i of {@code result} iff, for all choices,
-	 * there is a transition to a state in {@code v} and all transitions go to states in {@code u}.
-	 * @param subset Only compute for these states
-	 * @param u Set of states {@code u}
-	 * @param v Set of states {@code v}
-	 * @param result Store results here
-	 */
-	public default void prob1Astep(BitSet subset, BitSet u, BitSet v, BitSet result)
-	{
-		boolean b1;
-		for (OfInt it = new IterableStateSet(subset, getNumStates()).iterator(); it.hasNext();) {
-			final int s = it.nextInt();
-			b1 = true;
-			for (int choice = 0, numChoices = getNumChoices(s); choice < numChoices; choice++) {
-				if (!(successorsSafeAndCanReach(s, choice, u, v))) {
-					b1 = false;
-					break;
-				}
-			}
-			result.set(s, b1);
-		}
-	}
-
-	/**
-	 * Perform a single step of precomputation algorithm Prob1E, i.e., for states i in {@code subset},
-	 * set bit i of {@code result} iff, for some choice,
-	 * there is a transition to a state in {@code v} and all transitions go to states in {@code u}.
-	 * Optionally, store optimal (memoryless) strategy info for 1 states. 
-	 * @param subset Only compute for these states
-	 * @param u Set of states {@code u}
-	 * @param v Set of states {@code v}
-	 * @param result Store results here
-	 * @param strat Storage for (memoryless) strategy choice indices (ignored if null)
-	 */
-	public default void prob1Estep(BitSet subset, BitSet u, BitSet v, BitSet result, int strat[])
-	{
-		int stratCh = -1;
-		boolean b1;
-		for (OfInt it = new IterableStateSet(subset, getNumStates()).iterator(); it.hasNext();) {
-			final int s = it.nextInt();
-			b1 = false;
-			for (int choice = 0, numChoices = getNumChoices(s); choice < numChoices; choice++) {
-				if (successorsSafeAndCanReach(s, choice, u, v)) {
-					b1 = true;
-					// If strategy generation is enabled, remember optimal choice
-					if (strat != null)
-						stratCh = choice;
-					break;
-				}
-			}
-			// If strategy generation is enabled, store optimal choice
-			// (only if this the first time we add the state to S^yes)
-			if (strat != null & b1 & !result.get(s)) {
-				strat[s] = stratCh;
-			}
-			// Store result
-			result.set(s, b1);
-		}
-	}
-
-	/**
-	 * Perform a single step of precomputation algorithm Prob1, i.e., for states i in {@code subset},
-	 * set bit i of {@code result} iff, for all/some choices,
-	 * there is a transition to a state in {@code v} and all transitions go to states in {@code u}.
-	 * Quantification over choices is determined by {@code forall}.
-	 * @param subset Only compute for these states
-	 * @param u Set of states {@code u}
-	 * @param v Set of states {@code v}
-	 * @param forall For-all or there-exists (true=for-all, false=there-exists)
-	 * @param result Store results here
-	 */
-	public default void prob1step(BitSet subset, BitSet u, BitSet v, boolean forall, BitSet result)
-	{
-		boolean b1, b2;
-		for (OfInt it = new IterableStateSet(subset, getNumStates()).iterator(); it.hasNext();) {
-			final int s = it.nextInt();
-			b1 = forall; // there exists or for all
-			for (int choice = 0, numChoices = getNumChoices(s); choice < numChoices; choice++) {
-				b2 = successorsSafeAndCanReach(s, choice, u, v);
-				if (forall) {
-					if (!b2) {
-						b1 = false;
-						break;
-					}
-				} else {
-					if (b2) {
-						b1 = true;
-						break;
-					}
-				}
-			}
-			result.set(s, b1);
-		}
-	}
-
-	/**
-	 * Perform a single step of precomputation algorithm Prob1 for a single state/choice,
-	 * i.e., return whether there is a transition to a state in {@code v} and all transitions go to states in {@code u}.
-	 * @param s State (row) index
-	 * @param i Choice index
-	 * @param u Set of states {@code u}
-	 * @param v Set of states {@code v}
-	 */
-	public default boolean prob1stepSingle(int s, int i, BitSet u, BitSet v)
-	{
-		return successorsSafeAndCanReach(s, i, u, v);
 	}
 
 	/**

--- a/prism/src/explicit/MDPGeneric.java
+++ b/prism/src/explicit/MDPGeneric.java
@@ -1,0 +1,193 @@
+//==============================================================================
+//	
+//	Copyright (c) 2002-
+//	Authors:
+//	* Dave Parker <david.parker@comlab.ox.ac.uk> (University of Oxford)
+//	
+//------------------------------------------------------------------------------
+//	
+//	This file is part of PRISM.
+//	
+//	PRISM is free software; you can redistribute it and/or modify
+//	it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation; either version 2 of the License, or
+//	(at your option) any later version.
+//	
+//	PRISM is distributed in the hope that it will be useful,
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//	GNU General Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License
+//	along with PRISM; if not, write to the Free Software Foundation,
+//	Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//	
+//==============================================================================
+
+package explicit;
+
+import java.util.BitSet;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.PrimitiveIterator.OfInt;
+
+import common.IterableStateSet;
+
+/**
+ * Interface for classes that provide (read) access to an explicit-state MDP,
+ * gathering the generic methods, i.e., those that are independent of the
+ * underlying value type used for the transition probabilities.
+ * <br>
+ * This allows use of these methods e.g. in the explicit and parametric engines.
+ */
+public interface MDPGeneric<Value> extends NondetModel
+{
+	/**
+	 * Get an iterator over the transitions from choice {@code i} of state {@code s}.
+	 */
+	public Iterator<Entry<Integer, Value>> getTransitionsIterator(int s, int i);
+
+	/**
+	 * Perform a single step of precomputation algorithm Prob0, i.e., for states i in {@code subset},
+	 * set bit i of {@code result} iff, for all/some choices,
+	 * there is a transition to a state in {@code u}.
+	 * Quantification over choices is determined by {@code forall}.
+	 * @param subset Only compute for these states
+	 * @param u Set of states {@code u}
+	 * @param forall For-all or there-exists (true=for-all, false=there-exists)
+	 * @param result Store results here
+	 */
+	public default void prob0step(final BitSet subset, final BitSet u, final boolean forall, final BitSet result)
+	{
+		for (OfInt it = new IterableStateSet(subset, getNumStates()).iterator(); it.hasNext();) {
+			final int s = it.nextInt();
+			boolean b1 = forall; // there exists or for all
+			for (int choice = 0, numChoices = getNumChoices(s); choice < numChoices; choice++) {
+				boolean b2 = someSuccessorsInSet(s, choice, u);
+				if (forall) {
+					if (!b2) {
+						b1 = false;
+						break;
+					}
+				} else {
+					if (b2) {
+						b1 = true;
+						break;
+					}
+				}
+			}
+			result.set(s, b1);
+		}
+	}
+
+	/**
+	 * Perform a single step of precomputation algorithm Prob1A, i.e., for states i in {@code subset},
+	 * set bit i of {@code result} iff, for all choices,
+	 * there is a transition to a state in {@code v} and all transitions go to states in {@code u}.
+	 * @param subset Only compute for these states
+	 * @param u Set of states {@code u}
+	 * @param v Set of states {@code v}
+	 * @param result Store results here
+	 */
+	public default void prob1Astep(BitSet subset, BitSet u, BitSet v, BitSet result)
+	{
+		boolean b1;
+		for (OfInt it = new IterableStateSet(subset, getNumStates()).iterator(); it.hasNext();) {
+			final int s = it.nextInt();
+			b1 = true;
+			for (int choice = 0, numChoices = getNumChoices(s); choice < numChoices; choice++) {
+				if (!(successorsSafeAndCanReach(s, choice, u, v))) {
+					b1 = false;
+					break;
+				}
+			}
+			result.set(s, b1);
+		}
+	}
+
+	/**
+	 * Perform a single step of precomputation algorithm Prob1E, i.e., for states i in {@code subset},
+	 * set bit i of {@code result} iff, for some choice,
+	 * there is a transition to a state in {@code v} and all transitions go to states in {@code u}.
+	 * Optionally, store optimal (memoryless) strategy info for 1 states.
+	 * @param subset Only compute for these states
+	 * @param u Set of states {@code u}
+	 * @param v Set of states {@code v}
+	 * @param result Store results here
+	 * @param strat Storage for (memoryless) strategy choice indices (ignored if null)
+	 */
+	public default void prob1Estep(BitSet subset, BitSet u, BitSet v, BitSet result, int strat[])
+	{
+		int stratCh = -1;
+		boolean b1;
+		for (OfInt it = new IterableStateSet(subset, getNumStates()).iterator(); it.hasNext();) {
+			final int s = it.nextInt();
+			b1 = false;
+			for (int choice = 0, numChoices = getNumChoices(s); choice < numChoices; choice++) {
+				if (successorsSafeAndCanReach(s, choice, u, v)) {
+					b1 = true;
+					// If strategy generation is enabled, remember optimal choice
+					if (strat != null)
+						stratCh = choice;
+					break;
+				}
+			}
+			// If strategy generation is enabled, store optimal choice
+			// (only if this the first time we add the state to S^yes)
+			if (strat != null & b1 & !result.get(s)) {
+				strat[s] = stratCh;
+			}
+			// Store result
+			result.set(s, b1);
+		}
+	}
+
+	/**
+	 * Perform a single step of precomputation algorithm Prob1, i.e., for states i in {@code subset},
+	 * set bit i of {@code result} iff, for all/some choices,
+	 * there is a transition to a state in {@code v} and all transitions go to states in {@code u}.
+	 * Quantification over choices is determined by {@code forall}.
+	 * @param subset Only compute for these states
+	 * @param u Set of states {@code u}
+	 * @param v Set of states {@code v}
+	 * @param forall For-all or there-exists (true=for-all, false=there-exists)
+	 * @param result Store results here
+	 */
+	public default void prob1step(BitSet subset, BitSet u, BitSet v, boolean forall, BitSet result)
+	{
+		boolean b1, b2;
+		for (OfInt it = new IterableStateSet(subset, getNumStates()).iterator(); it.hasNext();) {
+			final int s = it.nextInt();
+			b1 = forall; // there exists or for all
+			for (int choice = 0, numChoices = getNumChoices(s); choice < numChoices; choice++) {
+				b2 = successorsSafeAndCanReach(s, choice, u, v);
+				if (forall) {
+					if (!b2) {
+						b1 = false;
+						break;
+					}
+				} else {
+					if (b2) {
+						b1 = true;
+						break;
+					}
+				}
+			}
+			result.set(s, b1);
+		}
+	}
+
+	/**
+	 * Perform a single step of precomputation algorithm Prob1 for a single state/choice,
+	 * i.e., return whether there is a transition to a state in {@code v} and all transitions go to states in {@code u}.
+	 * @param s State (row) index
+	 * @param i Choice index
+	 * @param u Set of states {@code u}
+	 * @param v Set of states {@code v}
+	 */
+	public default boolean prob1stepSingle(int s, int i, BitSet u, BitSet v)
+	{
+		return successorsSafeAndCanReach(s, i, u, v);
+	}
+
+}

--- a/prism/src/explicit/MDPModelChecker.java
+++ b/prism/src/explicit/MDPModelChecker.java
@@ -602,7 +602,8 @@ public class MDPModelChecker extends ProbModelChecker
 
 		// Start precomputation
 		timer = System.currentTimeMillis();
-		mainLog.println("Starting Prob0 (" + (min ? "min" : "max") + ")...");
+		if (!silentPrecomputations)
+			mainLog.println("Starting Prob0 (" + (min ? "min" : "max") + ")...");
 
 		// Special case: no target states
 		if (target.cardinality() == 0) {
@@ -646,8 +647,10 @@ public class MDPModelChecker extends ProbModelChecker
 
 		// Finished precomputation
 		timer = System.currentTimeMillis() - timer;
-		mainLog.print("Prob0 (" + (min ? "min" : "max") + ")");
-		mainLog.println(" took " + iters + " iterations and " + timer / 1000.0 + " seconds.");
+		if (!silentPrecomputations) {
+			mainLog.print("Prob0 (" + (min ? "min" : "max") + ")");
+			mainLog.println(" took " + iters + " iterations and " + timer / 1000.0 + " seconds.");
+		}
 
 		// If required, generate strategy. This is for min probs,
 		// so it can be done *after* the main prob0 algorithm (unlike for prob1).
@@ -688,7 +691,8 @@ public class MDPModelChecker extends ProbModelChecker
 
 		// Start precomputation
 		timer = System.currentTimeMillis();
-		mainLog.println("Starting Prob1 (" + (min ? "min" : "max") + ")...");
+		if (!silentPrecomputations)
+			mainLog.println("Starting Prob1 (" + (min ? "min" : "max") + ")...");
 
 		// Special case: no target states
 		if (target.cardinality() == 0) {
@@ -766,8 +770,10 @@ public class MDPModelChecker extends ProbModelChecker
 
 		// Finished precomputation
 		timer = System.currentTimeMillis() - timer;
-		mainLog.print("Prob1 (" + (min ? "min" : "max") + ")");
-		mainLog.println(" took " + iters + " iterations and " + timer / 1000.0 + " seconds.");
+		if (!silentPrecomputations) {
+			mainLog.print("Prob1 (" + (min ? "min" : "max") + ")");
+			mainLog.println(" took " + iters + " iterations and " + timer / 1000.0 + " seconds.");
+		}
 
 		return u;
 	}

--- a/prism/src/explicit/MDPModelChecker.java
+++ b/prism/src/explicit/MDPModelChecker.java
@@ -609,6 +609,11 @@ public class MDPModelChecker extends ProbModelChecker
 		if (target.cardinality() == 0) {
 			soln = new BitSet(mdp.getNumStates());
 			soln.set(0, mdp.getNumStates());
+
+			// for min, generate strategy, any choice (-2) is fine
+			if (min && strat != null) {
+				Arrays.fill(strat, -2);
+			}
 			return soln;
 		}
 

--- a/prism/src/explicit/MDPModelChecker.java
+++ b/prism/src/explicit/MDPModelChecker.java
@@ -593,7 +593,7 @@ public class MDPModelChecker extends ProbModelChecker
 	 * @param min Min or max probabilities (true=min, false=max)
 	 * @param strat Storage for (memoryless) strategy choice indices (ignored if null)
 	 */
-	public BitSet prob0(MDP mdp, BitSet remain, BitSet target, boolean min, int strat[])
+	public BitSet prob0(MDPGeneric<?> mdp, BitSet remain, BitSet target, boolean min, int strat[])
 	{
 		int n, iters;
 		BitSet u, soln, unknown;
@@ -687,7 +687,7 @@ public class MDPModelChecker extends ProbModelChecker
 	 * @param min Min or max probabilities (true=min, false=max)
 	 * @param strat Storage for (memoryless) strategy choice indices (ignored if null)
 	 */
-	public BitSet prob1(MDP mdp, BitSet remain, BitSet target, boolean min, int strat[])
+	public BitSet prob1(MDPGeneric<?> mdp, BitSet remain, BitSet target, boolean min, int strat[])
 	{
 		int n, iters;
 		BitSet u, v, soln, unknown;

--- a/prism/src/explicit/ProbModelChecker.java
+++ b/prism/src/explicit/ProbModelChecker.java
@@ -79,6 +79,8 @@ public class ProbModelChecker extends NonProbModelChecker
 	protected boolean precomp = true;
 	protected boolean prob0 = true;
 	protected boolean prob1 = true;
+	// should we suppress log output during precomputations?
+	protected boolean silentPrecomputations = false;
 	// Use predecessor relation? (e.g. for precomputation)
 	protected boolean preRel = true;
 	// Direction of convergence for value iteration (lfp/gfp)
@@ -289,6 +291,18 @@ public class ProbModelChecker extends NonProbModelChecker
 	public void setVerbosity(int verbosity)
 	{
 		this.verbosity = verbosity;
+	}
+
+	/**
+	 * Set flag for suppressing log output during precomputations (prob0, prob1, ...)
+	 * @param value silent?
+	 * @return the previous value of this flag
+	 */
+	public boolean setSilentPrecomputations(boolean value)
+	{
+		boolean old = silentPrecomputations;
+		silentPrecomputations = value;
+		return old;
 	}
 
 	/**

--- a/prism/src/param/BigRational.java
+++ b/prism/src/param/BigRational.java
@@ -185,6 +185,10 @@ public final class BigRational implements Comparable<BigRational>
 			this.num = new BigInteger("-1");
 			this.den = new BigInteger("0");
 			return;
+		} else if (string.equals("NaN")) {
+			this.num = new BigInteger("0");
+			this.den = new BigInteger("0");
+			return;
 		}
 		BigInteger num;
 		BigInteger den;

--- a/prism/src/param/BigRational.java
+++ b/prism/src/param/BigRational.java
@@ -825,6 +825,22 @@ public final class BigRational implements Comparable<BigRational>
 	}
 
 	/**
+	 * Return an approximate String representation (via conversion to double).
+	 * If the conversion is imprecise, the result string is prefixed by '~'.
+	 */
+	public String toApproximateString()
+	{
+		String result = Double.toString(doubleValue());
+		if (new BigRational(result).equals(this)) {
+			// round-trip did not lose precision
+			return result;
+		}
+		// only approximate
+		return "~" + result;
+
+	}
+
+	/**
 	 * Returns the int representation of this value,
 	 * if this value is an integer and if the integer can
 	 * be represented by an int variable.

--- a/prism/src/param/BoxRegion.java
+++ b/prism/src/param/BoxRegion.java
@@ -470,11 +470,17 @@ final class BoxRegion extends Region {
 		}
 		return result;
 	}
-	
+
 	@Override
 	ArrayList<Region> split(Function constraint)
 	{
 		// TODO could implement more clever splitting using constraints
+		return split();
+	}
+
+	@Override
+	ArrayList<Region> split()
+	{
 		if (((BoxRegionFactory) factory).getSplitMethod() == SPLIT_LONGEST) {
 			return splitLongest();
 		} else if (((BoxRegionFactory) factory).getSplitMethod() == SPLIT_ALL) {

--- a/prism/src/param/ConstraintChecker.java
+++ b/prism/src/param/ConstraintChecker.java
@@ -166,6 +166,20 @@ class ConstraintChecker {
 	 */
 	boolean check(Region region, Function constraint, boolean strict)
 	{
+		// handle case where the constraint is a constant number
+		if (constraint.isConstant()) {
+			BigRational value = constraint.asBigRational();
+
+			if (value.isNaN())
+				return false;
+
+			if (strict) {
+				return value.signum() == 1;
+			} else {
+				return value.signum() >= 0;
+			}
+		}
+
 		Function constr = constraint.toConstraint();
 		DecisionEntryKey key = new DecisionEntryKey();
 		key.constraint = constr;

--- a/prism/src/param/ConstraintChecker.java
+++ b/prism/src/param/ConstraintChecker.java
@@ -40,6 +40,8 @@ import java.util.HashMap;
  * @author Ernst Moritz Hahn <emhahn@cs.ox.ac.uk> (University of Oxford)
  */
 class ConstraintChecker {
+	private boolean usedUnsoundCheck = false;
+
 	/**
 	 * Class to store keys for the cache of the decision procedure.
 	 */
@@ -124,6 +126,7 @@ class ConstraintChecker {
 	 */
 	boolean mainCheck(Region region, Function constraint, boolean strict)
 	{
+		usedUnsoundCheck = true;
 		return true;
 	}
 
@@ -197,4 +200,10 @@ class ConstraintChecker {
 
 		return result;
 	}
+
+	public boolean unsoundCheckWasUsed()
+	{
+		return usedUnsoundCheck;
+	}
+
 }

--- a/prism/src/param/ModelBuilder.java
+++ b/prism/src/param/ModelBuilder.java
@@ -55,6 +55,8 @@ import prism.PrismSettings;
  */
 public final class ModelBuilder extends PrismComponent
 {
+	/** mode (parametric / exact) */
+	private final ParamMode mode;
 	/** the ModelGeneratorSymbolic interface providing the model to be transformed to a {@code ParamModel} */
 	private ModelGeneratorSymbolic modelGenSym;
 	/** function factory used in the constructed parametric model */
@@ -76,9 +78,10 @@ public final class ModelBuilder extends PrismComponent
 	/**
 	 * Constructor
 	 */
-	public ModelBuilder(PrismComponent parent) throws PrismException
+	public ModelBuilder(PrismComponent parent, ParamMode mode) throws PrismException
 	{
 		super(parent);
+		this.mode = mode;
 		// If present, initialise settings from PrismSettings
 		if (settings != null) {
 			functionType = settings.getString(PrismSettings.PRISM_PARAM_FUNCTION);
@@ -132,7 +135,7 @@ public final class ModelBuilder extends PrismComponent
 			case ExpressionBinaryOp.DIVIDE:
 				return f1.divide(f2);
 			default:
-				throw new PrismNotSupportedException("parametric analysis with rate/probability of " + expr + " not implemented");
+				throw new PrismNotSupportedException("For " + mode.engine() + ", analysis with rate/probability of " + expr + " not implemented");
 			}
 		} else if (expr instanceof ExpressionUnaryOp) {
 			ExpressionUnaryOp unExpr = ((ExpressionUnaryOp) expr);
@@ -143,7 +146,7 @@ public final class ModelBuilder extends PrismComponent
 			case ExpressionUnaryOp.PARENTH:
 				return f;
 			default:
-				throw new PrismNotSupportedException("parametric analysis with rate/probability of " + expr + " not implemented");
+				throw new PrismNotSupportedException("For " + mode.engine() + ", analysis with rate/probability of " + expr + " not implemented");
 			}
 		} else if (expr instanceof ExpressionITE){
 			ExpressionITE iteExpr = (ExpressionITE) expr;
@@ -165,7 +168,7 @@ public final class ModelBuilder extends PrismComponent
 					// Do nothing here, exception is thrown below
 				}
 			}
-			throw new PrismNotSupportedException("parametric analysis with rate/probability of " + expr + " not implemented");
+			throw new PrismNotSupportedException("For " + mode.engine() + ", analysis with rate/probability of " + expr + " not implemented");
 		} else if (expr instanceof ExpressionFunc) {
 			// functions (min, max, floor, ...) are supported if
 			// they don't refer to parametric constants in their arguments
@@ -178,10 +181,10 @@ public final class ModelBuilder extends PrismComponent
 				return factory.fromBigRational(value);
 			} catch (PrismException e) {
 				// Most likely, a parametric constant occurred.
-				throw new PrismNotSupportedException("parametric analysis with rate/probability of " + expr + " not implemented");
+				throw new PrismNotSupportedException("For " + mode.engine() + ", analysis with rate/probability of " + expr + " not implemented");
 			}
 		} else {
-			throw new PrismNotSupportedException("parametric analysis with rate/probability of " + expr + " not implemented");
+			throw new PrismNotSupportedException("For " + mode.engine() + ", analysis with rate/probability of " + expr + " not implemented");
 		}
 	}
 
@@ -248,7 +251,7 @@ public final class ModelBuilder extends PrismComponent
 		});*/
 		
 		// Build/return model
-		mainLog.print("\nBuilding model...\n");
+		mainLog.print("\nBuilding model (" + mode.engine() + ")...\n");
 		long time = System.currentTimeMillis();
 		ParamModel modelExpl = doModelConstruction(modelGenSym);
 		time = System.currentTimeMillis() - time;

--- a/prism/src/param/ModelBuilder.java
+++ b/prism/src/param/ModelBuilder.java
@@ -327,7 +327,7 @@ public final class ModelBuilder extends PrismComponent
 	 */
 	private ParamModel doModelConstruction(ModelGeneratorSymbolic modelGenSym) throws PrismException
 	{
-		ModelType modelType;
+		final ModelType modelType;
 
 		if (!modelGenSym.hasSingleInitialState()) {
 			throw new PrismNotSupportedException("Cannot do explicit-state reachability if there are multiple initial states");
@@ -399,11 +399,35 @@ public final class ModelBuilder extends PrismComponent
 				for (int succNr = 0; succNr < numSuccessors; succNr++) {
 					State stateNew = modelGenSym.computeTransitionTarget(choiceNr, succNr);
 					Function probFn = modelGenSym.getTransitionProbabilityFunction(choiceNr, succNr);
+
+					if (modelType == ModelType.CTMC) {
+						// check rate (non-normal?)
+						if (probFn.isInf() || probFn.isMInf() || probFn.isNaN()) {
+							throw new PrismException("For state " + state.toString(modelGenSym) + ", illegal rate " + probFn.asBigRational());
+						}
+						// check rate, if constant (negative?)
+						if (probFn.isConstant() && probFn.asBigRational().signum() < 0) {
+							throw new PrismException("For state " + state.toString(modelGenSym) + ", negative rate " + probFn.asBigRational());
+						}
+					}
+
 					// divide by sumOut
 					// for DTMC, this normalises over the choices
 					// for CTMC this builds the embedded DTMC
 					// for MDP this does nothing (sumOut is set to 1)
 					probFn = probFn.divide(sumOut);
+
+					if (modelType == ModelType.DTMC || modelType == ModelType.MDP) {
+						// check probability (non-normal?)
+						if (probFn.isInf() || probFn.isMInf() || probFn.isNaN()) {
+							throw new PrismException("For state " + state.toString(modelGenSym) + ", illegal probability " + probFn.asBigRational());
+						}
+						// check probability, if constant (negative?)
+						if (probFn.isConstant() && probFn.asBigRational().signum() < 0) {
+							throw new PrismException("For state " + state.toString(modelGenSym) + ", negative probability " + probFn.asBigRational());
+						}
+					}
+
 					model.addTransition(permut[states.get(stateNew)], probFn, action == null ? "" : action.toString());
 				}
 				if (isNonDet) {

--- a/prism/src/param/ParamMode.java
+++ b/prism/src/param/ParamMode.java
@@ -1,0 +1,63 @@
+//==============================================================================
+//	
+//	Copyright (c) 2017-
+//	Authors:
+//	* Joachim Klein <klein@tcs.inf.tu-dresden.de> (TU Dresden)
+//	
+//------------------------------------------------------------------------------
+//	
+//	This file is part of PRISM.
+//	
+//	PRISM is free software; you can redistribute it and/or modify
+//	it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation; either version 2 of the License, or
+//	(at your option) any later version.
+//	
+//	PRISM is distributed in the hope that it will be useful,
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//	GNU General Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License
+//	along with PRISM; if not, write to the Free Software Foundation,
+//	Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//	
+//==============================================================================
+
+
+package param;
+
+/** Mode (parametric / exact) */
+public enum ParamMode {
+	/** Parametric analysis mode for the parametric engine */
+	PARAMETRIC("parametric"),
+	/** Exact analysis mode (i.e., using constant functions) for the parametric engine */
+	EXACT("exact");
+
+	/** The mode name */
+	private final String name;
+
+	/** Private constructor */
+	private ParamMode(String name)
+	{
+		this.name = name;
+	}
+
+	/** Get either "parametric" or "exact", depending on mode. */
+	public String toString()
+	{
+		return name;
+	}
+
+	/** Get "parametric engine" or "exact engine", depending on mode. */
+	public String engine()
+	{
+		return name + " engine";
+	}
+
+	/** Get "Parametric engine" or "Exact engine", depending on mode. */
+	public String Engine()
+	{
+		return name.substring(0,1).toUpperCase() + name.substring(1) + " engine";
+	}
+}

--- a/prism/src/param/ParamModel.java
+++ b/prism/src/param/ParamModel.java
@@ -595,6 +595,7 @@ public final class ParamModel extends ModelExplicit implements MDPGeneric<Functi
 	ParamModel instantiate(Point point)
 	{
 		ParamModel result = new ParamModel();
+		result.setModelType(getModelType());
 		result.reserveMem(numStates, numTotalChoices, numTotalTransitions);
 		result.initialStates = new LinkedList<Integer>(this.initialStates);
 		for (int state = 0; state < numStates; state++) {

--- a/prism/src/param/ParamModelChecker.java
+++ b/prism/src/param/ParamModelChecker.java
@@ -1064,7 +1064,7 @@ final public class ParamModelChecker extends PrismComponent
 			throws PrismException {
 		int numStates = model.getNumStates();
 		List<State> statesList = model.getStatesList();
-		ParamRewardStruct rewSimple = new ParamRewardStruct(functionFactory, model.getNumTotalChoices());
+		ParamRewardStruct rewSimple = new ParamRewardStruct(functionFactory, model.getNumChoices());
 		int numRewItems = rewStruct.getNumItems();
 		for (int rewItem = 0; rewItem < numRewItems; rewItem++) {
 			Expression expr = rewStruct.getReward(rewItem);

--- a/prism/src/param/ParamModelChecker.java
+++ b/prism/src/param/ParamModelChecker.java
@@ -64,8 +64,11 @@ import parser.Values;
 import parser.ast.Expression;
 import parser.ast.ExpressionBinaryOp;
 import parser.ast.ExpressionConstant;
+import parser.ast.ExpressionExists;
 import parser.ast.ExpressionFilter;
 import parser.ast.ExpressionFilter.FilterOperator;
+import parser.ast.ExpressionForAll;
+import parser.ast.ExpressionFunc;
 import parser.ast.ExpressionLabel;
 import parser.ast.ExpressionLiteral;
 import parser.ast.ExpressionProb;
@@ -383,6 +386,10 @@ final public class ParamModelChecker extends PrismComponent
 			res = checkExpressionReward(model, (ExpressionReward) expr, needStates);
 		} else if (expr instanceof ExpressionSS) {
 			res = checkExpressionSteadyState(model, (ExpressionSS) expr, needStates);
+		} else if (expr instanceof ExpressionForAll || expr instanceof ExpressionExists) {
+			throw new PrismNotSupportedException("Non-probabilistic CTL model checking is currently not supported in the " + mode.engine());
+		} else if (expr instanceof ExpressionFunc && ((ExpressionFunc)expr).getNameCode() == ExpressionFunc.MULTI) {
+			throw new PrismNotSupportedException("Multi-objective model checking is not supported in the " + mode.engine());
 		} else {
 			res = checkExpressionAtomic(model, expr, needStates);
 		}

--- a/prism/src/param/ParamModelChecker.java
+++ b/prism/src/param/ParamModelChecker.java
@@ -541,16 +541,22 @@ final public class ParamModelChecker extends PrismComponent
 		RegionValues resVals = null;
 		switch (op) {
 		case PRINT:
+		case PRINTALL:
 			// Format of print-out depends on type
 			if (expr.getType() instanceof TypeBool) {
 				// NB: 'usual' case for filter(print,...) on Booleans is to use no filter
 				mainLog.print("\nSatisfying states");
 				mainLog.println(filterTrue ? ":" : " that are also in filter " + filter + ":");
-				mainLog.print(vals.filteredString(bsFilter));
 			} else {
 				mainLog.println("\nResults (non-zero only) for filter " + filter + ":");
-				mainLog.print(vals.filteredString(bsFilter));
 			}
+
+			vals.printFiltered(mainLog, mode, expr.getType(), bsFilter,
+				               model.getStatesList(),
+				               op == FilterOperator.PRINT, // printSparse if PRINT
+				               true,  // print state values
+				               true); // print state index
+
 			resVals = vals;
 			break;
 		case MIN:

--- a/prism/src/param/ParamModelChecker.java
+++ b/prism/src/param/ParamModelChecker.java
@@ -253,6 +253,10 @@ final public class ParamModelChecker extends PrismComponent
 		timer = System.currentTimeMillis() - timer;
 		mainLog.println("\nTime for model checking: " + timer / 1000.0 + " seconds.");
 
+		if (constraintChecker.unsoundCheckWasUsed()) {
+			mainLog.printWarning("Computation of Boolean values / parameter regions used heuristic sampling, results are potentially inaccurate.");
+		}
+
 		// Store result
 		result = new Result();
 		vals.clearExceptInit();

--- a/prism/src/param/ParamModelChecker.java
+++ b/prism/src/param/ParamModelChecker.java
@@ -220,7 +220,7 @@ final public class ParamModelChecker extends PrismComponent
 		constraintChecker = new ConstraintChecker(numRandomPoints);
 		regionFactory = new BoxRegionFactory(functionFactory, constraintChecker, precision,
 				model.getNumStates(), model.getFirstInitialState(), simplifyRegions, splitMethod);
-		valueComputer = new ValueComputer(paramModel, regionFactory, precision, eliminationOrder, bisimType);
+		valueComputer = new ValueComputer(this, paramModel, regionFactory, precision, eliminationOrder, bisimType);
 		
 		long timer = 0;
 		

--- a/prism/src/param/ParamResult.java
+++ b/prism/src/param/ParamResult.java
@@ -48,6 +48,8 @@ import prism.PrismNotSupportedException;
  */
 public class ParamResult
 {
+	/** The computation mode (parametric / exact) */
+	private ParamMode mode;
 	/** The actual result */
 	private RegionValues regionValues;
 	/** The model builder (for accessing expr2func) */
@@ -61,8 +63,9 @@ public class ParamResult
 	 * @param modelBuilder the model builder used during checking
 	 * @param factory the function factory used during checking
 	 */
-	public ParamResult(RegionValues regionValues, ModelBuilder modelBuilder, FunctionFactory factory)
+	public ParamResult(ParamMode mode, RegionValues regionValues, ModelBuilder modelBuilder, FunctionFactory factory)
 	{
+		this.mode = mode;
 		this.regionValues = regionValues;
 		this.modelBuilder = modelBuilder;
 		this.factory = factory;
@@ -98,7 +101,7 @@ public class ParamResult
 	public Object getSimpleResult(Type propertyType) throws PrismException
 	{
 		if (regionValues.getNumRegions() != 1)
-			throw new PrismException("Unexpected result from parametric model checker");
+			throw new PrismException("Unexpected result from " + mode + " model checker");
 
 		if (propertyType.equals(TypeBool.getInstance())) {
 			// boolean result
@@ -163,7 +166,7 @@ public class ParamResult
 	private boolean test(Type propertyType, Expression expected, String strExpected) throws PrismException
 	{
 		if (regionValues.getNumRegions() != 1) {
-			throw new PrismNotSupportedException("Testing parametric results with multiple regions not supported");
+			throw new PrismNotSupportedException("Testing " + mode + " results with multiple regions not supported");
 		}
 
 		if (propertyType.equals(TypeBool.getInstance())) {
@@ -180,7 +183,7 @@ public class ParamResult
 			try {
 				funcExpected = modelBuilder.expr2function(factory, expected);
 			} catch (PrismException e) {
-				throw new PrismException("Invalid (or unsupported) RESULT specification \"" + strExpected + "\" for parametric property");
+				throw new PrismException("Invalid (or unsupported) RESULT specification \"" + strExpected + "\" for " + mode + " property");
 			}
 			param.Function func = regionValues.getResult(0).getInitStateValueAsFunction();
 

--- a/prism/src/param/ParamRewardStruct.java
+++ b/prism/src/param/ParamRewardStruct.java
@@ -26,6 +26,9 @@
 
 package param;
 
+import prism.PrismException;
+import prism.PrismNotSupportedException;
+
 /**
  * Reward structure for parametric model.
  * We only consider rewards assigned to a certain nondeterministic choice,
@@ -122,7 +125,47 @@ final class ParamRewardStruct {
 	{
 		return rewards[choice];
 	}
-	
+
+	/**
+	 * Returns true if there are negative rewards.
+	 * <br>
+	 * Can only be called on a reward structure that
+	 * has been instantiated, i.e., where all rewards
+	 * are constant rational numbers.
+	 * <br>
+	 * If either +/-Inf or NaN are encountered, an exception is thrown.
+	 */
+	public boolean hasNegativeRewards() throws PrismException
+	{
+		for (Function r : rewards) {
+			if (!r.isConstant()) {
+				throw new UnsupportedOperationException("Can not check for negative rewards against non-constant functions");
+			}
+			BigRational v = r.asBigRational();
+			if (v.isSpecial()) {
+				throw new PrismNotSupportedException("Reward value " + v + " not supported");
+			}
+			if (r.asBigRational().signum() < 0) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check for non-normal reward values, i.e., +/-Inf and NaN,
+	 * throw exception if detected.
+	 */
+	public void checkForNonNormalRewards() throws PrismException
+	{
+		for (Function r : rewards) {
+			if (r.isInf() || r.isMInf() || r.isNaN()) {
+				throw new PrismNotSupportedException("Reward value " + r + " not supported");
+			}
+		}
+	}
+
 	@Override
 	public String toString() {
 		StringBuffer result = new StringBuffer();

--- a/prism/src/param/Region.java
+++ b/prism/src/param/Region.java
@@ -97,13 +97,19 @@ abstract class Region {
 	/**
 	 * Splits this region into several parts.
 	 * How this is done exactly depends on the implementation in derived
-	 * classes.
+	 * classes. Can take constraint into account.
 	 * 
 	 * @param constraint
-	 * @return
 	 */
 	abstract ArrayList<Region> split(Function constraint);
-	
+
+	/**
+	 * Splits this region into several parts.
+	 * How this is done exactly depends on the implementation in derived
+	 * classes.
+	 */
+	abstract ArrayList<Region> split();
+
 	abstract ArrayList<Point> specialPoints();
 
 	abstract Point randomPoint();

--- a/prism/src/param/RegionValues.java
+++ b/prism/src/param/RegionValues.java
@@ -31,7 +31,11 @@ import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map.Entry;
+
+import parser.State;
+import prism.PrismLog;
 
 /**
  * Assigns to the different regions different values over model states.
@@ -418,6 +422,30 @@ public final class RegionValues implements Iterable<Entry<Region, StateValues>>
 		}
 
 		return builder.toString();
+	}
+
+	/**
+	 * For each region, print part of vector to a log/file.
+	 * @param log The log
+	 * @param mode the mode
+	 * @param filter A BitSet specifying which states to print for (null if all).
+	 * @param printSparse Print non-zero/non-false elements only?
+	 * @param printStates Print states (variable values) for each element?
+	 * @param printIndices Print state indices for each element?
+	 */
+	public void printFiltered(PrismLog log, ParamMode mode, parser.type.Type type, BitSet filter, List<State> statesList, boolean printSparse, boolean printStates, boolean printIndices)
+	{
+		if (mode == ParamMode.EXACT) {
+			assert(parameterIndependent());
+			getStateValues().printFiltered(log, mode, type, filter, statesList, printSparse, printStates, printIndices);
+		} else {
+			for (Region region : regions) {
+				log.println(region + ":");
+				StateValues vals = values.get(region);
+				vals.printFiltered(log, mode, type, filter, statesList, printSparse, printStates, printIndices);
+				log.println();
+			}
+		}
 	}
 
 	public RegionValues unaryOp(int parserUnaryOpToRegionOp)

--- a/prism/src/param/Scheduler.java
+++ b/prism/src/param/Scheduler.java
@@ -49,7 +49,19 @@ final class Scheduler {
 			choices[state] = model.stateEnd(state) - 1;
 		}
 	}
-	
+
+	/** Copy constructor */
+	Scheduler(Scheduler other)
+	{
+		choices = other.choices.clone();
+	}
+
+	@Override
+	public Scheduler clone()
+	{
+		return new Scheduler(this);
+	}
+
 	/**
 	 * Set choice for given state.
 	 * 

--- a/prism/src/param/StateEliminator.java
+++ b/prism/src/param/StateEliminator.java
@@ -217,7 +217,7 @@ final class StateEliminator {
 		/* search for states which might never reach a target state and thus
 		 * have to be assigned a reward of infinity. */
 		if (pmc.isUseRewards()) {
-			int[] backStatesArr = collectStatesBackward();
+			int[] backStatesArr = collectStatesBackward(true);
 			HashSet<Integer> reaching = new HashSet<Integer>();
 			for (int stateNr = 0; stateNr < backStatesArr.length; stateNr++) {
 				reaching.add(backStatesArr[stateNr]);

--- a/prism/src/param/StateEliminator.java
+++ b/prism/src/param/StateEliminator.java
@@ -124,10 +124,23 @@ final class StateEliminator {
 	 * Orders states so that states near target states are eliminated first.
 	 * States which do not reach target states are eliminated last. In case
 	 * there are no target states, the order is arbitrary
+	 */
+	private int[] collectStatesBackward()
+	{
+		return collectStatesBackward(false);
+	}
+
+	/**
+	 * Orders states so that states near target states are eliminated first.
+	 * States which do not reach target states are eliminated last. In case
+	 * there are no target states, the order is arbitrary
+	 * <br>
+	 * If {@code onlyStatesReachingTarget} is true, only the states that
+	 * can reach the target states will be returned.
 	 * 
 	 * @return list of states in requested order
 	 */
-	private int[] collectStatesBackward()
+	private int[] collectStatesBackward(boolean onlyStatesReachingTarget)
 	{
 		int[] states = new int[pmc.getNumStates()];
 		BitSet seen = new BitSet(pmc.getNumStates());
@@ -155,7 +168,11 @@ final class StateEliminator {
 			}
 			current = next;
 		}
-		
+
+		if (onlyStatesReachingTarget) {
+			return states;
+		}
+
 		/* might not find all states when doing as above,
 		 * so add missing ones */
 		HashSet<Integer> allStates = new HashSet<Integer>();

--- a/prism/src/param/ValueComputer.java
+++ b/prism/src/param/ValueComputer.java
@@ -285,6 +285,9 @@ final class ValueComputer extends PrismComponent
 		case DTMC:
 			return computeUnboundedMC(region, b1, b2, rew);
 		case MDP:
+			if (model.getMaxNumChoices() == 1) {
+				return computeUnboundedMC(region, b1, b2, rew);
+			}
 			return computeUnboundedMDP(region, b1, b2, min, rew);
 		default:
 			throw new PrismNotSupportedException("Parametric unbounded reachability computation not supported for " + model.getModelType());

--- a/prism/src/param/ValueComputer.java
+++ b/prism/src/param/ValueComputer.java
@@ -226,6 +226,7 @@ final class ValueComputer extends PrismComponent
 		}
 	}
 
+	private ParamMode mode;
 	private ParamModel model;
 	private RegionFactory regionFactory;
 	private FunctionFactory functionFactory;
@@ -236,8 +237,9 @@ final class ValueComputer extends PrismComponent
 	private StateEliminator.EliminationOrder eliminationOrder;
 	private Lumper.BisimType bisimType;
 
-	ValueComputer(PrismComponent parent, ParamModel model, RegionFactory regionFactory, BigRational precision, StateEliminator.EliminationOrder eliminationOrder, Lumper.BisimType bisimType) {
+	ValueComputer(PrismComponent parent, ParamMode mode, ParamModel model, RegionFactory regionFactory, BigRational precision, StateEliminator.EliminationOrder eliminationOrder, Lumper.BisimType bisimType) {
 		super(parent);
+		this.mode = mode;
 		this.model = model;
 		this.regionFactory = regionFactory;
 		this.functionFactory = regionFactory.getFunctionFactory();

--- a/prism/src/param/ValueComputer.java
+++ b/prism/src/param/ValueComputer.java
@@ -32,12 +32,15 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map.Entry;
 
+import prism.PrismComponent;
+
+
 /**
  * Computes values for properties of a parametric Markov model. 
  * 
  * @author Ernst Moritz Hahn <emhahn@cs.ox.ac.uk> (University of Oxford)
  */
-final class ValueComputer
+final class ValueComputer extends PrismComponent
 {
 	private enum PropType {
 		REACH,
@@ -230,7 +233,8 @@ final class ValueComputer
 	private StateEliminator.EliminationOrder eliminationOrder;
 	private Lumper.BisimType bisimType;
 
-	ValueComputer(ParamModel model, RegionFactory regionFactory, BigRational precision, StateEliminator.EliminationOrder eliminationOrder, Lumper.BisimType bisimType) {
+	ValueComputer(PrismComponent parent, ParamModel model, RegionFactory regionFactory, BigRational precision, StateEliminator.EliminationOrder eliminationOrder, Lumper.BisimType bisimType) {
+		super(parent);
 		this.model = model;
 		this.regionFactory = regionFactory;
 		this.functionFactory = regionFactory.getFunctionFactory();

--- a/prism/src/param/ValueComputer.java
+++ b/prism/src/param/ValueComputer.java
@@ -286,10 +286,13 @@ final class ValueComputer extends PrismComponent
 			}
 		}
 
+		Scheduler initialScheduler = new Scheduler(model);
+		precomputeScheduler(model, initialScheduler, b1, b2, rew, min);
+
 		while (volume.compareTo(requiredVolume) == -1) {
 			Region currentRegion = todo.poll();
 			Point midPoint = ((BoxRegion)currentRegion).getMidPoint();
-			Scheduler scheduler = computeOptConcreteReachScheduler(midPoint, model, b1, b2, min, rew);
+			Scheduler scheduler = computeOptConcreteReachScheduler(midPoint, model, b1, b2, min, rew, initialScheduler);
 			ResultCacheEntry resultCacheEntry = lookupValues(PropType.REACH, b1, b2, rew, scheduler, min);
 			Function[] compare;
 			StateValues values;
@@ -360,7 +363,7 @@ final class ValueComputer extends PrismComponent
 		return resultCacheEntry;
 	}
 
-	Scheduler computeOptConcreteReachScheduler(Point point, ParamModel model, StateValues b1, StateValues b2, boolean min, ParamRewardStruct rew) throws PrismException
+	Scheduler computeOptConcreteReachScheduler(Point point, ParamModel model, StateValues b1, StateValues b2, boolean min, ParamRewardStruct rew, Scheduler initialScheduler) throws PrismException
 	{
 		ParamModel concrete = model.instantiate(point);
 		ParamRewardStruct rewConcrete = null;
@@ -372,8 +375,7 @@ final class ValueComputer extends PrismComponent
 		if (scheduler != null) {
 			return scheduler;
 		}
-		scheduler = new Scheduler(concrete);
-		precomputeScheduler(concrete, scheduler, b1, b2, rew, min);
+		scheduler = initialScheduler.clone();
 		boolean changed = true;
 		while (changed) {
 			MutablePMC pmc = buildAlterablePMCForReach(concrete, b1, b2, scheduler, rew);

--- a/prism/src/param/ValueComputer.java
+++ b/prism/src/param/ValueComputer.java
@@ -32,7 +32,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map.Entry;
 
+import common.IterableStateSet;
 import prism.PrismComponent;
+import prism.PrismException;
 
 
 /**
@@ -246,7 +248,7 @@ final class ValueComputer extends PrismComponent
 		this.bisimType = bisimType;
 	}
 
-	RegionValues computeUnbounded(RegionValues b1, RegionValues b2, boolean min, ParamRewardStruct rew) {
+	RegionValues computeUnbounded(RegionValues b1, RegionValues b2, boolean min, ParamRewardStruct rew) throws PrismException {
 		RegionValues result = new RegionValues(regionFactory);
 		RegionValuesIntersections co = new RegionValuesIntersections(b1, b2);
 		for (RegionIntersection inter : co) {
@@ -259,13 +261,28 @@ final class ValueComputer extends PrismComponent
 		return result;
 	}
 
-	private RegionValues computeUnbounded(Region region, StateValues b1, StateValues b2, boolean min, ParamRewardStruct rew)
+	private RegionValues computeUnbounded(Region region, StateValues b1, StateValues b2, boolean min, ParamRewardStruct rew) throws PrismException
 	{
 		BigRational requiredVolume = region.volume().multiply(BigRational.ONE.subtract(precision));		
 		RegionValues result = new RegionValues(regionFactory);
 		RegionsTODO todo = new RegionsTODO();
 		todo.add(region);
 		BigRational volume = BigRational.ZERO;
+
+		if (rew != null) {
+			// determine infinity states
+			explicit.MDPModelChecker mcExplicit = new explicit.MDPModelChecker(this);
+			mcExplicit.setSilentPrecomputations(true);
+			BitSet inf = mcExplicit.prob1(model, b1.toBitSet(), b2.toBitSet(), !min, null);
+			inf.flip(0, model.getNumStates());
+
+			for (int i : new IterableStateSet(inf, model.getNumStates())) {
+				// clear states with infinite value from b1 so they will get Infinity value
+				// in the DTMC
+				b1.setStateValue(i, false);
+			}
+		}
+
 		while (volume.compareTo(requiredVolume) == -1) {
 			Region currentRegion = todo.poll();
 			Point midPoint = ((BoxRegion)currentRegion).getMidPoint();
@@ -521,7 +538,12 @@ final class ValueComputer extends PrismComponent
 			if (isSink) {
 				pmc.addTransition(state, state, functionFactory.getOne());
 				if (null != rew) {
-					pmc.setReward(state, functionFactory.getZero());
+					if (isTarget) {
+						pmc.setReward(state, functionFactory.getZero());
+					} else {
+						// !b1 & !b2 state -> infinite (can not reach b2 via b1 states)
+						pmc.setReward(state, functionFactory.getInf());
+					}
 				}
 			} else {
 				if (rew != null) {

--- a/prism/src/prism/NondetModelChecker.java
+++ b/prism/src/prism/NondetModelChecker.java
@@ -1423,6 +1423,12 @@ public class NondetModelChecker extends NonProbModelChecker
 		JDDNode b;
 		StateValues rewards = null;
 
+		if (fairness && !min) {
+			// Rmax with fairness not supported; Rmin computation is unaffected
+			JDD.Deref(statesOfInterest);
+			throw new PrismNotSupportedException("Maximum reward computation currently not supported under fairness.");
+		}
+
 		// currently, ignore statesOfInterest
 		JDD.Deref(statesOfInterest);
 
@@ -1466,6 +1472,12 @@ public class NondetModelChecker extends NonProbModelChecker
 		LTLProduct<NondetModel> modelProduct;
 		NondetModelChecker mcProduct;
 		long l;
+
+		if (fairness && !min) {
+			// Rmax with fairness not supported; Rmin computation is unaffected
+			JDD.Deref(statesOfInterest);
+			throw new PrismNotSupportedException("Maximum reward computation currently not supported under fairness.");
+		}
 
 		if (Expression.containsTemporalTimeBounds(expr)) {
 			if (model.getModelType().continuousTime()) {
@@ -2184,6 +2196,8 @@ public class NondetModelChecker extends NonProbModelChecker
 		StateValues rewards = null;
 		// Local copy of setting
 		int engine = this.engine;
+
+		// For Rmax[ C ] computation, fairness does not affect the result
 
 		if (doIntervalIteration) {
 			throw new PrismNotSupportedException("Interval iteration for total rewards is currently not supported");

--- a/prism/src/prism/NondetModelChecker.java
+++ b/prism/src/prism/NondetModelChecker.java
@@ -381,6 +381,11 @@ public class NondetModelChecker extends NonProbModelChecker
 	 */
 	protected StateValues checkExpressionMultiObjective(List<Expression> exprs, boolean forAll, JDDNode statesOfInterest) throws PrismException
 	{
+		if (fairness) {
+			JDD.Deref(statesOfInterest);
+			throw new PrismNotSupportedException("Multi-objective reasoning under fairness currently not supported");
+		}
+
 		// For now, just support a single expression (which may encode a Boolean combination of objectives)
 		if (exprs.size() > 1) {
 			JDD.Deref(statesOfInterest);
@@ -489,7 +494,13 @@ public class NondetModelChecker extends NonProbModelChecker
 		boolean hasMaxReward = false;
 		//boolean hasLTLconstraint = false;
 
+		if (fairness) {
+			JDD.Deref(statesOfInterest);
+			throw new PrismNotSupportedException("Multi-objective reasoning under fairness currently not supported");
+		}
+
 		if (doIntervalIteration) {
+			JDD.Deref(statesOfInterest);
 			throw new PrismNotSupportedException("Interval iteration currently not supported for multi-objective reasoning");
 		}
 

--- a/prism/src/prism/Prism.java
+++ b/prism/src/prism/Prism.java
@@ -3159,9 +3159,9 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 		String[] paramLowerBounds = new String[] { "0" };
 		String[] paramUpperBounds = new String[] { "1" };
 		// And execute parameteric model checking
-		param.ModelBuilder builder = new ModelBuilder(this);
+		param.ModelBuilder builder = new ModelBuilder(this, param.ParamMode.EXACT);
 		ParamModel modelExpl = builder.constructModel(new ModulesFileModelGeneratorSymbolic(currentModulesFile, this), paramNames, paramLowerBounds, paramUpperBounds);
-		ParamModelChecker mc = new ParamModelChecker(this);
+		ParamModelChecker mc = new ParamModelChecker(this, param.ParamMode.EXACT);
 		mc.setModelBuilder(builder);
 		mc.setParameters(paramNames, paramLowerBounds, paramUpperBounds);
 		mc.setModulesFileAndPropertiesFile(currentModulesFile, propertiesFile);
@@ -3233,9 +3233,9 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 		if (definedPFConstants != null && definedPFConstants.getNumValues() > 0)
 			mainLog.println("Property constants: " + definedPFConstants);
 
-		param.ModelBuilder builder = new ModelBuilder(this);
+		param.ModelBuilder builder = new ModelBuilder(this, param.ParamMode.PARAMETRIC);
 		ParamModel modelExpl = builder.constructModel(new ModulesFileModelGeneratorSymbolic(currentModulesFile, this), paramNames, paramLowerBounds, paramUpperBounds);
-		ParamModelChecker mc = new ParamModelChecker(this);
+		ParamModelChecker mc = new ParamModelChecker(this, param.ParamMode.PARAMETRIC);
 		mc.setModelBuilder(builder);
 		mc.setParameters(paramNames, paramLowerBounds, paramUpperBounds);
 		mc.setModulesFileAndPropertiesFile(currentModulesFile, propertiesFile);

--- a/prism/src/prism/Prism.java
+++ b/prism/src/prism/Prism.java
@@ -3165,6 +3165,17 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 		mc.setModelBuilder(builder);
 		mc.setParameters(paramNames, paramLowerBounds, paramUpperBounds);
 		mc.setModulesFileAndPropertiesFile(currentModulesFile, propertiesFile);
+
+		if (digital) {
+			// have to do deadlock checks, as we are in digital clock mode for PTA checking,
+			// cf. doBuildModelDigitalClocksChecks()
+			if (modelExpl.getNumDeadlockStates() > 0) {
+				int dl = modelExpl.getFirstDeadlockState();
+				String dls = modelExpl.getStatesList().get(dl).toString(currentModelInfo);
+				throw new PrismException("Timelock in PTA, e.g. in state " + dls);
+			}
+		}
+
 		Result result = mc.check(modelExpl, prop.getExpression());
 
 		// Convert result of parametric model checking to a single value,

--- a/prism/src/prism/Prism.java
+++ b/prism/src/prism/Prism.java
@@ -3149,7 +3149,10 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	{
 		// Some checks
 		if (!(currentModelType == ModelType.DTMC || currentModelType == ModelType.CTMC || currentModelType == ModelType.MDP))
-			throw new PrismException("Exact model checking is only supported for DTMCs, CTMCs and MDPs");
+			throw new PrismNotSupportedException("Exact model checking is only supported for DTMCs, CTMCs and MDPs");
+
+		if (currentModelType == ModelType.MDP && getFairness())
+			throw new PrismNotSupportedException("Exact model checking does not support checking MDPs under fairness");
 
 		// Set up a dummy parameter (not used)
 		String[] paramNames = new String[] { "dummy" };
@@ -3200,7 +3203,10 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 			throw new PrismException("Must specify some parameters when using " + "the parametric analysis");
 		}
 		if (!(currentModelType == ModelType.DTMC || currentModelType == ModelType.CTMC || currentModelType == ModelType.MDP))
-			throw new PrismException("Parametric model checking is only supported for DTMCs, CTMCs and MDPs");
+			throw new PrismNotSupportedException("Parametric model checking is only supported for DTMCs, CTMCs and MDPs");
+
+		if (currentModelType == ModelType.MDP && getFairness())
+			throw new PrismNotSupportedException("Parametric model checking does not support checking MDPs under fairness");
 
 		Values definedPFConstants = propertiesFile.getConstantValues();
 		Values constlist = currentModulesFile.getConstantValues();


### PR DESCRIPTION
Included:

- fix for the handling of infinity values in reward computations (#4 and #15)
- improved error output, differentiating between exact and parametric engine
- first tiny steps towards unifying model storage in explicit and exact/parametric engine, i.e., storage independent of the concrete transition probabilities; reuse of explicit engine's prob0/prob1 computations and scheduler generation
- improved filter(print / printall) for exact and parametric
- checks for fairness flag in exact, parametric, multi-objective mode
- support for RESULT: ~0.124 syntax to specify that a given expected result is imprecise
- properly check well-formedness of model in exact mode (probabilities, rates, rewards)
- in parametric mode, check well-formedness at least for the instantiated models (midpoint in region)
- don't perform the full MDP treatment (policy iteration) when computing values for DTMCs/CTMCs and MDPs with only a single choice in parametric / exact engine