### PR TITLE
Fixes to support exact model building

### DIFF
--- a/prism/src/explicit/ConstructModel.java
+++ b/prism/src/explicit/ConstructModel.java
@@ -407,7 +407,7 @@ public class ConstructModel extends PrismComponent
 			UndefinedConstants undefinedConstants = new UndefinedConstants(modulesFile, null);
 			if (args.length > 2)
 				undefinedConstants.defineUsingConstSwitch(args[2]);
-			modulesFile.setUndefinedConstants(undefinedConstants.getMFConstantValues());
+			modulesFile.setUndefinedConstants(undefinedConstants.getMFConstantValues(), false);
 			ConstructModel constructModel = new ConstructModel(prism);
 			simulator.ModulesFileModelGenerator modelGen = new simulator.ModulesFileModelGenerator(modulesFile, constructModel);
 			Model model = constructModel.constructModel(modelGen);

--- a/prism/src/explicit/PrismExplicit.java
+++ b/prism/src/explicit/PrismExplicit.java
@@ -433,9 +433,9 @@ public class PrismExplicit extends PrismComponent
 			prism = new Prism(mainLog);
 			//prism.initialise();
 			ModulesFile modulesFile = prism.parseModelFile(new File(args[0]));
-			modulesFile.setUndefinedConstants(null);
+			modulesFile.setUndefinedConstants(null, false);
 			PropertiesFile propertiesFile = prism.parsePropertiesFile(modulesFile, new File(args[1]));
-			propertiesFile.setUndefinedConstants(null);
+			propertiesFile.setUndefinedConstants(null, false);
 			PrismExplicit pe = new PrismExplicit(prism.getMainLog(), prism.getSettings());
 			Model modelExpl = pe.buildModel(modulesFile, new ModulesFileModelGenerator(modulesFile, prism));
 			pe.modelCheck(modelExpl, modulesFile, propertiesFile, propertiesFile.getProperty(0));

--- a/prism/src/explicit/QuantAbstractRefineExample.java
+++ b/prism/src/explicit/QuantAbstractRefineExample.java
@@ -324,7 +324,7 @@ public class QuantAbstractRefineExample extends QuantAbstractRefine
 			ModulesFile modulesFile = prism.parseModelFile(new File(args[0]));
 			UndefinedConstants undefinedConstants = new UndefinedConstants(modulesFile, null);
 			undefinedConstants.defineUsingConstSwitch("");
-			modulesFile.setUndefinedConstants(undefinedConstants.getMFConstantValues());
+			modulesFile.setUndefinedConstants(undefinedConstants.getMFConstantValues(), false);
 			modulesFile = (ModulesFile) modulesFile.deepCopy().expandConstants(modulesFile.getConstantList());
 			
 			// Build the model (explicit-state reachability) 

--- a/prism/src/explicit/StateValues.java
+++ b/prism/src/explicit/StateValues.java
@@ -139,7 +139,7 @@ public class StateValues implements StateVector
 				valuesI[i] = initI;
 		} else if (type instanceof TypeDouble) {
 			valuesD = new double[size];
-			Double objD = ((TypeDouble) type).castValueTo(init);
+			Double objD = ((TypeDouble) type).castValueTo(init).doubleValue();
 			double initD = objD.doubleValue();
 			for (i = 0; i < size; i++)
 				valuesD[i] = initD;

--- a/prism/src/param/BigRational.java
+++ b/prism/src/param/BigRational.java
@@ -697,6 +697,30 @@ public final class BigRational extends Number implements Comparable<BigRational>
 		return this.compareTo(new BigRational(i));
 	}
 
+	/** Returns true if this number is less than the other number */
+	public boolean lessThan(BigRational other)
+	{
+		return this.compareTo(other) < 0;
+	}
+
+	/** Returns true if this number is less than or equal the other number */
+	public boolean lessThanEquals(BigRational other)
+	{
+		return this.compareTo(other) <= 0;
+	}
+
+	/** Returns true if this number is greater than the other number */
+	public boolean greaterThan(BigRational other)
+	{
+		return this.compareTo(other) > 0;
+	}
+
+	/** Returns true if this number is greater than or equal the other number */
+	public boolean greaterThanEquals(BigRational other)
+	{
+		return this.compareTo(other) >= 0;
+	}
+
 	/**
 	 * Return numerator of this BigRational as a BigInteger.
 	 * 

--- a/prism/src/param/BigRational.java
+++ b/prism/src/param/BigRational.java
@@ -41,7 +41,7 @@ import prism.PrismLangException;
  * 
  * @author Ernst Moritz Hahn <emhahn@cs.ox.ac.uk> (University of Oxford)
  */
-public final class BigRational implements Comparable<BigRational>
+public final class BigRational extends Number implements Comparable<BigRational>
 {
 	/** the BigInteger "-1" */
 	private final static BigInteger BMONE = BigInteger.ONE.negate();
@@ -558,6 +558,87 @@ public final class BigRational implements Comparable<BigRational>
 			div = div.add(BigInteger.ONE);
 		}
 		return signum * div.doubleValue() / Math.pow(2.0, 55);
