### PR TITLE
Tweak output of floating-point result in exact mode

### DIFF
--- a/prism/src/prism/Prism.java
+++ b/prism/src/prism/Prism.java
@@ -3192,7 +3192,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 		mainLog.println("\n" + resultString);
 
 		if (result.getResult() instanceof BigRational) {
-			mainLog.println("Approximate result: " + ((BigRational)result.getResult()).doubleValue());
+			mainLog.println(" As floating point: " + ((BigRational)result.getResult()).toApproximateString());
 		}
 
 		return result;


### PR DESCRIPTION
Previously, we'd print an 'Approximate result' in addition to the
exact rational number in exact mode:

Result (probability): 1/6
Approximate result: 0.16666666666666666

Result (probability): 1/6
Approximate result: 0.16666666666666666

Now, we rename that to 'As floating point' and
use BigRational.toApproximateString to print an
approximate result with ~ prefix, and an exact
floating point result without ~:

Result (probability): 1/6
 As floating point: ~0.16666666666666666

Result (probability): 1/2
 As floating point: 0.5