### PR TITLE
Remove static class-based allocation for GUI renderers / editors for settings

### DIFF
--- a/prism/src/settings/BooleanSetting.java
+++ b/prism/src/settings/BooleanSetting.java
@@ -30,14 +30,7 @@ public class BooleanSetting extends Setting
 {
     private static BooleanRenderer renderer;
     private static BooleanEditor editor;
-    
-    static
-    {
-        renderer = new BooleanRenderer();
-        editor = new BooleanEditor();
-    }
-    
-    
+
     /** Creates a new instance of BooleanSetting */
     public BooleanSetting(String name, Boolean value, String comment, SettingOwner owner, boolean editableWhenMultiple)
     {
@@ -51,11 +44,17 @@ public class BooleanSetting extends Setting
 	
     public SettingEditor getSettingEditor()
     {
+        if (editor == null) {
+            editor = new BooleanEditor();
+        }
         return editor;
     }
     
     public SettingRenderer getSettingRenderer()
     {
+        if (renderer == null) {
+            renderer = new BooleanRenderer();
+        }
         return renderer;
     }
     

--- a/prism/src/settings/ChoiceSetting.java
+++ b/prism/src/settings/ChoiceSetting.java
@@ -29,29 +29,25 @@ package settings;
 public class ChoiceSetting extends Setting
 {
     private static ChoiceRenderer renderer;
-    
-    
-    static
-    {
-        renderer = new ChoiceRenderer();
-    }
-    
-    
+
     private String[]values;
-    private ChoiceEditor editor; //editor is not static, we need one editor for each object
+    /**
+     * Editor for these settings.
+     * It is not static, as we need one editor for each object.
+     * Delayed allocation on first use, so we don't allocate on headless use.
+     */
+    private ChoiceEditor editor;
     
     /** Creates a new instance of ChoiceSetting */
     public ChoiceSetting(String name, String[]values, String value, String comment, SettingOwner owner, boolean editableWhenMultiple)
     {
         super(name, value, comment, owner, editableWhenMultiple);
-        editor = new ChoiceEditor(values);
         this.values = values;
     }
 	
 	public ChoiceSetting(String name, String[]values, String value, String comment, SettingOwner owner, boolean editableWhenMultiple, StringConstraint constraint)
 	{
 		super(name, value, comment, owner, editableWhenMultiple, constraint);
-		editor = new ChoiceEditor(values);
 		this.values = values;
 	}
     
@@ -72,11 +68,17 @@ public class ChoiceSetting extends Setting
     
     public SettingEditor getSettingEditor()
     {
+        if (editor == null) {
+            editor = new ChoiceEditor(values);
+        }
         return editor;
     }
     
     public SettingRenderer getSettingRenderer()
     {
+        if (renderer == null) {
+            renderer = new ChoiceRenderer();
+        }
         return renderer;
     }
     

--- a/prism/src/settings/ColorSetting.java
+++ b/prism/src/settings/ColorSetting.java
@@ -33,13 +33,7 @@ public class ColorSetting extends Setting
 {
 	private static ColorRenderer renderer;
 	private static ColorEditor editor;
-	
-	static
-	{
-		renderer = new ColorRenderer();
-		editor = new ColorEditor();
-	}
-	
+
 	/** Creates a new instance of ColorSetting */
 	public ColorSetting(String name, Color value, String comment, SettingOwner owner, boolean editableWhenMultiple)
 	{
@@ -54,11 +48,17 @@ public class ColorSetting extends Setting
 	
 	public SettingEditor getSettingEditor()
 	{
+		if (editor == null) {
+			editor = new ColorEditor();
+		}
 		return editor;
 	}
 	
 	public SettingRenderer getSettingRenderer()
 	{
+		if (renderer == null) {
+			renderer = new ColorRenderer();
+		}
 		return renderer;
 	}
 	

--- a/prism/src/settings/DoubleSetting.java
+++ b/prism/src/settings/DoubleSetting.java
@@ -30,14 +30,7 @@ public class DoubleSetting extends Setting
 {
     private static DoubleRenderer renderer;
     private static DoubleEditor editor;
-    
-    static
-    {
-        renderer = new DoubleRenderer();
-        editor = new DoubleEditor();
-    }
-    
-    
+
     /** Creates a new instance of DoubleSetting */
     public DoubleSetting(String name, Double value, String comment, SettingOwner owner, boolean editableWhenMultiple, NumericConstraint constraint)
     {
@@ -51,11 +44,17 @@ public class DoubleSetting extends Setting
     
     public SettingEditor getSettingEditor()
     {
+        if (editor == null) {
+            editor = new DoubleEditor();
+        }
         return editor;
     }
     
     public SettingRenderer getSettingRenderer()
     {
+        if (renderer == null) {
+            renderer = new DoubleRenderer();
+        }
         return renderer;
     }
     

--- a/prism/src/settings/FileSetting.java
+++ b/prism/src/settings/FileSetting.java
@@ -72,8 +72,6 @@ public class FileSetting extends Setting
         super(name, value, comment, owner, editableWhenMultiple);
 		if(value != null) validFile = value.isFile();
 		else validFile = false;
-		
-		selector = defaultSelector();
     }
 	
     public FileSetting(String name, File value, String comment, SettingOwner owner, boolean editableWhenMultiple, FontColorConstraint constraint)
@@ -81,8 +79,6 @@ public class FileSetting extends Setting
         super(name, value, comment, owner, editableWhenMultiple, constraint);
 		if(value != null) validFile = value.isFile();
 		else validFile = false;
-		
-		selector = defaultSelector();
     }
 	
 	public void checkObjectWithConstraints(Object obj) throws SettingException
@@ -153,6 +149,9 @@ public class FileSetting extends Setting
 	
 	public FileSelector getFileSelector()
 	{
+		if (selector == null) {
+			selector = defaultSelector();
+		}
 		return selector;
 	}
 	

--- a/prism/src/settings/FontColorSetting.java
+++ b/prism/src/settings/FontColorSetting.java
@@ -33,14 +33,7 @@ public class FontColorSetting extends Setting
 {
     private static FontColorRenderer renderer;
     private static FontColorEditor editor;
-    
-    static
-    {
-        renderer = new FontColorRenderer();
-        editor = new FontColorEditor();
-    }
-    
-    
+
     /** Creates a new instance of FontColorSetting */
 	public FontColorSetting(String name, FontColorPair value, String comment, SettingOwner owner, boolean editableWhenMultiple)
     {
@@ -54,11 +47,17 @@ public class FontColorSetting extends Setting
     
     public SettingEditor getSettingEditor()
     {
+        if (editor == null) {
+            editor = new FontColorEditor();
+        }
         return editor;
     }
     
     public SettingRenderer getSettingRenderer()
     {
+        if (renderer == null) {
+            renderer = new FontColorRenderer();
+        }
         return renderer;
     }
     

--- a/prism/src/settings/IntegerSetting.java
+++ b/prism/src/settings/IntegerSetting.java
@@ -30,14 +30,7 @@ public class IntegerSetting extends Setting
 {
     private static IntegerRenderer renderer;
     private static IntegerEditor editor;
-    
-    static
-    {
-        renderer = new IntegerRenderer();
-        editor = new IntegerEditor();
-    }
-    
-    
+
     /** Creates a new instance of DoubleSetting */
 	public IntegerSetting(String name, Integer value, String comment, SettingOwner owner, boolean editableWhenMultiple)
     {
@@ -51,11 +44,17 @@ public class IntegerSetting extends Setting
     
     public SettingEditor getSettingEditor()
     {
+        if (editor == null) {
+            editor = new IntegerEditor();
+        }
         return editor;
     }
     
     public SettingRenderer getSettingRenderer()
     {
+        if (renderer == null) {
+            renderer = new IntegerRenderer();
+        }
         return renderer;
     }
     

--- a/prism/src/settings/LongSetting.java
+++ b/prism/src/settings/LongSetting.java
@@ -30,14 +30,7 @@ public class LongSetting extends Setting
 {
     private static LongRenderer renderer;
     private static LongEditor editor;
-    
-    static
-    {
-        renderer = new LongRenderer();
-        editor = new LongEditor();
-    }
-    
-    
+
     /** Creates a new instance of LongSetting */
 	public LongSetting(String name, Long value, String comment, SettingOwner owner, boolean editableWhenMultiple)
     {
@@ -51,11 +44,17 @@ public class LongSetting extends Setting
     
     public SettingEditor getSettingEditor()
     {
+        if (editor == null) {
+            editor = new LongEditor();
+        }
         return editor;
     }
     
     public SettingRenderer getSettingRenderer()
     {
+        if (renderer == null) {
+            renderer = new LongRenderer();
+        }
         return renderer;
     }
     

--- a/prism/src/settings/MultipleLineStringSetting.java
+++ b/prism/src/settings/MultipleLineStringSetting.java
@@ -30,14 +30,7 @@ public class MultipleLineStringSetting extends Setting
 {
     private static MultipleLineStringRenderer renderer;
     private static MultipleLineStringEditor editor;
-    
-    static
-    {
-        renderer = new MultipleLineStringRenderer();
-        editor = new MultipleLineStringEditor();
-    }
-    
-    
+
     /** Creates a new instance of MultipleLineStringSetting */
 	public MultipleLineStringSetting(String name, String value, String comment, SettingOwner owner, boolean editableWhenMultiple)
     {
@@ -51,11 +44,17 @@ public class MultipleLineStringSetting extends Setting
     
     public SettingEditor getSettingEditor()
     {
+        if (editor == null) {
+            editor = new MultipleLineStringEditor();
+        }
         return editor;
     }
     
     public SettingRenderer getSettingRenderer()
     {
+        if (renderer == null) {
+            renderer = new MultipleLineStringRenderer();
+        }
         return renderer;
     }
     

--- a/prism/src/settings/SingleLineStringSetting.java
+++ b/prism/src/settings/SingleLineStringSetting.java
@@ -31,14 +31,6 @@ public class SingleLineStringSetting extends Setting
     private static SingleLineStringRenderer renderer;
     private static SingleLineStringEditor editor;
     
-    static
-    {
-        renderer = new SingleLineStringRenderer();
-        editor = new SingleLineStringEditor();
-    }
-    
-    
-    
     /** Creates a new instance of SingleLineStringSetting */
 	public SingleLineStringSetting(String name, String value, String comment, SettingOwner owner, boolean editableWhenMultiple, StringConstraint constraint)
     {
@@ -52,11 +44,17 @@ public class SingleLineStringSetting extends Setting
     
     public SettingEditor getSettingEditor()
     {
+        if (editor == null) {
+            editor = new SingleLineStringEditor();
+        }
         return editor;
     }
     
     public SettingRenderer getSettingRenderer()
     {
+        if (renderer == null) {
+            renderer = new SingleLineStringRenderer();
+        }
         return renderer;
     }
     


### PR DESCRIPTION
As noted on the mailing list, running PRISM in headless / command-line mode still leads to some AWT (GUI) calls, which can result in errors if there are problems with the Java AWT configuration. E.g., crashes with error message

```Exception in thread "main" java.awt.AWTError: Assistive Technology not found: org.GNOME.Accessibility.AtkWrapper```

These AWT calls are due to the settings objects creating static renderers or editors on class construction. These commits switch this to allocation-on-first-use, i.e., when a first call to `getSettingEditor()` or `getSettingRenderer()` is done (as was already the case for `FileSetting`).

This should remove all AWT calls when running from the command-line. On my computer, with these changes, the PRISM command-line startup time, i.e., just running
```$ time prism/bin/prism```
is decreased from 1.413s to 0.643s, by more than 50%...