+	}
+
+	/**
+	 * Returns the value of the specified number as an {@code int},
+	 * which may involve rounding or truncation.
+	 * <br>
+	 * Note: In contrast to the standard Number.intValue() behaviour,
+	 * this implementation throws an Arithmetic exception if the underlying
+	 * rational number is not an integer or if representing as an {@code int}
+	 * overflows.
+	 * <br>
+	 * Positive and negative infinity are mapped to Integer.MAX_VALUE and Integer.MIN_VALUE,
+	 * respectively, NaN is mapped to 0 (per the Java Language Specification).
+	 *
+	 * @return  the numeric value represented by this object after conversion
+	 *          to type {@code int}.
+	 */
+	@Override
+	public int intValue()
+	{
+		if (isSpecial()) {
+			if (isInf()) return Integer.MAX_VALUE;
+			if (isMInf()) return Integer.MIN_VALUE;
+			if (isNaN()) return 0;  // per Java Language Specification
+		}
+
+		// TODO JK: In case of fraction / overflow, this method should not throw an
+		// exception but return some imprecise result. We are conservative here.
+		// In the future, it may make sense to have an intValueExact (similar to BigInteger)
+		if (!isInteger()) {
+			throw new ArithmeticException("Can not convert fractional number to int");
+		}
+		int value = getNum().intValue();
+		if (!getNum().equals(new BigInteger(Integer.toString(value)))) {
+			throw new ArithmeticException("Can not convert BigInteger to int, value out of range");
+		}
+		return value;
+	}
+
+	/**
+	 * Returns the value of the specified number as a {@code long},
+	 * which may involve rounding or truncation.
+	 * <br>
+	 * Note: In contrast to the standard Number.longValue() behaviour,
+	 * this implementation throws an Arithmetic exception if the underlying
+	 * rational number is not an integer or if representing as a {@code long}
+	 * overflows.
+	 * <br>
+	 * Positive and negative infinity are mapped to Long.MAX_VALUE and Long.MIN_VALUE,
+	 * respectively, NaN is mapped to 0 (per the Java Language Specification).
+	 *
+	 * @return  the numeric value represented by this object after conversion
+	 *          to type {@code int}.
+	 */
+	@Override
+	public long longValue()
+	{
+		if (isSpecial()) {
+			if (isInf()) return Long.MAX_VALUE;
+			if (isMInf()) return Long.MIN_VALUE;
+			if (isNaN()) return 0;  // per Java Language Specification
+		}
+
+		// TODO JK: In case of fraction / overflow, this method should not throw an
+		// exception but return some imprecise result. We are conservative here. In the future,
+		// it may make sense to have an intValueExact (similar to BigInteger)
+		if (!isInteger()) {
+			throw new ArithmeticException("Can not convert fractional number to long");
+		}
+		long value = getNum().longValue();
+		if (!getNum().equals(new BigInteger(Long.toString(value)))) {
+			throw new ArithmeticException("Can not convert BigInteger to long, value out of range");
+		}
+		return value;
+	}
+
+	@Override
+	public float floatValue()
+	{
+		// TODO JK: Better precision?
+		return (float)doubleValue();
 	}
 
 	/**

--- a/prism/src/param/BigRational.java
+++ b/prism/src/param/BigRational.java
@@ -190,10 +190,8 @@ public final class BigRational extends Number implements Comparable<BigRational>
 			this.den = new BigInteger("0");
 			return;
 		}
-		BigInteger num;
-		BigInteger den;
 		string = string.trim();
-		int slashIdx = string.indexOf('/');
+		int slashIdx = string.lastIndexOf('/');
 		if (slashIdx < 0) {
 			// decimal point notation
 			Double.parseDouble(string); // ensures correctness of format
@@ -222,7 +220,8 @@ public final class BigRational extends Number implements Comparable<BigRational>
 				int eInt = Integer.parseInt(eStr);
 				expo += eInt;
 			}
-			num = new BigInteger((negate ? "-" : "") + noDotCoeff);
+			BigInteger num = new BigInteger((negate ? "-" : "") + noDotCoeff);
+			BigInteger den;
 			BigInteger ten = BITEN;
 			if (expo == 0) {
 				den = BigInteger.ONE;
@@ -237,9 +236,14 @@ public final class BigRational extends Number implements Comparable<BigRational>
 			this.den = result.den;
 		} else {
 			// fractional
-			num = new BigInteger(string.substring(0, slashIdx));
-			den = new BigInteger(string.substring(slashIdx + 1, string.length()));
-			BigRational r = cancel(num, den);
+			if (slashIdx == 0 || slashIdx == string.length()-1) {
+				throw new NumberFormatException("Illegal fraction syntax");
+			}
+			// because we use lastIndexOf, we obtain left-associativity,
+			// i.e. a/b/c is interpreted as (a/b)/c
+			BigRational num = new BigRational(string.substring(0, slashIdx));
+			BigRational den = new BigRational(string.substring(slashIdx + 1, string.length()));
+			BigRational r = num.divide(den);
 			this.num = r.num;
 			this.den = r.den;
 			return;

--- a/prism/src/param/BigRational.java
+++ b/prism/src/param/BigRational.java
@@ -962,7 +962,7 @@ public final class BigRational extends Number implements Comparable<BigRational>
 		}
 		int value = getNum().intValue();
 		if (!getNum().equals(new BigInteger(Integer.toString(value)))) {
-			throw new PrismLangException("Can not convert BigInteger to int, value out of range");
+			throw new PrismLangException("Can not convert BigInteger to int, value " + this + " out of int range");
 		}
 		return value;
 	}

--- a/prism/src/param/ChoiceListFlexi.java
+++ b/prism/src/param/ChoiceListFlexi.java
@@ -187,7 +187,8 @@ public class ChoiceListFlexi //implements Choice
 					first = false;
 				else
 					s += ", ";
-				s += up.getVar(j) + "'=" + up.getExpression(j).evaluate(currentState);
+				BigRational newValue = up.getExpression(j).evaluateExact(currentState);
+				s += up.getVar(j) + "'=" + up.getExpression(j).getType().castFromBigRational(newValue);
 			}
 		}
 		return s;
@@ -213,14 +214,16 @@ public class ChoiceListFlexi //implements Choice
 	{
 		State newState = new State(currentState);
 		for (Update up : updates.get(i))
-			up.update(currentState, newState);
+			// evaluate and apply update expression (in exact evaluation mode)
+			up.update(currentState, newState, true);
 		return newState;
 	}
 
 	public void computeTarget(int i, State currentState, State newState) throws PrismLangException
 	{
 		for (Update up : updates.get(i))
-			up.update(currentState, newState);
+			// evaluate and apply update expression (in exact evaluation mode)
+			up.update(currentState, newState, true);
 	}
 
 	public Function getProbability(int i)

--- a/prism/src/param/ModelBuilder.java
+++ b/prism/src/param/ModelBuilder.java
@@ -157,7 +157,7 @@ public final class ModelBuilder extends PrismComponent
 					// non-parametric constants and state variable values have
 					// been already partially expanded, so if this evaluation
 					// succeeds there are no parametric constants involved
-					boolean ifValue = iteExpr.getOperand1().evaluateBoolean();
+					boolean ifValue = iteExpr.getOperand1().evaluateExact().toBoolean();
 					if (ifValue) {
 						return expr2function(factory, iteExpr.getOperand2());
 					} else {

--- a/prism/src/param/ParamModelChecker.java
+++ b/prism/src/param/ParamModelChecker.java
@@ -1106,7 +1106,7 @@ final public class ParamModelChecker extends PrismComponent
 			String action = rewStruct.getSynch(rewItem);
 			boolean isTransitionReward = rewStruct.getRewardStructItem(rewItem).isTransitionReward();
 			for (int state = 0; state < numStates; state++) {
-				if (guard.evaluateBoolean(constantValues, statesList.get(state))) {
+				if (guard.evaluateExact(constantValues, statesList.get(state)).toBoolean()) {
 					int[] varMap = new int[statesList.get(0).varValues.length];
 					for (int i = 0; i < varMap.length; i++) {
 						varMap[i] = i;

--- a/prism/src/param/ParamResult.java
+++ b/prism/src/param/ParamResult.java
@@ -172,7 +172,7 @@ public class ParamResult
 		if (propertyType.equals(TypeBool.getInstance())) {
 			// boolean result
 			boolean boolResult = regionValues.getResult(0).getInitStateValueAsBoolean();
-			boolean boolExpected = expected.evaluateBoolean();
+			boolean boolExpected = expected.evaluateExact().toBoolean();
 
 			if (boolResult != boolExpected) {
 				throw new PrismException("Wrong result (expected " + strExpected + ", got " + boolResult + ")");

--- a/prism/src/param/SymbolicEngine.java
+++ b/prism/src/param/SymbolicEngine.java
@@ -258,7 +258,7 @@ public class SymbolicEngine
 		n = module.getNumCommands();
 		for (i = 0; i < n; i++) {
 			command = module.getCommand(i);
-			if (command.getGuard().evaluateBoolean(state)) {
+			if (command.getGuard().evaluateExact(state).toBoolean()) {
 				j = command.getSynchIndex();
 				updateLists.get(m).get(j).add(command.getUpdates());
 				enabledSynchs.set(j);

--- a/prism/src/parser/Values.java
+++ b/prism/src/parser/Values.java
@@ -244,16 +244,19 @@ public class Values //implements Comparable
 	public int getIntValue(int i) throws PrismLangException
 	{
 		Object o;
-		
+
 		o = values.get(i);
-		
+
 		if (o instanceof Boolean) {
 			return ((Boolean)o).booleanValue() ? 1 : 0;
 		}
 		if (o instanceof Integer) {
 			return ((Integer)o).intValue();
 		}
-		
+		if (o instanceof BigRational) {
+			return ((BigRational)o).toInt();
+		}
+
 		throw new PrismLangException("Cannot get integer value for \"" + getName(i) + "\"");
 	}
 
@@ -276,6 +279,9 @@ public class Values //implements Comparable
 		if (o instanceof Double) {
 			return ((Double)o).doubleValue();
 		}
+		if (o instanceof BigRational) {
+			return ((BigRational)o).doubleValue();
+		}
 		
 		throw new PrismLangException("Cannot get double value for \"" + getName(i) + "\"");
 	}
@@ -286,14 +292,16 @@ public class Values //implements Comparable
 	public boolean getBooleanValue(int i) throws PrismLangException
 	{
 		Object o;
-		
+
 		o = values.get(i);
-		
-		if (!(o instanceof Boolean)) {
+
+		if (o instanceof Boolean) {
+			return ((Boolean)o).booleanValue();
+		} else if (o instanceof BigRational) {
+			return ((BigRational)o).toBoolean();
+		} else {
 			throw new PrismLangException("Cannot get boolean value for \"" + getName(i) + "\"");
 		}
-		
-		return ((Boolean)o).booleanValue();
 	}
 
 	/**

--- a/prism/src/parser/Values.java
+++ b/prism/src/parser/Values.java
@@ -31,6 +31,7 @@ import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Locale;
 
+import param.BigRational;
 import parser.type.Type;
 import parser.type.TypeBool;
 import parser.type.TypeDouble;
@@ -223,6 +224,7 @@ public class Values //implements Comparable
 		Object o = values.get(i);
 		if (o instanceof Integer) return TypeInt.getInstance();
 		if (o instanceof Double)  return TypeDouble.getInstance();
+		if (o instanceof BigRational) return TypeDouble.getInstance();
 		if (o instanceof Boolean) return TypeBool.getInstance();
 		else return null;
 	}

--- a/prism/src/parser/ast/Expression.java
+++ b/prism/src/parser/ast/Expression.java
@@ -355,6 +355,9 @@ public abstract class Expression extends ASTElement
 		if (o instanceof Double) {
 			return ((Double) o).doubleValue();
 		}
+		if (o instanceof BigRational) {
+			return ((BigRational)o).doubleValue();
+		}
 		if (o instanceof Boolean) {
 			return ((Boolean) o).booleanValue() ? 1.0 : 0.0;
 		}

--- a/prism/src/parser/ast/ExpressionConstant.java
+++ b/prism/src/parser/ast/ExpressionConstant.java
@@ -82,6 +82,13 @@ public class ExpressionConstant extends Expression
 		Object res = ec.getConstantValue(name);
 		if (res == null)
 			throw new PrismLangException("Could not evaluate constant", this);
+
+		if (res instanceof BigRational) {
+			// Constants can also be BigRational, cast to appropriate type
+			// This might loose precision
+			BigRational r = (BigRational) res;
+			return getType().castFromBigRational(r);
+		}
 		return res;
 	}
 

--- a/prism/src/parser/ast/ExpressionLiteral.java
+++ b/prism/src/parser/ast/ExpressionLiteral.java
@@ -34,7 +34,7 @@ import parser.type.*;
 public class ExpressionLiteral extends Expression
 {
 	Object value; // Value
-	String string; // Optionally, keep original string to preserve user formatting
+	String string; // Optionally, keep original string to preserve user formatting and allow exact evaluation
 
 	// Constructor
 	
@@ -92,13 +92,24 @@ public class ExpressionLiteral extends Expression
 	@Override
 	public Object evaluate(EvaluateContext ec) throws PrismLangException
 	{
+		if (value instanceof BigRational) {
+			// cast from BigRational to appropriate Java data type
+			return getType().castFromBigRational((BigRational) value);
+		}
 		return value;
 	}
 
 	@Override
 	public BigRational evaluateExact(EvaluateContext ec) throws PrismLangException
 	{
-		return BigRational.from(value);
+		if (value instanceof BigRational) {
+			// if already a BigRational, return that
+			return (BigRational) value;
+		} else if (value instanceof Boolean) {
+			return BigRational.from(value);
+		}
+		// otherwise, convert from string representation (potentially provides more precision for double literals)
+		return BigRational.from(string);
 	}
 
 	@Override

--- a/prism/src/parser/ast/ModulesFile.java
+++ b/prism/src/parser/ast/ModulesFile.java
@@ -28,6 +28,7 @@ package parser.ast;
 
 import java.util.*;
 
+import param.BigRational;
 import parser.*;
 import parser.visitor.*;
 import prism.ModelInfo;
@@ -1069,8 +1070,25 @@ public class ModulesFile extends ASTElement implements ModelInfo
 	 * Assumes that values for constants have been provided for the model.
 	 * Note: This method replaces the old getInitialValues() method,
 	 * since State objects are now preferred to Values objects for efficiency.
+	 * <br>
+	 * The init expression is evaluated using the default evaluate, i.e.,
+	 * not using exact arithmetic.
 	 */
 	public State getDefaultInitialState() throws PrismLangException
