### PR TITLE
Return stop watch instance on start

### DIFF
--- a/prism/src/common/StopWatch.java
+++ b/prism/src/common/StopWatch.java
@@ -84,17 +84,18 @@ public class StopWatch
 	}
 
 	/** Start the stop watch (without task description) */
-	public void start()
+	public StopWatch start()
 	{
-		start(null);
+		return start(null);
 	}
 
 	/** Start the stop watch, store task description (may be {@code null}) */
-	public void start(String taskDescription)
+	public StopWatch start(String taskDescription)
 	{
 		this.taskDescription = taskDescription;
 		running = true;
 		time = System.currentTimeMillis();
+		return this;
 	}
 
 	/**


### PR DESCRIPTION
For convenience, Stopwatch::start should return the instance instead of void.