### PR TITLE
Support for properly killing PRISM

### DIFF
--- a/prism/src/bin/prism.cygwin
+++ b/prism/src/bin/prism.cygwin
@@ -107,5 +107,16 @@ if [ "$PRISM_DEBUG" != "" ]; then
 	PRISM_JAVA="$PRISM_DEBUG"
 fi
 
-# Run PRISM through Java
-"$PRISM_JAVA" $PRISM_JAVA_ARG1 $PRISM_JAVA_ARG2 $PRISM_JAVA_DEBUG $PRISM_JAVAMAXMEM $PRISM_JAVASTACKSIZE -Djava.awt.headless=$PRISM_HEADLESS -Djava.library.path="$JAVA_LIBRARY_PATH_WIN" -classpath "$PRISM_CLASSPATH_WIN" $PRISM_MAINCLASS "$@"
+#
+# If environment variable PRISM_NO_EXEC is set to 'yes', use old method of starting Java.
+# The default method is to use an exec call.
+#
+if [ "$PRISM_NO_EXEC" = "yes" ]; then
+	# Run PRISM through Java as a child process (exit code of script is exit code of the java call)
+	# Note: Killing this startup script will not necessarily kill the Java process
+	"$PRISM_JAVA" $PRISM_JAVA_ARG1 $PRISM_JAVA_ARG2 $PRISM_JAVA_DEBUG $PRISM_JAVAMAXMEM $PRISM_JAVASTACKSIZE -Djava.awt.headless=$PRISM_HEADLESS -Djava.library.path="$JAVA_LIBRARY_PATH_WIN" -classpath "$PRISM_CLASSPATH_WIN" $PRISM_MAINCLASS "$@"
+else
+	# (Default) Run PRISM through Java via an exec call (the shell process is replaced by the Java process)
+	exec "$PRISM_JAVA" $PRISM_JAVA_ARG1 $PRISM_JAVA_ARG2 $PRISM_JAVA_DEBUG $PRISM_JAVAMAXMEM $PRISM_JAVASTACKSIZE -Djava.awt.headless=$PRISM_HEADLESS -Djava.library.path="$JAVA_LIBRARY_PATH_WIN" -classpath "$PRISM_CLASSPATH_WIN" $PRISM_MAINCLASS "$@"
+fi
+

--- a/prism/src/bin/prism.darwin32
+++ b/prism/src/bin/prism.darwin32
@@ -112,6 +112,16 @@ if [ "$PRISM_DEBUG" != "" ]; then
 	PRISM_JAVA="$PRISM_DEBUG"
 fi
 
-# Run PRISM through Java (exit code of script is exit code of the java call)
-"$PRISM_JAVA" $PRISM_JAVA_ARG1 $PRISM_JAVA_ARG2 $PRISM_JAVA_DEBUG $PRISM_JAVAMAXMEM $PRISM_JAVASTACKSIZE "$PRISM_ICON" "$PRISM_DOCK_NAME" -Djava.awt.headless=$PRISM_HEADLESS -Djava.library.path="$JAVA_LIBRARY_PATH" -classpath "$PRISM_CLASSPATH" $PRISM_MAINCLASS "$@"
+#
+# If environment variable PRISM_NO_EXEC is set to 'yes', use old method of starting Java.
+# The default method is to use an exec call.
+#
+if [ "$PRISM_NO_EXEC" = "yes" ]; then
+	# Run PRISM through Java as a child process (exit code of script is exit code of the java call)
+	# Note: Killing this startup script will not necessarily kill the Java process
+	"$PRISM_JAVA" $PRISM_JAVA_ARG1 $PRISM_JAVA_ARG2 $PRISM_JAVA_DEBUG $PRISM_JAVAMAXMEM $PRISM_JAVASTACKSIZE "$PRISM_ICON" "$PRISM_DOCK_NAME" -Djava.awt.headless=$PRISM_HEADLESS -Djava.library.path="$JAVA_LIBRARY_PATH" -classpath "$PRISM_CLASSPATH" $PRISM_MAINCLASS "$@"
+else
+	# (Default) Run PRISM through Java via an exec call (the shell process is replaced by the Java process)
+	exec "$PRISM_JAVA" $PRISM_JAVA_ARG1 $PRISM_JAVA_ARG2 $PRISM_JAVA_DEBUG $PRISM_JAVAMAXMEM $PRISM_JAVASTACKSIZE "$PRISM_ICON" "$PRISM_DOCK_NAME" -Djava.awt.headless=$PRISM_HEADLESS -Djava.library.path="$JAVA_LIBRARY_PATH" -classpath "$PRISM_CLASSPATH" $PRISM_MAINCLASS "$@"
+fi
 

