### PR TITLE
explicit: Fix transition rewards from deadlock states

### DIFF
--- a/prism-tests/bugfixes/deadlock-rewards-issue-29.prism
+++ b/prism-tests/bugfixes/deadlock-rewards-issue-29.prism
@@ -1,0 +1,15 @@
+// test case for github issue #29
+// transitions added for deadlock removal should not get rewards
+
+mdp
+
+module M1
+  s: [0..1] init 0;
+
+  // deadlock for state 1
+  [] s=0 -> 1:(s'=1);
+endmodule
+
+rewards "r"
+  [] true: 2;
+endrewards

--- a/prism-tests/bugfixes/deadlock-rewards-issue-29.prism.mc.props
+++ b/prism-tests/bugfixes/deadlock-rewards-issue-29.prism.mc.props
@@ -1,0 +1,3 @@
+// total reward
+// RESULT: 2.0
+R=?[ C ]

--- a/prism-tests/bugfixes/deadlock-rewards-issue-29.prism.mc.props.args
+++ b/prism-tests/bugfixes/deadlock-rewards-issue-29.prism.mc.props.args
@@ -1,0 +1,11 @@
+# As a CTMC
+-ctmc -ex
+-ctmc -mtbdd
+-ctmc -hybrid
+-ctmc -sparse
+
+# As a DTMC
+-dtmc -ex
+-dtmc -mtbdd
+-dtmc -hybrid
+-dtmc -sparse

--- a/prism-tests/bugfixes/deadlock-rewards-issue-29.prism.props
+++ b/prism-tests/bugfixes/deadlock-rewards-issue-29.prism.props
@@ -1,0 +1,6 @@
+// total reward
+// RESULT: 2.0
+Rmax=?[ C ]
+
+// RESULT: 2.0
+Rmin=?[ C ]

--- a/prism-tests/bugfixes/deadlock-rewards-issue-29.prism.props.args
+++ b/prism-tests/bugfixes/deadlock-rewards-issue-29.prism.props.args
@@ -1,0 +1,4 @@
+-ex
+-mtbdd
+-hybrid
+-sparse

--- a/prism/src/explicit/rewards/ConstructRewards.java
+++ b/prism/src/explicit/rewards/ConstructRewards.java
@@ -174,6 +174,12 @@ public class ConstructRewards
 					if (guard.evaluateBoolean(constantValues, statesList.get(j))) {
 						// Transition reward
 						if (rewStr.getRewardStructItem(i).isTransitionReward()) {
+							if (mdp.isDeadlockState(j)) {
+								// As state j is a deadlock state, any outgoing transition
+								// was added to "fix" the deadlock and thus does not get a reward.
+								// Skip to next state
+								continue;
+							}
 							numChoices = mdp.getNumChoices(j);
 							for (k = 0; k < numChoices; k++) {
 								mdpAction = mdp.getAction(j, k);
@@ -275,7 +281,14 @@ public class ConstructRewards
 			if (!allowNegative && rew < 0)
 				throw new PrismException("Reward structure evaluates to " + rew + " at state " + state +", negative rewards not allowed");
 			rewSimple.addToStateReward(j, rew);
+
 			// State-action rewards
+			if (mdp.isDeadlockState(j)) {
+				// As state j is a deadlock state, any outgoing transition
+				// was added to "fix" the deadlock and thus does not get a reward.
+				// Skip to next state
+				continue;
+			}
 			int numChoices = mdp.getNumChoices(j);
 			for (int k = 0; k < numChoices; k++) {
 				rew = modelGen.getStateActionReward(r, state, mdp.getAction(j, k));


### PR DESCRIPTION
Previously, a transition reward with [] would match the self loop
transition added for fixing deadlocks in the explicit engine.

Fixes #29.