+	{
+		return getDefaultInitialState(false);
+	}
+
+	/**
+	 * Create a State object representing the default initial state of this model.
+	 * If there are potentially multiple initial states (because the model has an
+	 * init...endinit specification), this method returns null;
+	 * Assumes that values for constants have been provided for the model.
+	 * Note: This method replaces the old getInitialValues() method,
+	 * since State objects are now preferred to Values objects for efficiency.
+	 * @param exact use exact arithmetic in evaluation of init expression?
+	 */
+	public State getDefaultInitialState(boolean exact) throws PrismLangException
 	{
 		int i, j, count, n, n2;
 		Module module;
@@ -1089,8 +1107,13 @@ public class ModulesFile extends ASTElement implements ModelInfo
 		n = getNumGlobals();
 		for (i = 0; i < n; i++) {
 			decl = getGlobal(i);
-			initialValue = decl.getStartOrDefault().evaluate(constantValues);
-			initialValue = getGlobal(i).getType().castValueTo(initialValue);
+			if (exact) {
+				BigRational r = decl.getStartOrDefault().evaluateExact(constantValues);
+				initialValue = getGlobal(i).getType().castFromBigRational(r);
+			} else {
+				initialValue = decl.getStartOrDefault().evaluate(constantValues);
+				initialValue = getGlobal(i).getType().castValueTo(initialValue);
+			}
 			initialState.setValue(count++, initialValue);
 		}
 		n = getNumModules();
@@ -1099,8 +1122,13 @@ public class ModulesFile extends ASTElement implements ModelInfo
 			n2 = module.getNumDeclarations();
 			for (j = 0; j < n2; j++) {
 				decl = module.getDeclaration(j);
-				initialValue = decl.getStartOrDefault().evaluate(constantValues);
-				initialValue = module.getDeclaration(j).getType().castValueTo(initialValue);
+				if (exact) {
+					BigRational r = decl.getStartOrDefault().evaluateExact(constantValues);
+					initialValue = module.getDeclaration(j).getType().castFromBigRational(r);
+				} else {
+					initialValue = decl.getStartOrDefault().evaluate(constantValues);
+					initialValue = module.getDeclaration(j).getType().castValueTo(initialValue);
+				}
 				initialState.setValue(count++, initialValue);
 			}
 		}

--- a/prism/src/parser/ast/ModulesFile.java
+++ b/prism/src/parser/ast/ModulesFile.java
@@ -686,7 +686,9 @@ public class ModulesFile extends ASTElement implements ModelInfo
 		// NB: Can't call setUndefinedConstants if there are undefined constants
 		// because semanticCheckAfterConstants may fail. 
 		if (getUndefinedConstants().isEmpty()) {
-			setUndefinedConstants(null);
+			// by default, we use non-exact constant evaluation,
+			// if exact evaluation is needed, constants will be reevaluated later-on
+			setUndefinedConstants(null, false);
 		}
 	}
 
@@ -1012,10 +1014,10 @@ public class ModulesFile extends ASTElement implements ModelInfo
 	 * Calling this method also triggers some additional semantic checks
 	 * that can only be done once constant values have been specified.
 	 */
-	public void setUndefinedConstants(Values someValues) throws PrismLangException
+	public void setUndefinedConstants(Values someValues, boolean exact) throws PrismLangException
 	{
 		undefinedConstantValues = someValues == null ? null : new Values(someValues);
-		constantValues = constantList.evaluateConstants(someValues, null);
+		constantValues = constantList.evaluateConstants(someValues, null, exact);
 		doSemanticChecksAfterConstants();
 	}
 
@@ -1025,10 +1027,10 @@ public class ModulesFile extends ASTElement implements ModelInfo
 	 * Undefined constants can be subsequently redefined to different values with the same method.
 	 * The current constant values (if set) are available via {@link #getConstantValues()}.
 	 */
-	public void setSomeUndefinedConstants(Values someValues) throws PrismLangException
+	public void setSomeUndefinedConstants(Values someValues, boolean exact) throws PrismLangException
 	{
 		undefinedConstantValues = someValues == null ? null : new Values(someValues);
-		constantValues = constantList.evaluateSomeConstants(someValues, null);
+		constantValues = constantList.evaluateSomeConstants(someValues, null, exact);
 		doSemanticChecksAfterConstants();
 	}
 

--- a/prism/src/parser/ast/PropertiesFile.java
+++ b/prism/src/parser/ast/PropertiesFile.java
@@ -305,7 +305,9 @@ public class PropertiesFile extends ASTElement
 
 		// Set up some values for constants
 		// (without assuming any info about undefined constants)
-		setSomeUndefinedConstants(null);
+		// use non-exact constant evaluation by default, for exact evaluation
+		// reevaluate later-on
+		setSomeUndefinedConstants(null, false);
 	}
 
 	// check formula identifiers
