### PR TITLE
Exclude OSX .DS_Store from install.sh

### DIFF
--- a/prism/install.sh
+++ b/prism/install.sh
@@ -17,7 +17,7 @@ if [ ! "$1" = "silent" ] ; then
     echo "Installing PRISM (directory=$PRISM_DIR)"
 fi
 TEMP_FILE=tmp
-FILES_TO_CHANGE=`find bin -maxdepth 1 ! -type d ! -name '*.bat' ! -name ngprism`
+FILES_TO_CHANGE=`find bin -maxdepth 1 ! -type d ! -name '*.bat' ! -name ngprism ! -name .DS_Store`
 for FILE_TO_CHANGE in $FILES_TO_CHANGE
 do
   if [ -f "$PRISM_DIR"/$FILE_TO_CHANGE ]; then


### PR DESCRIPTION
This prevents, that `sed` fails with _RE error: illegal byte sequence_ in install.sh on MacOS.