### PR TITLE
Makefile cleanup

### DIFF
--- a/prism/Makefile
+++ b/prism/Makefile
@@ -299,7 +299,7 @@ JAVA_INCLUDES = -I $(JAVA_JNI_H_DIR) -I $(JAVA_JNI_MD_H_DIR)
 # Main part of Makefile #
 #########################
 
-MAKE_DIRS = dd jdd odd dv prism mtbdd sparse hybrid parser settings userinterface pepa/compiler simulator jltl2ba jltl2dstar explicit pta param strat automata
+MAKE_DIRS = dd jdd odd dv prism mtbdd sparse hybrid parser settings userinterface pepa/compiler simulator jltl2ba jltl2dstar explicit pta param strat automata common cex
 
 EXT_PACKAGES = lpsolve55 lp_solve_5.5_java
 

--- a/prism/Makefile
+++ b/prism/Makefile
@@ -413,21 +413,24 @@ test:
 	bin/prism ../prism-tests/functionality/verify/dtmcs/dtmc_pctl.pm ../prism-tests/functionality/verify/dtmcs/dtmc_pctl.pm.props -prop 2 -test
 
 # Run all tests (in ../prism-tests and ./tests)
+# Optionally, extra arguments for prism-auto are picked up via variable TESTS_ARGS
 tests: testslocal
 	@if [ -d ../prism-tests ]; then \
-	  cd ../prism-tests && "$(PWD)"/etc/scripts/prism-auto -t -m . -p "$(PWD)"/bin/prism --nailgun --ngprism "$(PWD)"/bin/ngprism; \
+	  cd ../prism-tests && "$(PWD)"/etc/scripts/prism-auto -t -m . -p "$(PWD)"/bin/prism --nailgun --ngprism "$(PWD)"/bin/ngprism $(TESTS_ARGS); \
 	else \
 	  echo "Skipping tests"; \
 	fi
 
 # Just display the command to run the test suite on this version of PRISM
+# Optionally, extra arguments for prism-auto are picked up via variable TESTS_ARGS
 testsecho:
-	@echo etc/scripts/prism-auto -t -m --nailgun --ngprism bin/ngprism ../prism-tests -p bin/prism
+	@echo etc/scripts/prism-auto -t -m --nailgun --ngprism bin/ngprism ../prism-tests -p bin/prism $(TESTS_ARGS)
 
 # Run local tests (in ./tests)
+# Optionally, extra arguments for prism-auto are picked up via variable TESTS_ARGS
 testslocal:
 	@if [ -d tests ]; then \
-	  cd tests && "$(PWD)"/etc/scripts/prism-auto -t -m . -p "$(PWD)"/bin/prism --nailgun --ngprism "$(PWD)"/bin/ngprism; \
+	  cd tests && "$(PWD)"/etc/scripts/prism-auto -t -m . -p "$(PWD)"/bin/prism --nailgun --ngprism "$(PWD)"/bin/ngprism $(TESTS_ARGS); \
 	else \
 	  echo "Skipping local tests"; \
 	fi

--- a/prism/src/cex/Makefile
+++ b/prism/src/cex/Makefile
@@ -9,11 +9,11 @@
 
 # Reminder: $@ = target, $* = target without extension, $< = dependency
 
-THIS_DIR = simulator
+THIS_DIR = cex
 PRISM_DIR_REL = ../..
 