@@ -534,10 +536,10 @@ public class PropertiesFile extends ASTElement
 	 * Undefined constants can be subsequently redefined to different values with the same method.
 	 * The current constant values (if set) are available via {@link #getConstantValues()}. 
 	 */
-	public void setUndefinedConstants(Values someValues) throws PrismLangException
+	public void setUndefinedConstants(Values someValues, boolean exact) throws PrismLangException
 	{
 		// Might need values for ModulesFile constants too
-		constantValues = constantList.evaluateConstants(someValues, modulesFile.getConstantValues());
+		constantValues = constantList.evaluateConstants(someValues, modulesFile.getConstantValues(), exact);
 		// Note: unlike ModulesFile, we don't trigger any semantic checks at this point
 		// This will usually be done on a per-property basis later
 	}
@@ -548,10 +550,10 @@ public class PropertiesFile extends ASTElement
 	 * Undefined constants can be subsequently redefined to different values with the same method.
 	 * The current constant values (if set) are available via {@link #getConstantValues()}.
 	 */
-	public void setSomeUndefinedConstants(Values someValues) throws PrismLangException
+	public void setSomeUndefinedConstants(Values someValues, boolean exact) throws PrismLangException
 	{
 		// Might need values for ModulesFile constants too
-		constantValues = constantList.evaluateSomeConstants(someValues, modulesFile.getConstantValues());
+		constantValues = constantList.evaluateSomeConstants(someValues, modulesFile.getConstantValues(), exact);
 		// Note: unlike ModulesFile, we don't trigger any semantic checks at this point
 		// This will usually be done on a per-property basis later
 	}

--- a/prism/src/parser/ast/Property.java
+++ b/prism/src/parser/ast/Property.java
@@ -41,6 +41,7 @@ import prism.PrismException;
 import prism.PrismLangException;
 import prism.PrismNotSupportedException;
 import prism.PrismUtils;
+import prism.DefinedConstant;
 import prism.Point;
 import prism.Prism;
 import prism.TileList;
@@ -189,7 +190,7 @@ public class Property extends ASTElement
 						match = false;
 					// Check doubles numerically
 					else if (constValToMatch instanceof Double)
-						match = PrismUtils.doublesAreCloseRel(((Double) constValToMatch).doubleValue(), Double.parseDouble(constVal), 1e-10);
+						match = PrismUtils.doublesAreCloseRel(((Double) constValToMatch).doubleValue(), DefinedConstant.parseDouble(constVal), 1e-10);
 					// if constant is exact rational number, compare exactly
 					else if (constValToMatch instanceof BigRational)
 						match = BigRational.from(constVal).equals(constValToMatch);

--- a/prism/src/parser/ast/Property.java
+++ b/prism/src/parser/ast/Property.java
@@ -190,6 +190,9 @@ public class Property extends ASTElement
 					// Check doubles numerically
 					else if (constValToMatch instanceof Double)
 						match = PrismUtils.doublesAreCloseRel(((Double) constValToMatch).doubleValue(), Double.parseDouble(constVal), 1e-10);
+					// if constant is exact rational number, compare exactly
+					else if (constValToMatch instanceof BigRational)
+						match = BigRational.from(constVal).equals(constValToMatch);
 					// Otherwise just check for exact string match for now
 					else
 						match = constValToMatch.toString().equals(constVal);

--- a/prism/src/parser/ast/Update.java
+++ b/prism/src/parser/ast/Update.java
@@ -29,6 +29,7 @@ package parser.ast;
 import java.util.ArrayList;
 import java.util.BitSet;
 
+import param.BigRational;
 import parser.*;
 import parser.type.*;
 import parser.visitor.*;
@@ -245,15 +246,39 @@ public class Update extends ASTElement
 	 * Apply changes in variables to a provided copy of the State object.
 	 * (i.e. oldState and newState should be equal when passed in) 
 	 * It is assumed that any constants have already been defined.
+	 * <br>
+	 * Arithmetic expressions are evaluated using the default evaluate (i.e., not using exact arithmetic)
 	 * @param oldState Variable values in current state
 	 * @param newState State object to apply changes to
 	 */
 	public void update(State oldState, State newState) throws PrismLangException
 	{
+		update(oldState, newState, false);
+	}
+
+	/**
+	 * Execute this update, based on variable values specified as a State object.
+	 * Apply changes in variables to a provided copy of the State object.
+	 * (i.e. oldState and newState should be equal when passed in)
+	 * It is assumed that any constants have already been defined.
+	 * @param oldState Variable values in current state
+	 * @param newState State object to apply changes to
+	 * @param exact evaluate arithmetic expressions exactly?
+	 */
+	public void update(State oldState, State newState, boolean exact) throws PrismLangException
+	{
 		int i, n;
 		n = exprs.size();
 		for (i = 0; i < n; i++) {
-			newState.setValue(getVarIndex(i), getExpression(i).evaluate(oldState));
+			Object newValue;
+			if (exact) {
+				BigRational r = getExpression(i).evaluateExact(oldState);
+				// cast to Java data type
+				newValue = getExpression(i).getType().castFromBigRational(r);
+			} else {
+				newValue = getExpression(i).evaluate(oldState);
+			}
+			newState.setValue(getVarIndex(i), newValue);
 		}
 	}
 

--- a/prism/src/parser/type/Type.java
+++ b/prism/src/parser/type/Type.java
@@ -26,6 +26,7 @@
 
 package parser.type;
 
+import param.BigRational;
 import prism.PrismLangException;
 
 public abstract class Type 
@@ -64,7 +65,21 @@ public abstract class Type
 		// Play safe: assume error unless explicitly overridden.
 		throw new PrismLangException("Cannot cast a value to type " + getTypeString());
 	}
-	
+
+	/**
+	 * Cast a BigRational value to the Java data type (Boolean, Integer, Double, ...)
+	 * corresponding to this type.
+	 * <br>
+	 * For boolean and integer, this throws an exception if the value can not be
+	 * precisely represented by the Java data type; for double, loss of precision
+	 * is expected and does not raise an exception.
+	 */
+	public Object castFromBigRational(BigRational value) throws PrismLangException
+	{
+		// Play safe: assume error unless explicitly overridden.
+		throw new PrismLangException("Cannot cast rational number to type " + getTypeString());
+	}
+
 	@Override
 	public String toString()
 	{

--- a/prism/src/parser/type/TypeBool.java
+++ b/prism/src/parser/type/TypeBool.java
@@ -26,6 +26,7 @@
 
 package parser.type;
 
+import param.BigRational;
 import prism.PrismLangException;
 
 public class TypeBool extends Type 
@@ -77,4 +78,11 @@ public class TypeBool extends Type
 		else
 			throw new PrismLangException("Can't convert " + value.getClass() + " to type " + getTypeString());
 	}
+
+	@Override
+	public Object castFromBigRational(BigRational value) throws PrismLangException
+	{
+		return value.toBoolean();
+	}
+
 }

--- a/prism/src/parser/type/TypeDouble.java
+++ b/prism/src/parser/type/TypeDouble.java
@@ -26,6 +26,7 @@
 
 package parser.type;
 
+import param.BigRational;
 import prism.PrismLangException;
 
 public class TypeDouble extends Type 
@@ -70,10 +71,12 @@ public class TypeDouble extends Type
 	}
 	
 	@Override
-	public Double castValueTo(Object value) throws PrismLangException
+	public Number castValueTo(Object value) throws PrismLangException
 	{
 		if (value instanceof Double)
 			return (Double) value;
+		if (value instanceof BigRational)
+			return (BigRational) value;
 		if (value instanceof Integer)
 			return new Double(((Integer) value).intValue());
 		else

--- a/prism/src/parser/type/TypeDouble.java
+++ b/prism/src/parser/type/TypeDouble.java
@@ -82,4 +82,11 @@ public class TypeDouble extends Type
 		else
 			throw new PrismLangException("Can't convert " + value.getClass() + " to type " + getTypeString());
 	}
+
+	@Override
+	public Object castFromBigRational(BigRational value) throws PrismLangException
+	{
+		return value.doubleValue();
+	}
+
 }

--- a/prism/src/parser/type/TypeInt.java
+++ b/prism/src/parser/type/TypeInt.java
@@ -26,6 +26,7 @@
 
 package parser.type;
 
+import param.BigRational;
 import prism.PrismLangException;
 
 public class TypeInt extends Type 
@@ -77,4 +78,11 @@ public class TypeInt extends Type
 		else
 			throw new PrismLangException("Can't convert " + value.getClass() + " to type " + getTypeString());
 	}
+
+	@Override
+	public Object castFromBigRational(BigRational value) throws PrismLangException
+	{
+		return value.toInt();
+	}
+
 }

--- a/prism/src/prism/DefaultModelGenerator.java
+++ b/prism/src/prism/DefaultModelGenerator.java
@@ -47,7 +47,7 @@ public abstract class DefaultModelGenerator implements ModelGenerator
 	public abstract ModelType getModelType();
 	
 	@Override
