### PR TITLE
explicit: don't re-explore states when not using labels

### DIFF
--- a/prism/src/explicit/ConstructModel.java
+++ b/prism/src/explicit/ConstructModel.java
@@ -374,6 +374,8 @@ public class ConstructModel extends PrismComponent
 		int numStates = statesList.size();
 		// Create storage for labels
 		int numLabels = modelGen.getNumLabels();
+		// No need to continue unless this ModelGenerator uses labels
+		if (numLabels == 0) return;
 		BitSet bitsets[] = new BitSet[numLabels];
 		for (int j = 0; j < numLabels; j++) {
 			bitsets[j] = new BitSet();


### PR DESCRIPTION
In `attachLabels()`, avoid unnecessarily exploring the state space again when the ModelGenerator indicates that labels aren't used (i.e. when `getNumLabels() == 0`).

Test results are identical before and after this change on linux64:

```
Test results:
 Success:      2846
 Warnings:     378  (use -w to show)
 Failure:      0
 Unsupported:  14
 Skipped:      23
```