### PR TITLE
Rewrite Values#clone for readability and efficiency

### DIFF
--- a/prism/src/parser/Values.java
+++ b/prism/src/parser/Values.java
@@ -26,10 +26,7 @@
 
 package parser;
 
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
 import java.util.ArrayList;
-import java.util.Locale;
 
 import parser.type.Type;
 import parser.type.TypeBool;
@@ -43,7 +40,7 @@ import prism.PrismUtils;
  * Class to store a list of typed constant/variable values.
  * (Basically, just a mapping from String to Object)
  */
-public class Values //implements Comparable
+public class Values implements Cloneable //implements Comparable
 {
 	protected ArrayList<String> names;
 	protected ArrayList<Object> values;
@@ -405,26 +402,19 @@ public class Values //implements Comparable
 // 		return 0;
 // 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
-	public Object clone()
+	public Values clone()
 	{
-		Values res;
-		int i, n;
-		String s;
-		Object o;
-		
-		res = new Values();
-		n = getNumValues();
-		for (i = 0; i < n; i++) {
-			s = getName(i);
-			o = getValue(i);
-			if (o instanceof Integer) o = new Integer(((Integer)o).intValue());
-			else if (o instanceof Double) o = new Double(((Double)o).doubleValue());
-			else o = new Boolean(((Boolean)o).booleanValue());
-			res.addValue(s, o);
+		Values clone;
+		try {
+			clone = (Values) super.clone();
+		} catch (CloneNotSupportedException e) {
+			throw new InternalError("Object#clone is expected to work for Cloneable objects.", e);
 		}
-		
-		return res;
+		clone.names = (ArrayList<String>) names.clone();
+		clone.values = (ArrayList<Object>) values.clone();
+		return clone;
 	}
 
 	@Override


### PR DESCRIPTION
The current implementation is a bit cumbersome and potentially inefficient due to resizing of the array lists during adding. This PR resolves this issue and marks the class cloneable.