-	public void setSomeUndefinedConstants(Values someValues) throws PrismException
+	public void setSomeUndefinedConstants(Values someValues, boolean exact) throws PrismException
 	{
 		if (someValues != null && someValues.getNumValues() > 0)
 			throw new PrismException("This model has no constants to set");

--- a/prism/src/prism/DefinedConstant.java
+++ b/prism/src/prism/DefinedConstant.java
@@ -27,6 +27,7 @@
 
 package prism;
 
+import param.BigRational;
 import parser.type.*;
 
 /**
@@ -80,14 +81,22 @@ public class DefinedConstant
 		return (low != null);
 	}
 
-	/** Define the constant (by passing in strings). */
-	
-	public void define(String sl, String sh, String ss) throws PrismException
+	/**
+	 * Define the constant (by passing in strings).
+	 * <br>
+	 * If {@code exact} is true, BigRationals are used for real values,
+	 * otherwise double arithmetic is used.
+	 */
+	public void define(String sl, String sh, String ss, boolean exact) throws PrismException
 	{
 		if (type instanceof TypeInt) {
 			defineInt(sl, sh, ss);
-		}else if (type instanceof TypeDouble) {
-			defineDouble(sl, sh, ss);
+		} else if (type instanceof TypeDouble) {
+			if (exact) {
+				defineBigRational(sl, sh, ss);
+			} else {
+				defineDouble(sl, sh, ss);
+			}
 		} else if (type instanceof TypeBool) { 
 			defineBoolean(sl, sh, ss);
 		} else {
@@ -212,7 +221,65 @@ public class DefinedConstant
 		high = new Double(dh);
 		step = new Double(ds);
 	}
-	
+
+	public void defineBigRational(String sl, String sh, String ss) throws PrismException
+	{
+		BigRational r, rl, rh, rs;
+
+		// parse low value
+		try {
+			rl = BigRational.from(sl);
+		}
+		catch (NumberFormatException e) {
+			throw new PrismException("Value " + sl + " for constant " + name + " is not a valid rational number");
+		}
+		// if no high value given, use low value, default step is 1.0
+		if (sh == null) {
+			rh = rl;
+			rs = BigRational.from(1);
+		}
+		else {
+			// parse high value
+			try {
+				rh = BigRational.from(sh);
+			}
+			catch (NumberFormatException e) {
+				throw new PrismException("Value " + sh + " for constant " + name + " is not a valid rational number");
+			}
+			if (rh.lessThan(rl)) throw new PrismException("Low value "+rl+" for constant " + name + " is higher than the high value "+rh);
+			if (ss == null) {
+				// default step is 1.0
+				rs = BigRational.from(1);
+			}
+			else {
+				// parse step
+				try {
+					rs = BigRational.from(ss);
+				}
+				catch (NumberFormatException e) {
+					throw new PrismException("Value " + ss + " for constant " + name + " is not a valid double");
+				}
+				if (rs.isZero()) throw new PrismException("Step value for constant " + name + " cannot be zero");
+				if (rs.lessThan(BigRational.ZERO)) throw new PrismException("Step value for constant " + name + " must be positive");
+				if (rs.greaterThan(rh.subtract(rl))) throw new PrismException("Step value "+rs+" for constant " + name + " is bigger than the difference between "+rl+" and "+rh);
+			}
+		}
+		// compute num steps
+		numSteps = 0;
+		BigRational rhNew = rh;
+		for (r = rl; r.lessThanEquals(rh); r = rl.add(rs.multiply(numSteps)))
+		{
+			numSteps++;
+			rhNew = r;
+		}
+		// store 'actual' value for high
+		rh = rhNew;
+		// store
+		low = rl;
+		high = rh;
+		step = rs;
+	}
+
 	public void defineBoolean(String sl, String sh, String ss) throws PrismException
 	{
 		// parse value (low)
@@ -261,20 +328,39 @@ public class DefinedConstant
 		}
 		// double
 		else if (type instanceof TypeDouble) {
-			dl = ((Double)low).doubleValue();
-			dh = ((Double)high).doubleValue();
-			ds = ((Double)step).doubleValue();
-			dv = ((Double)value).doubleValue();
-			// if possible, increment
-			int index = getValueIndex(value) + 1;			
-			dv = dl + index * ds; 
-			if (dv <= dh + DOUBLE_PRECISION_CORRECTION * ds) {
-				value = new Double(dv);
-			}
-			// otherwise, reset to low value, note overflow
-			else {
-				value = low;
-				overflow = true;
+			if (low instanceof BigRational) {
+				BigRational rl = (BigRational) low;
+				BigRational rh = (BigRational) high;
+				BigRational rs = (BigRational) step;
+				BigRational rv = (BigRational) value;
+				// if possible, increment
+				int index = getValueIndex(value) + 1;
+				rv = rl.add(rs.multiply(index));
+				if (rv.lessThanEquals(rh)) {
+					value = rv;
+				}
+				// otherwise, reset to low value, note overflow
+				else {
+					value = low;
+					overflow = true;
+				}
+			} else {
+				// double arithmetic
+				dl = ((Double)low).doubleValue();
+				dh = ((Double)high).doubleValue();
+				ds = ((Double)step).doubleValue();
+				dv = ((Double)value).doubleValue();
+				// if possible, increment
+				int index = getValueIndex(value) + 1;
+				dv = dl + index * ds;
+				if (dv <= dh + DOUBLE_PRECISION_CORRECTION * ds) {
+					value = new Double(dv);
+				}
+				// otherwise, reset to low value, note overflow
+				else {
+					value = low;
+					overflow = true;
+				}
 			}
 		}
 		// boolean
@@ -315,12 +401,21 @@ public class DefinedConstant
 		}
 		// double
 		else if (type instanceof TypeDouble) {
-			dl = ((Double)low).doubleValue();
-			ds = ((Double)step).doubleValue();
-			dv = dl;
-			//for (i = 0; i < j; i++) dv += ds;			
-			dv = dl + j * ds;
-			return new Double(dv);
+			if (low instanceof BigRational) {
+				BigRational rl = (BigRational)low;
+				BigRational rs = (BigRational)low;
+				BigRational rv;
+				// rv = rl + j*rs
+				rv = rl.add(rs.multiply(j));
+				return rv;
+			} else {
+				dl = ((Double)low).doubleValue();
+				ds = ((Double)step).doubleValue();
+				dv = dl;
+				//for (i = 0; i < j; i++) dv += ds;
+				dv = dl + j * ds;
+				return new Double(dv);
+			}
 		} 
 		// boolean (case should be redundant)
 		else if (type instanceof TypeBool) { 
@@ -350,10 +445,22 @@ public class DefinedConstant
 		}
 		// double
 		else if (type instanceof TypeDouble) {
-			dl = ((Double)low).doubleValue();
-			ds = ((Double)step).doubleValue();
-			dv = ((Double)v).doubleValue();
-			return (int)Math.round((dv-dl)/ds);
+			if (low instanceof BigRational) {
+				BigRational rl = (BigRational) low;
+				BigRational rs = (BigRational) step;
+				BigRational rv = (BigRational) value;
+				BigRational index = (rv.subtract(rl)).divide(rs);
+				try {
+					return index.toInt();
+				} catch (PrismLangException e) {
+					throw new IllegalArgumentException("Can not compute value index, out of range: " + e);
+				}
+			} else {
+				dl = ((Double)low).doubleValue();
+				ds = ((Double)step).doubleValue();
+				dv = ((Double)v).doubleValue();
+				return (int)Math.round((dv-dl)/ds);
+			}
 		} 
 		// boolean (case should be redundant)
 		else if (type instanceof TypeBool) { 

--- a/prism/src/prism/DefinedConstant.java
+++ b/prism/src/prism/DefinedConstant.java
@@ -170,7 +170,10 @@ public class DefinedConstant
 		
 		// parse low value
 		try {
-			dl = Double.parseDouble(sl);
+			dl = parseDouble(sl);
+			if (!Double.isFinite(dl)) {
+				throw new NumberFormatException("Value is not finite");
+			}
 		}
 		catch (NumberFormatException e) {
 			throw new PrismException("Value " + sl + " for constant " + name + " is not a valid double");
@@ -183,7 +186,10 @@ public class DefinedConstant
 		else {
 			// parse high value
 			try {
-				dh = Double.parseDouble(sh);
+				dh = parseDouble(sh);
+				if (!Double.isFinite(dh)) {
+					throw new NumberFormatException("Value is not finite");
+				}
 			}
 			catch (NumberFormatException e) {
 				throw new PrismException("Value " + sh + " for constant " + name + " is not a valid double");
@@ -196,7 +202,10 @@ public class DefinedConstant
 			else {
 				// parse step
 				try {
-					ds = Double.parseDouble(ss);
+					ds = parseDouble(ss);
+					if (!Double.isFinite(ds)) {
+						throw new NumberFormatException("Value is not finite");
+					}
 				}
 				catch (NumberFormatException e) {
 					throw new PrismException("Value " + ss + " for constant " + name + " is not a valid double");
@@ -229,6 +238,9 @@ public class DefinedConstant
 		// parse low value
 		try {
 			rl = BigRational.from(sl);
+			if (rl.isSpecial()) {
+				throw new NumberFormatException("Value is not finite");
+			}
 		}
 		catch (NumberFormatException e) {
 			throw new PrismException("Value " + sl + " for constant " + name + " is not a valid rational number");
@@ -242,6 +254,9 @@ public class DefinedConstant
 			// parse high value
 			try {
 				rh = BigRational.from(sh);
+				if (rh.isSpecial()) {
+					throw new NumberFormatException("Value is not finite");
+				}
 			}
 			catch (NumberFormatException e) {
 				throw new PrismException("Value " + sh + " for constant " + name + " is not a valid rational number");
@@ -255,6 +270,9 @@ public class DefinedConstant
 				// parse step
 				try {
 					rs = BigRational.from(ss);
+					if (rs.isSpecial()) {
+						throw new NumberFormatException("Value is not finite");
+					}
 				}
 				catch (NumberFormatException e) {
 					throw new PrismException("Value " + ss + " for constant " + name + " is not a valid double");
@@ -498,5 +516,39 @@ public class DefinedConstant
 		if (numSteps > 1) s += ":" + step + ":" + high;
 		
 		return s;
-	}	
+	}
+
+	/** Parse a double value (supports a/b fraction syntax) */
+	public static double parseDouble(String s)
+	{
+		int slashIdx = s.lastIndexOf('/');
+		if (slashIdx < 0) {
+			return Double.parseDouble(s);
+		} else {
+			// fraction
+			// because we use lastIndexOf, we obtain left-associativity,
+			// i.e. a/b/c is interpreted as (a/b)/c
+			if (slashIdx == 0 || slashIdx == s.length()-1) {
+				throw new NumberFormatException("Illegal fraction syntax");
+			}
+			double num = parseDouble(s.substring(0, slashIdx));
+			double den = parseDouble(s.substring(slashIdx+1));
+			return num / den;
+		}
+	}
+
+	/**
+	 * Check that the string can be parsed as a double value
+	 * (double, or fraction).
+	 */
+	public static boolean isValidDouble(String s)
+	{
+		try {
+			parseDouble(s);
+			return true;
+		} catch (NumberFormatException e) {
+			return false;
+		}
+	}
+
 }

--- a/prism/src/prism/ModelInfo.java
+++ b/prism/src/prism/ModelInfo.java
@@ -50,7 +50,7 @@ public interface ModelInfo
 	 * Undefined constants can be subsequently redefined to different values with the same method.
 	 * The current constant values (if set) are available via {@link #getConstantValues()}.
 	 */
-	public void setSomeUndefinedConstants(Values someValues) throws PrismException;
+	public void setSomeUndefinedConstants(Values someValues, boolean exact) throws PrismException;
 
 	/**
 	 * Get access to the values for all constants in the model, including the 

--- a/prism/src/prism/Prism.java
+++ b/prism/src/prism/Prism.java
@@ -262,6 +262,8 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	private ModelGenerator currentModelGenerator = null;
 	// Constants to be defined for PRISM model
 	private Values currentDefinedMFConstants = null;
+	// Was currentDefinedMFConstants evaluated exactly?
+	private boolean currentDefinedMFConstantsAreExact = false;
 	// Built model storage - symbolic or explicit - at most one is non-null
 	private Model currentModel = null;
 	private explicit.Model currentModelExpl = null;
@@ -1775,23 +1777,29 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	 * Set (some or all) undefined constants for the currently loaded PRISM model
 	 * (assuming they have changed since the last time this was called).
 	 * @param definedMFConstants The constant values
+	 * @param exact evaluation of constants (using BigRational)
 	 */
-	public void setPRISMModelConstants(Values definedMFConstants) throws PrismException
+	public void setPRISMModelConstants(Values definedMFConstants, boolean exact) throws PrismException
 	{
-		if (currentDefinedMFConstants == null && definedMFConstants == null)
+		if (currentDefinedMFConstants == null && definedMFConstants == null && currentDefinedMFConstantsAreExact == exact)
 			return;
-		if (currentDefinedMFConstants != null && currentDefinedMFConstants.equals(definedMFConstants))
+		if (currentDefinedMFConstants != null &&
+		    currentDefinedMFConstants.equals(definedMFConstants) &&
+		    currentDefinedMFConstantsAreExact == exact) {
+			// no change in constants and evaluation mode, nothing to do
 			return;
+		}
 
 		// Clear any existing built model(s)
 		clearBuiltModel();
 		// Store constants here and in ModulesFile
 		currentDefinedMFConstants = definedMFConstants;
+		currentDefinedMFConstantsAreExact = exact;
 		if (currentModulesFile != null) {
-			currentModulesFile.setSomeUndefinedConstants(definedMFConstants);
+			currentModulesFile.setSomeUndefinedConstants(definedMFConstants, exact);
 		}
 		if (currentModelGenerator != null) {
-			currentModelGenerator.setSomeUndefinedConstants(definedMFConstants);
+			currentModelGenerator.setSomeUndefinedConstants(definedMFConstants, exact);
 		}
 
 		// If required, export parsed PRISM model, with constants expanded
@@ -2970,7 +2978,8 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 				DigitalClocks dc = new DigitalClocks(this);
 				dc.translate(oldModulesFile, propertiesFile, expr);
 				currentModulesFile = dc.getNewModulesFile();
-				currentModulesFile.setUndefinedConstants(oldModulesFile.getConstantValues());
+				// evaluate constants exactly if we are in exact computation mode
+				currentModulesFile.setUndefinedConstants(oldModulesFile.getConstantValues(), settings.getBoolean(PrismSettings.PRISM_EXACT_ENABLED));
 				currentModelType = ModelType.MDP;
 				currentModelGenerator = new ModulesFileModelGenerator(currentModulesFile, this);
 				clearBuiltModel();

--- a/prism/src/prism/PrismCL.java
+++ b/prism/src/prism/PrismCL.java
@@ -680,6 +680,25 @@ public class PrismCL implements PrismModelListener
 
 	private void doExports()
 	{
+		if (param || prism.getSettings().getBoolean(PrismSettings.PRISM_EXACT_ENABLED)) {
+			if (exporttrans ||
+			    exportstaterewards ||
+			    exporttransrewards ||
+			    exportstates ||
+			    exportspy ||
+			    exportdot ||
+			    exporttransdot ||
+			    exporttransdotstates ||
+			    exportmodeldotview ||
+			    exportlabels ||
+			    exportsccs ||
+			    exportbsccs ||
+			    exportmecs) {
+				mainLog.printWarning("Skipping exports in parametric / exact model checking mode, currently not supported.");
+				return;
+			}
+		}
+
 		// export transition matrix to a file
 		if (exporttrans) {
 			try {
@@ -879,6 +898,11 @@ public class PrismCL implements PrismModelListener
 		File exportSteadyStateFile = null;
 
 		if (steadystate) {
+			if (param || prism.getSettings().getBoolean(PrismSettings.PRISM_EXACT_ENABLED)) {
+				mainLog.printWarning("Skipping steady-state computation in parametric / exact model checking mode, currently not supported.");
+				return;
+			}
+
 			try {
 				// Choose destination for output (file or log)
 				if (exportSteadyStateFilename == null || exportSteadyStateFilename.equals("stdout"))
@@ -904,6 +928,11 @@ public class PrismCL implements PrismModelListener
 
 		if (dotransient) {
 			try {
+				if (param || prism.getSettings().getBoolean(PrismSettings.PRISM_EXACT_ENABLED)) {
+					mainLog.printWarning("Skipping transient probability computation in parametric / exact model checking mode, currently not supported.");
+					return;
+				}
+
 				// Choose destination for output (file or log)
 				if (exportTransientFilename == null || exportTransientFilename.equals("stdout"))
 					exportTransientFile = null;

--- a/prism/src/prism/UndefinedConstants.java
+++ b/prism/src/prism/UndefinedConstants.java
@@ -54,6 +54,8 @@ public class UndefinedConstants
 	private List<Property> props = null;
 	// just get constants from labels (in properties file)?
 	private boolean justLabels = false;
+	// computation / evaluation of constants via double or exact arithmetic?
+	private boolean exact = false;
 
 	// info about constants
 	private int mfNumConsts = 0;
@@ -148,6 +150,11 @@ public class UndefinedConstants
 	public void setJustLabels(boolean justLabels)
 	{
 		this.justLabels = justLabels;
+	}
+
+	public void setExactMode(boolean exact)
+	{
+		this.exact = exact;
 	}
 
 	/**
@@ -503,13 +510,13 @@ public class UndefinedConstants
 		if (index != -1) {
 			// const is in modules file
 			overwrite = (mfConsts.get(index).isDefined());
-			mfConsts.get(index).define(sl, sh, ss);
+			mfConsts.get(index).define(sl, sh, ss, exact);
 		} else {
 			index = getPFConstIndex(name);
 			if (index != -1) {
 				// const is in properties file
 				overwrite = (pfConsts.get(index).isDefined());
-				pfConsts.get(index).define(sl, sh, ss);
+				pfConsts.get(index).define(sl, sh, ss, exact);
 			} else {
 				// If we are required to use all supplied const values, check for this
 				// (by default we don't care about un-needed or non-existent const values)

--- a/prism/src/simulator/ModulesFileModelGenerator.java
+++ b/prism/src/simulator/ModulesFileModelGenerator.java
@@ -112,7 +112,7 @@ public class ModulesFileModelGenerator extends DefaultModelGenerator
 	}
 	
 	@Override
-	public void setSomeUndefinedConstants(Values someValues) throws PrismException
+	public void setSomeUndefinedConstants(Values someValues, boolean exact) throws PrismException
 	{
 		// We start again with a copy of the original modules file
 		// and set the constants in the copy.
@@ -121,7 +121,7 @@ public class ModulesFileModelGenerator extends DefaultModelGenerator
 		// start again at a place where references to constants have not
 		// yet been replaced.
 		modulesFile = (ModulesFile) originalModulesFile.deepCopy();
-		modulesFile.setSomeUndefinedConstants(someValues);
+		modulesFile.setSomeUndefinedConstants(someValues, exact);
 		mfConstants = modulesFile.getConstantValues();
 		initialise();
 	}

--- a/prism/src/simulator/ModulesFileModelGeneratorSymbolic.java
+++ b/prism/src/simulator/ModulesFileModelGeneratorSymbolic.java
@@ -23,6 +23,15 @@ import prism.PrismComponent;
 import prism.PrismException;
 import prism.PrismLangException;
 
+/**
+ * A variant of ModulesFileGenerator that is suitable for model generation
+ * at a symbolic level, i.e., where numeric values are kept as expressions
+ * instead of being evaluated.
+ * <br>
+ * Used by the parametric / exact engine to build models.
+ * <br>
+ * Uses exact arithmetic to evaluate the various expressions in a model description.
+ */
 public class ModulesFileModelGeneratorSymbolic extends DefaultModelGenerator implements ModelGeneratorSymbolic
 {
 	// Parent PrismComponent (logs, settings etc.)
@@ -241,7 +250,8 @@ public class ModulesFileModelGeneratorSymbolic extends DefaultModelGenerator imp
 	public State getInitialState() throws PrismException
 	{
 		if (modulesFile.getInitialStates() == null) {
-			return modulesFile.getDefaultInitialState();
+			// get initial state, using exact evaluation
+			return modulesFile.getDefaultInitialState(true);
 		} else {
 			// Inefficient but probably won't be called
 			return getInitialStates().get(0);
@@ -254,7 +264,8 @@ public class ModulesFileModelGeneratorSymbolic extends DefaultModelGenerator imp
 		List<State> initStates = new ArrayList<State>();
 		// Easy (normal) case: just one initial state
 		if (modulesFile.getInitialStates() == null) {
-			State state = modulesFile.getDefaultInitialState();
+			// get initial state, using exact evaluation
+			State state = modulesFile.getDefaultInitialState(true);
 			initStates.add(state);
 		}
 		// Otherwise, there may be multiple initial states
@@ -263,7 +274,7 @@ public class ModulesFileModelGeneratorSymbolic extends DefaultModelGenerator imp
 			Expression init = modulesFile.getInitialStates();
 			List<State> allPossStates = varList.getAllStates();
 			for (State possState : allPossStates) {
-				if (init.evaluateBoolean(modulesFile.getConstantValues(), possState)) {
+				if (init.evaluateExact(modulesFile.getConstantValues(), possState).toBoolean()) {
 					initStates.add(possState);
 				}
 			}
@@ -364,7 +375,7 @@ public class ModulesFileModelGeneratorSymbolic extends DefaultModelGenerator imp
 	public boolean isLabelTrue(int i) throws PrismException
 	{
 		Expression expr = labelList.getLabel(i);
-		return expr.evaluateBoolean(exploreState);
+		return expr.evaluateExact(exploreState).toBoolean();
 	}
 	
 	@Override
@@ -376,8 +387,8 @@ public class ModulesFileModelGeneratorSymbolic extends DefaultModelGenerator imp
 		for (int i = 0; i < n; i++) {
 			if (!rewStr.getRewardStructItem(i).isTransitionReward()) {
 				Expression guard = rewStr.getStates(i);
-				if (guard.evaluateBoolean(modulesFile.getConstantValues(), state)) {
-					double rew = rewStr.getReward(i).evaluateDouble(modulesFile.getConstantValues(), state);
+				if (guard.evaluateExact(modulesFile.getConstantValues(), state).toBoolean()) {
+					double rew = rewStr.getReward(i).evaluateExact(modulesFile.getConstantValues(), state).doubleValue();
 					if (Double.isNaN(rew))
 						throw new PrismLangException("Reward structure evaluates to NaN at state " + state, rewStr.getReward(i));
 					d += rew;
@@ -398,8 +409,8 @@ public class ModulesFileModelGeneratorSymbolic extends DefaultModelGenerator imp
 				Expression guard = rewStr.getStates(i);
 				String cmdAction = rewStr.getSynch(i);
 				if (action == null ? (cmdAction.isEmpty()) : action.equals(cmdAction)) {
-					if (guard.evaluateBoolean(modulesFile.getConstantValues(), state)) {
-						double rew = rewStr.getReward(i).evaluateDouble(modulesFile.getConstantValues(), state);
+					if (guard.evaluateExact(modulesFile.getConstantValues(), state).toBoolean()) {
+						double rew = rewStr.getReward(i).evaluateExact(modulesFile.getConstantValues(), state).doubleValue();
 						if (Double.isNaN(rew))
 							throw new PrismLangException("Reward structure evaluates to NaN at state " + state, rewStr.getReward(i));
 						d += rew;

--- a/prism/src/simulator/ModulesFileModelGeneratorSymbolic.java
+++ b/prism/src/simulator/ModulesFileModelGeneratorSymbolic.java
@@ -137,7 +137,7 @@ public class ModulesFileModelGeneratorSymbolic extends DefaultModelGenerator imp
 	}
 	
 	@Override
-	public void setSomeUndefinedConstants(Values someValues) throws PrismException
+	public void setSomeUndefinedConstants(Values someValues, boolean exact) throws PrismException
 	{
 		// We start again with a copy of the original modules file
 		// and set the constants in the copy.
@@ -146,7 +146,7 @@ public class ModulesFileModelGeneratorSymbolic extends DefaultModelGenerator imp
 		// start again at a place where references to constants have not
 		// yet been replaced.
 		modulesFile = (ModulesFile) originalModulesFile.deepCopy();
-		modulesFile.setSomeUndefinedConstants(someValues);
+		modulesFile.setSomeUndefinedConstants(someValues, exact);
 		mfConstants = modulesFile.getConstantValues();
 		initialise();
 	}

--- a/prism/src/simulator/SimulatorEngine.java
+++ b/prism/src/simulator/SimulatorEngine.java
@@ -1608,7 +1608,8 @@ public class SimulatorEngine extends PrismComponent
 		for (int i = 0; i < n; i++) {
 			definedPFConstants = undefinedConstants.getPFConstantValues();
 			pfcs[i] = definedPFConstants;
-			propertiesFile.setSomeUndefinedConstants(definedPFConstants);
+			// for simulation, use non-exact constant evaluation
+			propertiesFile.setSomeUndefinedConstants(definedPFConstants, false);
 			try {
 				checkPropertyForSimulation(expr);
 				indices[i] = addProperty(expr, propertiesFile);

--- a/prism/src/userinterface/model/GUIMultiModelHandler.java
+++ b/prism/src/userinterface/model/GUIMultiModelHandler.java
@@ -627,7 +627,8 @@ public class GUIMultiModelHandler extends JPanel implements PrismModelListener
 			lastMFConstants = unC.getMFConstantValues();
 		}
 		try {
-			prism.setPRISMModelConstants(unC.getMFConstantValues());
+			// currently, don't evaluate constants exactly
+			prism.setPRISMModelConstants(unC.getMFConstantValues(), false);
 		} catch (PrismException e) {
 			theModel.error(e.getMessage());
 			return;
@@ -724,7 +725,8 @@ public class GUIMultiModelHandler extends JPanel implements PrismModelListener
 			lastMFConstants = unC.getMFConstantValues();
 		}
 		try {
-			prism.setPRISMModelConstants(unC.getMFConstantValues());
+			// currently, don't evaluate constants exactly
+			prism.setPRISMModelConstants(unC.getMFConstantValues(), false);
 		} catch (PrismException e) {
 			theModel.error(e.getMessage());
 			return;
@@ -762,7 +764,8 @@ public class GUIMultiModelHandler extends JPanel implements PrismModelListener
 			lastMFConstants = unC.getMFConstantValues();
 		}
 		try {
-			prism.setPRISMModelConstants(unC.getMFConstantValues());
+			// for steady-state, currently don't evaluate constants exactly
+			prism.setPRISMModelConstants(unC.getMFConstantValues(), false);
 		} catch (PrismException e) {
 			theModel.error(e.getMessage());
 			return;
@@ -800,7 +803,8 @@ public class GUIMultiModelHandler extends JPanel implements PrismModelListener
 			lastMFConstants = unC.getMFConstantValues();
 		}
 		try {
-			prism.setPRISMModelConstants(unC.getMFConstantValues());
+			// for transient computation, currently don't evaluate constants exactly
+			prism.setPRISMModelConstants(unC.getMFConstantValues(), false);
 		} catch (PrismException e) {
 			theModel.error(e.getMessage());
 			return;

--- a/prism/src/userinterface/properties/ConstantLine.java
+++ b/prism/src/userinterface/properties/ConstantLine.java
@@ -263,11 +263,11 @@ public class ConstantLine extends javax.swing.JPanel
 		else if(type instanceof TypeDouble)
 		{
 			try {
-				s = singleValueField.getText(); Double.parseDouble(s);
+				s = singleValueField.getText(); DefinedConstant.parseDouble(s);
 				if (isRange()) {
-					s = startValueField.getText(); Double.parseDouble(s);
-					s = endValueField.getText(); Double.parseDouble(s);
-					s = stepValueField.getText(); Double.parseDouble(s);
+					s = startValueField.getText(); DefinedConstant.parseDouble(s);
+					s = endValueField.getText(); DefinedConstant.parseDouble(s);
+					s = stepValueField.getText(); DefinedConstant.parseDouble(s);
 				}
 			} catch (NumberFormatException e) {
 				throw new PrismException("Invalid value \""+s+"\" for double constant \""+getName()+"\"");

--- a/prism/src/userinterface/properties/GUIExperiment.java
+++ b/prism/src/userinterface/properties/GUIExperiment.java
@@ -224,12 +224,17 @@ public class GUIExperiment
 					}
 				});
 
+				// are we in exact mode?
+				boolean exact = prism.getSettings().getBoolean(PrismSettings.PRISM_EXACT_ENABLED);
+				// for simulation, don't use exact mode...
+				exact &= !useSimulation;
+
 				for (i = 0; i < undefinedConstants.getNumModelIterations(); i++) {
 
 					// set values for ModulesFile constants
 					try {
 						definedMFConstants = undefinedConstants.getMFConstantValues();
-						prism.setPRISMModelConstants(definedMFConstants);
+						prism.setPRISMModelConstants(definedMFConstants, exact);
 					} catch (Exception e) {
 						// in case of error, report it (in log only), store as result, and go on to the next model
 						errorLog(e);
@@ -302,7 +307,7 @@ public class GUIExperiment
 								// Set values for PropertiesFile constants
 								if (propertiesFile != null) {
 									definedPFConstants = undefinedConstants.getPFConstantValues();
-									propertiesFile.setSomeUndefinedConstants(definedPFConstants);
+									propertiesFile.setSomeUndefinedConstants(definedPFConstants, exact);
 								}
 								// Normal model checking
 								if (!useSimulation) {

--- a/prism/src/userinterface/properties/GUIMultiProperties.java
+++ b/prism/src/userinterface/properties/GUIMultiProperties.java
@@ -269,6 +269,9 @@ public class GUIMultiProperties extends GUIPlugin implements MouseListener, List
 		verifyAfterReceiveParseNotification = false;
 
 		try {
+			// are we in exact mode?
+			boolean exact = getPrism().getSettings().getBoolean(PrismSettings.PRISM_EXACT_ENABLED);
+
 			// Get valid/selected properties
 			String propertiesString = getLabelsString() + "\n" + getConstantsString() + "\n" + propList.getValidSelectedAndReferencedString();
 			// Get PropertiesFile for valid/selected properties
@@ -281,6 +284,7 @@ public class GUIMultiProperties extends GUIPlugin implements MouseListener, List
 			for (int i = 0; i < n; i++)
 				validProperties.add(parsedProperties.getPropertyObject(i));
 			uCon = new UndefinedConstants(parsedModel, parsedProperties, validProperties);
+			uCon.setExactMode(exact);
 			if (uCon.getMFNumUndefined() + uCon.getPFNumUndefined() > 0) {
 				// Use previous constant values as defaults in dialog
 				int result = GUIConstantsPicker.defineConstantsWithDialog(this.getGUI(), uCon, mfConstants, pfConstants);
@@ -290,8 +294,8 @@ public class GUIMultiProperties extends GUIPlugin implements MouseListener, List
 			// Store model/property constants
 			mfConstants = uCon.getMFConstantValues();
 			pfConstants = uCon.getPFConstantValues();
-			getPrism().setPRISMModelConstants(mfConstants);
-			parsedProperties.setSomeUndefinedConstants(pfConstants);
+			getPrism().setPRISMModelConstants(mfConstants, exact);
+			parsedProperties.setSomeUndefinedConstants(pfConstants, exact);
 			// Store properties to be verified
 			propertiesToBeVerified = validGUIProperties;
 			for (GUIProperty gp : propertiesToBeVerified)
@@ -361,8 +365,9 @@ public class GUIMultiProperties extends GUIPlugin implements MouseListener, List
 			// Store model/property constants
 			mfConstants = uCon.getMFConstantValues();
 			pfConstants = uCon.getPFConstantValues();
-			getPrism().setPRISMModelConstants(mfConstants);
-			parsedProperties.setSomeUndefinedConstants(pfConstants);
+			// currently, evaluate constants non-exact for simulation
+			getPrism().setPRISMModelConstants(mfConstants, false);
+			parsedProperties.setSomeUndefinedConstants(pfConstants, false);
 			for (GUIProperty gp : simulatableGUIProperties)
 				gp.setConstants(mfConstants, pfConstants);
 
@@ -433,6 +438,7 @@ public class GUIMultiProperties extends GUIPlugin implements MouseListener, List
 
 		// sort out undefined constants
 		UndefinedConstants uCon = new UndefinedConstants(parsedModel, parsedProperties, props);
+		uCon.setExactMode(getPrism().getSettings().getBoolean(PrismSettings.PRISM_EXACT_ENABLED));
 		boolean showGraphDialog = false;
 		boolean useSimulation = false;
 		if (uCon.getMFNumUndefined() + uCon.getPFNumUndefined() == 0) {
@@ -1131,8 +1137,9 @@ public class GUIMultiProperties extends GUIPlugin implements MouseListener, List
 			// Store model/property constants
 			mfConstants = uCon.getMFConstantValues();
 			pfConstants = uCon.getPFConstantValues();
-			getPrism().setPRISMModelConstants(mfConstants);
-			parsedProperties.setSomeUndefinedConstants(pfConstants);
+			// currently, evaluate constants non-exact for model building
+			getPrism().setPRISMModelConstants(mfConstants, false);
+			parsedProperties.setSomeUndefinedConstants(pfConstants, false);
 			// If export is being done to log, switch view to log
 			if (exportFile == null)
 				logToFront();

--- a/prism/src/userinterface/simulator/GUISimulator.java
+++ b/prism/src/userinterface/simulator/GUISimulator.java
@@ -406,9 +406,9 @@ public class GUISimulator extends GUIPlugin implements MouseListener, ListSelect
 			// remember constant values for next time
 			lastConstants = uCon.getMFConstantValues();
 			lastPropertyConstants = uCon.getPFConstantValues();
-			// store constants
-			parsedModel.setUndefinedConstants(lastConstants);
-			pf.setSomeUndefinedConstants(lastPropertyConstants);
+			// store constants (currently, compute non-exact for simulation)
+			parsedModel.setUndefinedConstants(lastConstants, false);
+			pf.setSomeUndefinedConstants(lastPropertyConstants, false);
 
 			// check here for possibility of multiple initial states
 			// (not supported yet) to avoid problems below
@@ -782,8 +782,8 @@ public class GUISimulator extends GUIPlugin implements MouseListener, ListSelect
 			}
 			// remember constant values for next time
 			lastConstants = uCon.getMFConstantValues();
-			// store constants
-			parsedModel.setUndefinedConstants(lastConstants);
+			// store constants (currently, compute non-exact for simulation)
+			parsedModel.setUndefinedConstants(lastConstants, false);
 
 			// do we need to ask for an initial state for simulation?
 			// no: just use default/random


### PR DESCRIPTION
In exact or parametric model checking mode, we'd like to evaluate all expressions in a modules file using exact arithmetic.

This PR provides exact handling (in exact or parametric mode) of:
 - constants / experiments, including those passed by command-line or in the GUI
 - guard, update and init expressions
 - reward structure guards and values

For double literals, the rational number is now constructed from the literal string instead of from the parsed and converted to 'double' value, providing exact precision.

Conversions from rational numbers to int, e.g., when used in updates, throws exceptions on overflows. Currently, int literals in model or property source code are restricted to the Java int range and yield syntax errors if they can't be exactly represented.