--- a/prism/src/bin/prism.darwin32
+++ b/prism/src/bin/prism.darwin32
@@ -5,14 +5,6 @@
 # PRISM home directory
 PRISM_DIR=/home/luser/prism
 
-# Default value for notification after the scipt has finished (yes/no)
-NOTIFY_DEFAULT=no
-
-# Set value for notification
-if [ "$NOTIFY" = "" ]; then
-	NOTIFY=$NOTIFY_DEFAULT
-fi;
-
 # Command to launch Java
 if [ "$PRISM_JAVA" = "" ]; then
 	# On OS X, we want to avoiding calling java from the /usr/bin link
@@ -120,15 +112,6 @@ if [ "$PRISM_DEBUG" != "" ]; then
 	PRISM_JAVA="$PRISM_DEBUG"
 fi
 
-# Run PRISM through Java
+# Run PRISM through Java (exit code of script is exit code of the java call)
 "$PRISM_JAVA" $PRISM_JAVA_ARG1 $PRISM_JAVA_ARG2 $PRISM_JAVA_DEBUG $PRISM_JAVAMAXMEM $PRISM_JAVASTACKSIZE "$PRISM_ICON" "$PRISM_DOCK_NAME" -Djava.awt.headless=$PRISM_HEADLESS -Djava.library.path="$JAVA_LIBRARY_PATH" -classpath "$PRISM_CLASSPATH" $PRISM_MAINCLASS "$@"
 
-PRISM_EXIT_CODE=$?
-
-if [ "$NOTIFY" = "yes" ]; then
-	if [ -n "`which growlnotify`" ]; then
-		growlnotify --image $PRISM_DIR/etc/icons/prism.ico PRISM has finished -m "" > /dev/null 2> /dev/null
-	fi
-fi;
-
-exit $PRISM_EXIT_CODE

--- a/prism/src/bin/prism.darwin64
+++ b/prism/src/bin/prism.darwin64
@@ -112,6 +112,16 @@ if [ "$PRISM_DEBUG" != "" ]; then
 	PRISM_JAVA="$PRISM_DEBUG"
 fi
 
-# Run PRISM through Java (exit code of script is exit code of the java call)
-"$PRISM_JAVA" $PRISM_JAVA_ARG1 $PRISM_JAVA_ARG2 $PRISM_JAVA_DEBUG $PRISM_JAVAMAXMEM $PRISM_JAVASTACKSIZE "$PRISM_ICON" "$PRISM_DOCK_NAME" -Djava.awt.headless=$PRISM_HEADLESS -Djava.library.path="$JAVA_LIBRARY_PATH" -classpath "$PRISM_CLASSPATH" $PRISM_MAINCLASS "$@"
+#
+# If environment variable PRISM_NO_EXEC is set to 'yes', use old method of starting Java.
+# The default method is to use an exec call.
+#
+if [ "$PRISM_NO_EXEC" = "yes" ]; then
+	# Run PRISM through Java as a child process (exit code of script is exit code of the java call)
+	# Note: Killing this startup script will not necessarily kill the Java process
+	"$PRISM_JAVA" $PRISM_JAVA_ARG1 $PRISM_JAVA_ARG2 $PRISM_JAVA_DEBUG $PRISM_JAVAMAXMEM $PRISM_JAVASTACKSIZE "$PRISM_ICON" "$PRISM_DOCK_NAME" -Djava.awt.headless=$PRISM_HEADLESS -Djava.library.path="$JAVA_LIBRARY_PATH" -classpath "$PRISM_CLASSPATH" $PRISM_MAINCLASS "$@"
+else
+	# (Default) Run PRISM through Java via an exec call (the shell process is replaced by the Java process)
+	exec "$PRISM_JAVA" $PRISM_JAVA_ARG1 $PRISM_JAVA_ARG2 $PRISM_JAVA_DEBUG $PRISM_JAVAMAXMEM $PRISM_JAVASTACKSIZE "$PRISM_ICON" "$PRISM_DOCK_NAME" -Djava.awt.headless=$PRISM_HEADLESS -Djava.library.path="$JAVA_LIBRARY_PATH" -classpath "$PRISM_CLASSPATH" $PRISM_MAINCLASS "$@"
+fi
 