-JAVA_FILES_ALL = $(wildcard *.java sampler/*.java networking/*.java method/*.java)
-JAVA_FILES = $(patsubst %package-info.java,,$(JAVA_FILES_ALL))
+JAVA_FILES_ALL = $(wildcard *.java)
+JAVA_FILES = $(subst package-info.java,,$(JAVA_FILES_ALL))
 CLASS_FILES = $(JAVA_FILES:%.java=$(PRISM_DIR_REL)/$(CLASSES_DIR)/$(THIS_DIR)/%.class)
 
 PRISM_CLASSPATH = "$(THIS_DIR)/$(PRISM_DIR_REL)/$(CLASSES_DIR)$(CLASSPATHSEP)$(THIS_DIR)/$(PRISM_DIR_REL)/lib/*"
@@ -35,7 +35,7 @@ $(PRISM_DIR_REL)/$(CLASSES_DIR)/$(THIS_DIR)/%.class: %.java
 	(cd ..; $(JAVAC) -sourcepath $(THIS_DIR)/$(PRISM_DIR_REL)/$(SRC_DIR) -classpath $(PRISM_CLASSPATH) -d $(THIS_DIR)/$(PRISM_DIR_REL)/$(CLASSES_DIR) $(THIS_DIR)/$<)
 
 clean: checks
-	@rm -f $(CLASS_FILES) $(PRISM_DIR_REL)/$(LIB_DIR)/$(LIBPREFIX)simengine$(LIBSUFFIX) $(O_FILES)
+	@rm -f $(CLASS_FILES)
 
 celan: clean
 

--- a/prism/src/common/Makefile
+++ b/prism/src/common/Makefile
@@ -9,11 +9,11 @@
 
 # Reminder: $@ = target, $* = target without extension, $< = dependency
 
-THIS_DIR = simulator
+THIS_DIR = common
 PRISM_DIR_REL = ../..
 
-JAVA_FILES_ALL = $(wildcard *.java sampler/*.java networking/*.java method/*.java)
-JAVA_FILES = $(patsubst %package-info.java,,$(JAVA_FILES_ALL))
+JAVA_FILES_ALL = $(wildcard *.java iterable/*.java functions/primitive/*.java)
+JAVA_FILES = $(subst package-info.java,,$(JAVA_FILES_ALL))
 CLASS_FILES = $(JAVA_FILES:%.java=$(PRISM_DIR_REL)/$(CLASSES_DIR)/$(THIS_DIR)/%.class)
 
 PRISM_CLASSPATH = "$(THIS_DIR)/$(PRISM_DIR_REL)/$(CLASSES_DIR)$(CLASSPATHSEP)$(THIS_DIR)/$(PRISM_DIR_REL)/lib/*"
@@ -35,7 +35,7 @@ $(PRISM_DIR_REL)/$(CLASSES_DIR)/$(THIS_DIR)/%.class: %.java
 	(cd ..; $(JAVAC) -sourcepath $(THIS_DIR)/$(PRISM_DIR_REL)/$(SRC_DIR) -classpath $(PRISM_CLASSPATH) -d $(THIS_DIR)/$(PRISM_DIR_REL)/$(CLASSES_DIR) $(THIS_DIR)/$<)
 
 clean: checks
-	@rm -f $(CLASS_FILES) $(PRISM_DIR_REL)/$(LIB_DIR)/$(LIBPREFIX)simengine$(LIBSUFFIX) $(O_FILES)
+	@rm -f $(CLASS_FILES)
 
 celan: clean
 

--- a/prism/src/explicit/Makefile
+++ b/prism/src/explicit/Makefile
@@ -10,7 +10,7 @@
 THIS_DIR = explicit
 PRISM_DIR_REL = ../..
 
-JAVA_FILES_ALL = $(wildcard *.java)
+JAVA_FILES_ALL = $(wildcard *.java rewards/*.java modelviews/*.java graphviz/*.java)
 JAVA_FILES = $(subst package-info.java,,$(JAVA_FILES_ALL))
 CLASS_FILES = $(JAVA_FILES:%.java=$(PRISM_DIR_REL)/$(CLASSES_DIR)/$(THIS_DIR)/%.class)
 


### PR DESCRIPTION
Cleanup the Makefiles, adding missing ones for common and cex and adding sub-packages, where missing.

Additionally, allow the use of 
```make tests TESTS_ARGS=...```
to pass additional arguments to the prism-auto running the regression tests.