### PR TITLE
GUI: In properties tab, support double-click for adding constants, labels

### DIFF
--- a/prism/src/userinterface/properties/GUIMultiProperties.java
+++ b/prism/src/userinterface/properties/GUIMultiProperties.java
@@ -1393,6 +1393,16 @@ public class GUIMultiProperties extends GUIPlugin implements MouseListener, List
 						// there is no property yet, open new property editor
 						a_newProperty();
 					}
+				} else if (e.getSource() == consTable || e.getSource() == constantsScroll) {
+					if (consTable.rowAtPoint(e.getPoint()) == -1) {
+						// double-click, not an existing row -> add a new constant
+						a_addConstant();
+					}
+				} else if (e.getSource() == labTable || e.getSource() == labelsScroll) {
+					if (labTable.rowAtPoint(e.getPoint()) == -1) {
+						// double-click, not an existing row -> add a new label
+						a_addLabel();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Similar to the behaviour in the properties list, if we double-click
inside the constant or label table but not on an existing entry, we
add a new contant/label line in the table.