--- a/prism/src/bin/prism.darwin64
+++ b/prism/src/bin/prism.darwin64
@@ -5,14 +5,6 @@
 # PRISM home directory
 PRISM_DIR=/home/luser/prism
 
-# Default value for notification after the scipt has finished (yes/no)
-NOTIFY_DEFAULT=no
-
-# Set value for notification
-if [ "$NOTIFY" = "" ]; then
-	NOTIFY=$NOTIFY_DEFAULT
-fi;
-
 # Command to launch Java
 if [ "$PRISM_JAVA" = "" ]; then
 	# On OS X, we want to avoiding calling java from the /usr/bin link
@@ -120,15 +112,6 @@ if [ "$PRISM_DEBUG" != "" ]; then
 	PRISM_JAVA="$PRISM_DEBUG"
 fi
 
-# Run PRISM through Java
+# Run PRISM through Java (exit code of script is exit code of the java call)
 "$PRISM_JAVA" $PRISM_JAVA_ARG1 $PRISM_JAVA_ARG2 $PRISM_JAVA_DEBUG $PRISM_JAVAMAXMEM $PRISM_JAVASTACKSIZE "$PRISM_ICON" "$PRISM_DOCK_NAME" -Djava.awt.headless=$PRISM_HEADLESS -Djava.library.path="$JAVA_LIBRARY_PATH" -classpath "$PRISM_CLASSPATH" $PRISM_MAINCLASS "$@"
 
-PRISM_EXIT_CODE=$?
-
-if [ "$NOTIFY" = "yes" ]; then
-	if [ -n "`which growlnotify`" ]; then
-		growlnotify --image $PRISM_DIR/etc/icons/prism.ico PRISM has finished -m "" > /dev/null 2> /dev/null
-	fi
-fi;
-
-exit $PRISM_EXIT_CODE

--- a/prism/src/bin/prism.linux
+++ b/prism/src/bin/prism.linux
@@ -5,14 +5,6 @@
 # PRISM home directory
 PRISM_DIR=/home/luser/prism
 
-# Default value for notification after the scipt has finished (yes/no)
-NOTIFY_DEFAULT=no
-
-# Set value for notification
-if [ "$NOTIFY" = "" ]; then
-	NOTIFY=$NOTIFY_DEFAULT
-fi;
-
 # Command to launch Java
 if [ "$PRISM_JAVA" = "" ]; then
 	PRISM_JAVA=java
@@ -111,15 +103,6 @@ if [ "$PRISM_DEBUG" != "" ]; then
 	PRISM_JAVA="$PRISM_DEBUG"
 fi
 
-# Run PRISM through Java
+# Run PRISM through Java (exit code of script is exit code of the java call)
 "$PRISM_JAVA" $PRISM_JAVA_ARG1 $PRISM_JAVA_ARG2 $PRISM_JAVA_DEBUG $PRISM_JAVAMAXMEM $PRISM_JAVASTACKSIZE -Djava.awt.headless=$PRISM_HEADLESS -Djava.library.path="$JAVA_LIBRARY_PATH" -classpath "$PRISM_CLASSPATH" $PRISM_MAINCLASS "$@"
 
-PRISM_EXIT_CODE=$?
-
-if [ "$NOTIFY" = "yes" ]; then
-	if [ -n "`which notify-send`" ]; then
-	notify-send --icon=$PRISM_DIR/etc/icons/prism.ico "PRISM has finished" > /dev/null 2> /dev/null
-	fi
-fi;
-
-exit $PRISM_EXIT_CODE

--- a/prism/src/bin/prism.linux
+++ b/prism/src/bin/prism.linux
@@ -103,6 +103,16 @@ if [ "$PRISM_DEBUG" != "" ]; then
 	PRISM_JAVA="$PRISM_DEBUG"
 fi
 
-# Run PRISM through Java (exit code of script is exit code of the java call)
-"$PRISM_JAVA" $PRISM_JAVA_ARG1 $PRISM_JAVA_ARG2 $PRISM_JAVA_DEBUG $PRISM_JAVAMAXMEM $PRISM_JAVASTACKSIZE -Djava.awt.headless=$PRISM_HEADLESS -Djava.library.path="$JAVA_LIBRARY_PATH" -classpath "$PRISM_CLASSPATH" $PRISM_MAINCLASS "$@"
+#
+# If environment variable PRISM_NO_EXEC is set to 'yes', use old method of starting Java.
+# The default method is to use an exec call.
+#
+if [ "$PRISM_NO_EXEC" = "yes" ]; then
+	# Run PRISM through Java as a child process (exit code of script is exit code of the java call)
+	# Note: Killing this startup script will not necessarily kill the Java process
+	"$PRISM_JAVA" $PRISM_JAVA_ARG1 $PRISM_JAVA_ARG2 $PRISM_JAVA_DEBUG $PRISM_JAVAMAXMEM $PRISM_JAVASTACKSIZE -Djava.awt.headless=$PRISM_HEADLESS -Djava.library.path="$JAVA_LIBRARY_PATH" -classpath "$PRISM_CLASSPATH" $PRISM_MAINCLASS "$@"
+else
+	# (Default) Run PRISM through Java via an exec call (the shell process is replaced by the Java process)
+	exec "$PRISM_JAVA" $PRISM_JAVA_ARG1 $PRISM_JAVA_ARG2 $PRISM_JAVA_DEBUG $PRISM_JAVAMAXMEM $PRISM_JAVASTACKSIZE -Djava.awt.headless=$PRISM_HEADLESS -Djava.library.path="$JAVA_LIBRARY_PATH" -classpath "$PRISM_CLASSPATH" $PRISM_MAINCLASS "$@"
+fi
 


### PR DESCRIPTION
Currently, in non-interactive situations where PRISM is called from some script, killing the startup script (e.g., on a timeout or using a process manager) does not necessarily kill the Java process of PRISM, which continues to run and consume resources.

In the proposed changes, we avoid this by starting Java via `exec java`, replacing the startup shell process by the Java process, which can then be easily killed. As far as I can see, the only drawback is that in the output of `pstree` or process monitors we lose the nicer `bash bin/prism ...` command line which is a bit easier to parse visually when there are multiple PRISM processes running on the system, instead we only get the `java ...` line with all the (not that interesting) Java arguments.

I have played around with other solutions to the problem of reliably killing the Java process when the startup script is killed, but found no really simple/reliable/portable solution. If anyone has a good alternative idea, I'd be definitely interested.

As a part of this change, we have to get rid of support for GUI notifications signaling that a PRISM process has finished. This can be better accomplished via a wrapper script or similar.

The old behaviour of calling java as a child process is, for the moment, available via setting the environment variable `PRISM_NO_EXEC` to `yes`.

This PR is currently intended for discussion of the approach and testing, I've yet to thoroughly test on Linux and Windows.