### PR TITLE
More graceful stack overflow handling

### DIFF
--- a/prism/src/bin/prism.cygwin
+++ b/prism/src/bin/prism.cygwin
@@ -10,6 +10,8 @@ if [ "$PRISM_JAVA" = "" ]; then
 	PRISM_JAVA=java
 fi
 
+#### Java heap size handling (either via -javamaxmem argument or PRISM_JAVAMAXMEM environment variable)
+
 # If there is a -javamaxmem switch, use it for PRISM_JAVAMAXMEM
 ARGS=( "$@" )
 for ((i=0;i<${#ARGS[@]};i+=1)); do
@@ -33,7 +35,34 @@ else
 	# default
 	PRISM_JAVAMAXMEM="-Xmx1g"
 fi
-PRISM_JAVASTACKSIZE="-Xss4M"
+
+#### Java stack size handling (either via -javastack argument or PRISM_JAVASTACKSIZE environment variable)
+
+# If there is a -javastack switch, use it for PRISM_JAVASTACKSIZE
+for ((i=0;i<${#ARGS[@]};i+=1)); do
+	if [ "${ARGS[$i]}" = "-javastack" ]; then
+		PRISM_JAVASTACKSIZE=${ARGS[$i+1]}
+		PRISM_JAVASTACKSIZE=`echo "$PRISM_JAVASTACKSIZE" | awk /^[0-9]+[kmg]?$/`
+		if [ "$PRISM_JAVASTACKSIZE" = "" ]; then
+			echo; echo "Error: Invalid value for -javastack switch."; exit
+		fi
+	fi
+done
+
+# Stack size for Java
+if [ "$PRISM_JAVASTACKSIZE" != "" ]; then
+	PRISM_JAVASTACKSIZE=`echo "$PRISM_JAVASTACKSIZE" | awk /^[0-9]+[kmg]?$/`
+	if [ "$PRISM_JAVASTACKSIZE" = "" ]; then
+		echo; echo "Error: Environment variable PRISM_JAVASTACKSIZE is invalid."; exit
+	fi
+	PRISM_JAVASTACKSIZE="-Xss$PRISM_JAVASTACKSIZE"
+else
+	# default (4 MB)
+	PRISM_JAVASTACKSIZE="-Xss4m"
+fi
+
+####
+
 
 # Set up CLASSPATH:
 #  - PRISM jar file (for binary versions) (gets priority)

--- a/prism/src/bin/prism.darwin32
+++ b/prism/src/bin/prism.darwin32
@@ -24,6 +24,8 @@ if [ "$PRISM_JAVA" = "" ]; then
 	fi
 fi
 
+#### Java heap size handling (either via -javamaxmem argument or PRISM_JAVAMAXMEM environment variable)
+
 # If there is a -javamaxmem switch, use it for PRISM_JAVAMAXMEM
 ARGS=( "$@" )
 for ((i=0;i<${#ARGS[@]};i+=1)); do
@@ -47,7 +49,34 @@ else
 	# default
 	PRISM_JAVAMAXMEM="-Xmx1g"
 fi
-PRISM_JAVASTACKSIZE="-Xss4M"
+
+#### Java stack size handling (either via -javastack argument or PRISM_JAVASTACKSIZE environment variable)
+
+# If there is a -javastack switch, use it for PRISM_JAVASTACKSIZE
+for ((i=0;i<${#ARGS[@]};i+=1)); do
+	if [ "${ARGS[$i]}" = "-javastack" ]; then
+		PRISM_JAVASTACKSIZE=${ARGS[$i+1]}
+		PRISM_JAVASTACKSIZE=`echo "$PRISM_JAVASTACKSIZE" | awk /^[0-9]+[kmg]?$/`
+		if [ "$PRISM_JAVASTACKSIZE" = "" ]; then
+			echo; echo "Error: Invalid value for -javastack switch."; exit
+		fi
+	fi
+done
+
+# Stack size for Java
+if [ "$PRISM_JAVASTACKSIZE" != "" ]; then
+	PRISM_JAVASTACKSIZE=`echo "$PRISM_JAVASTACKSIZE" | awk /^[0-9]+[kmg]?$/`
+	if [ "$PRISM_JAVASTACKSIZE" = "" ]; then
+		echo; echo "Error: Environment variable PRISM_JAVASTACKSIZE is invalid."; exit
+	fi
+	PRISM_JAVASTACKSIZE="-Xss$PRISM_JAVASTACKSIZE"
+else
+	# default (4 MB)
+	PRISM_JAVASTACKSIZE="-Xss4m"
+fi
+
+####
+
 
 # Set up CLASSPATH:
 #  - PRISM jar file (for binary versions) (gets priority)

--- a/prism/src/bin/prism.darwin64
+++ b/prism/src/bin/prism.darwin64
@@ -24,6 +24,8 @@ if [ "$PRISM_JAVA" = "" ]; then
 	fi
 fi
 
+#### Java heap size handling (either via -javamaxmem argument or PRISM_JAVAMAXMEM environment variable)
+
 # If there is a -javamaxmem switch, use it for PRISM_JAVAMAXMEM
 ARGS=( "$@" )
 for ((i=0;i<${#ARGS[@]};i+=1)); do
@@ -47,7 +49,34 @@ else
 	# default
 	PRISM_JAVAMAXMEM="-Xmx1g"
 fi
-PRISM_JAVASTACKSIZE="-Xss4M"
+
+#### Java stack size handling (either via -javastack argument or PRISM_JAVASTACKSIZE environment variable)
+
+# If there is a -javastack switch, use it for PRISM_JAVASTACKSIZE
+for ((i=0;i<${#ARGS[@]};i+=1)); do
+	if [ "${ARGS[$i]}" = "-javastack" ]; then
+		PRISM_JAVASTACKSIZE=${ARGS[$i+1]}
+		PRISM_JAVASTACKSIZE=`echo "$PRISM_JAVASTACKSIZE" | awk /^[0-9]+[kmg]?$/`
+		if [ "$PRISM_JAVASTACKSIZE" = "" ]; then
+			echo; echo "Error: Invalid value for -javastack switch."; exit
+		fi
+	fi
+done
+
+# Stack size for Java
+if [ "$PRISM_JAVASTACKSIZE" != "" ]; then
+	PRISM_JAVASTACKSIZE=`echo "$PRISM_JAVASTACKSIZE" | awk /^[0-9]+[kmg]?$/`
+	if [ "$PRISM_JAVASTACKSIZE" = "" ]; then
+		echo; echo "Error: Environment variable PRISM_JAVASTACKSIZE is invalid."; exit
+	fi
+	PRISM_JAVASTACKSIZE="-Xss$PRISM_JAVASTACKSIZE"
+else
+	# default (4 MB)
+	PRISM_JAVASTACKSIZE="-Xss4m"
+fi
+
+####
+
 
 # Set up CLASSPATH:
 #  - PRISM jar file (for binary versions) (gets priority)

--- a/prism/src/bin/prism.linux
+++ b/prism/src/bin/prism.linux
@@ -18,6 +18,8 @@ if [ "$PRISM_JAVA" = "" ]; then
 	PRISM_JAVA=java
 fi
 
+#### Java heap size handling (either via -javamaxmem argument or PRISM_JAVAMAXMEM environment variable)
+
 # If there is a -javamaxmem switch, use it for PRISM_JAVAMAXMEM
 ARGS=( "$@" )
 for ((i=0;i<${#ARGS[@]};i+=1)); do
@@ -41,7 +43,34 @@ else
 	# default
 	PRISM_JAVAMAXMEM="-Xmx1g"
 fi
-PRISM_JAVASTACKSIZE="-Xss4M"
+
+#### Java stack size handling (either via -javastack argument or PRISM_JAVASTACKSIZE environment variable)
+
+# If there is a -javastack switch, use it for PRISM_JAVASTACKSIZE
+for ((i=0;i<${#ARGS[@]};i+=1)); do
+	if [ "${ARGS[$i]}" = "-javastack" ]; then
+		PRISM_JAVASTACKSIZE=${ARGS[$i+1]}
+		PRISM_JAVASTACKSIZE=`echo "$PRISM_JAVASTACKSIZE" | awk /^[0-9]+[kmg]?$/`
+		if [ "$PRISM_JAVASTACKSIZE" = "" ]; then
+			echo; echo "Error: Invalid value for -javastack switch."; exit
+		fi
+	fi
+done
+
+# Stack size for Java
+if [ "$PRISM_JAVASTACKSIZE" != "" ]; then
+	PRISM_JAVASTACKSIZE=`echo "$PRISM_JAVASTACKSIZE" | awk /^[0-9]+[kmg]?$/`
+	if [ "$PRISM_JAVASTACKSIZE" = "" ]; then
+		echo; echo "Error: Environment variable PRISM_JAVASTACKSIZE is invalid."; exit
+	fi
+	PRISM_JAVASTACKSIZE="-Xss$PRISM_JAVASTACKSIZE"
+else
+	# default (4 MB)
+	PRISM_JAVASTACKSIZE="-Xss4m"
+fi
+
+####
+
 
 # Set up CLASSPATH:
 #  - PRISM jar file (for binary versions) (gets priority)

--- a/prism/src/common/StackTraceHelper.java
+++ b/prism/src/common/StackTraceHelper.java
@@ -1,0 +1,69 @@
+//==============================================================================
+//	
+//	Copyright (c) 2018-
+//	Authors:
+//	* Joachim Klein <klein@tcs.inf.tu-dresden.de> (TU Dresden)
+//	
+//------------------------------------------------------------------------------
+//	
+//	This file is part of PRISM.
+//	
+//	PRISM is free software; you can redistribute it and/or modify
+//	it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation; either version 2 of the License, or
+//	(at your option) any later version.
+//	
+//	PRISM is distributed in the hope that it will be useful,
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//	GNU General Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License
+//	along with PRISM; if not, write to the Free Software Foundation,
+//	Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//	
+//==============================================================================
+
+package common;
+
+/** Helper class for converting stack traces to strings for output */
+public class StackTraceHelper
+{
+	/** Default limit for number of lines in a stack trace */
+	public static final int DEFAULT_STACK_TRACE_LIMIT = 25;
+
+	/**
+	 * Get a string representation of the stack trace for the Throwable
+	 * (up to the given limit of lines).
+	 * @param throwable the throwable
+	 * @param limit the limit
+	 */
+	public static String asString(Throwable throwable, int limit)
+	{
+		return asString(throwable.getStackTrace(), limit);
+	}
+
+	/**
+	 * Get a string representation of the stack trace for the given stack trace array
+	 * (up to the given limit of lines).
+	 * @param elements array of stack trace elements (zero-th element is top of stack)
+	 * @param limit the limit (0 = no limit)
+	 */
+	public static String asString(StackTraceElement[] elements, int limit)
+	{
+		StringBuilder sb = new StringBuilder();
+
+		int i = 0;
+		for (StackTraceElement element : elements) {
+			if (limit != 0 && i++ > limit) {
+				sb.append("    ....\n");
+				break;
+			}
+			sb.append("    at ");
+			sb.append(element);
+			sb.append("\n");
+		}
+
+		return sb.toString();
+	}
+}

--- a/prism/src/prism/PrismCL.java
+++ b/prism/src/prism/PrismCL.java
@@ -1055,10 +1055,10 @@ public class PrismCL implements PrismModelListener
 					}
 					exit();
 				}
-				// java max mem
-				else if (sw.equals("javamaxmem")) {
+				// java max mem & java stack size
+				else if (sw.equals("javamaxmem") || sw.equals("javastack")) {
 					i++;
-					// ignore - this is dealt with before java is launched
+					// ignore argument and subsequent value, this is dealt with before java is launched
 				}
 				// timeout
 				else if (sw.equals("timeout")) {
@@ -2309,7 +2309,8 @@ public class PrismCL implements PrismModelListener
 		mainLog.println("-nobuild ....................... Skip model construction (just do parse/export)");
 		mainLog.println("-test .......................... Enable \"test\" mode");
 		mainLog.println("-testall ....................... Enable \"test\" mode, but don't exit on error");
-		mainLog.println("-javamaxmem .................... Set the maximum heap size for Java, e.g. 500m, 4g [default: 1g]");
+		mainLog.println("-javamaxmem <x>................. Set the maximum heap size for Java, e.g. 500m, 4g [default: 1g]");
+		mainLog.println("-javastack <x> ................. Set the Java stack size [default: 4m]");
 		mainLog.println("-timeout <n> ................... Exit after a time-out of <n> seconds if not already terminated");
 		mainLog.println("-ng ............................ Run PRISM in Nailgun server mode; subsequent calls are then made via \"ngprism\"");
 		mainLog.println();

--- a/prism/src/prism/PrismCL.java
+++ b/prism/src/prism/PrismCL.java
@@ -35,6 +35,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
+import common.StackTraceHelper;
 import parser.Values;
 import parser.ast.Expression;
 import parser.ast.ExpressionReward;
@@ -219,14 +220,20 @@ public class PrismCL implements PrismModelListener
 			// we don't want to catch the nailgun exception below,
 			// so we catch it and rethrow
 			throw e;
-		} catch (Exception e) {
-			// We catch Exceptions here ourself to ensure that we actually exit
+		} catch (Exception|StackOverflowError e) {
+			// We catch Exceptions/stack overflows here ourself to ensure that we actually exit
 			// In the presence of thread pools (e.g., in the JAS library when using -exact),
 			// the main thread dying does not necessarily quit the program...
-			StringWriter sw = new StringWriter();
-			sw.append("\n");
-			e.printStackTrace(new PrintWriter(sw));
-			mainLog.print(sw.toString());
+			mainLog.println();
+			if (e instanceof StackOverflowError) {
+				// print exception + limited stack trace for stack overflows
+				mainLog.println(e.toString());
+				mainLog.println(StackTraceHelper.asString(e, StackTraceHelper.DEFAULT_STACK_TRACE_LIMIT));
+				mainLog.println("Try increasing the value of the Java stack size (via the -javastack argument).");
+			} else {
+				// print exception + full stack trace for generic exceptions
+				mainLog.print(e.toString() + "\n" + StackTraceHelper.asString(e, 0));
+			}
 			errorAndExit("Caught unhandled exception, aborting...");
 		}
 	}

--- a/prism/src/userinterface/GUIPrism.java
+++ b/prism/src/userinterface/GUIPrism.java
@@ -402,10 +402,11 @@ public class GUIPrism extends JFrame
 	public void passCLArgs(String args[])
 	{
 		// just before we get started, pass any command-line args to all plugins
-		// we first remove the -javamaxmem argument, if present
+		// we first remove the -javamaxmem/-javastack arguments, if present
 		List<String> argsCopy = new ArrayList<String>();
 		for (int i = 0; i < args.length; i++) {
-			if (args[i].equals("-javamaxmem")) {
+			if (args[i].equals("-javamaxmem") || args[i].equals("-javastack")) {
+				// ignore argument and subsequent value
 				i++;
 			} else {
 				argsCopy.add(args[i]);

--- a/prism/src/userinterface/model/computation/BuildModelThread.java
+++ b/prism/src/userinterface/model/computation/BuildModelThread.java
@@ -65,7 +65,7 @@ public class BuildModelThread extends GUIComputationThread
 		// Do build
 		try {
 			prism.buildModel();
-		} catch (Exception e) {
+		} catch (Throwable e) {
 			error(e);
 			SwingUtilities.invokeLater(new Runnable()
 			{

--- a/prism/src/userinterface/model/computation/ComputeSteadyStateThread.java
+++ b/prism/src/userinterface/model/computation/ComputeSteadyStateThread.java
@@ -76,7 +76,7 @@ public class ComputeSteadyStateThread extends GUIComputationThread
 		// Do Computation
 		try {
 			prism.doSteadyState(exportType, exportFile, null);
-		} catch (Exception e) {
+		} catch (Throwable e) {
 			error(e);
 			SwingUtilities.invokeLater(new Runnable()
 			{

--- a/prism/src/userinterface/model/computation/ComputeTransientThread.java
+++ b/prism/src/userinterface/model/computation/ComputeTransientThread.java
@@ -78,7 +78,7 @@ public class ComputeTransientThread extends GUIComputationThread
 		// Do Computation
 		try {
 			prism.doTransient(transientTime, exportType, exportFile, null);
-		} catch (Exception e) {
+		} catch (Throwable e) {
 			error(e);
 			SwingUtilities.invokeLater(new Runnable()
 			{

--- a/prism/src/userinterface/model/computation/ExportBuiltModelThread.java
+++ b/prism/src/userinterface/model/computation/ExportBuiltModelThread.java
@@ -112,7 +112,7 @@ public class ExportBuiltModelThread extends GUIComputationThread
 					}
 				});
 				return;
-			} catch (Exception e2) {
+			} catch (Throwable e2) {
 				error(e2);
 				SwingUtilities.invokeAndWait(new Runnable()
 				{

--- a/prism/src/userinterface/properties/GUIExperiment.java
+++ b/prism/src/userinterface/properties/GUIExperiment.java
@@ -35,6 +35,9 @@ import prism.*;
 import userinterface.*;
 
 import javax.swing.*;
+
+import common.StackTraceHelper;
+
 import java.util.*;
 import userinterface.util.*;
 
@@ -236,6 +239,13 @@ public class GUIExperiment
 						setMultipleErrors(definedMFConstants, null, e);
 						undefinedConstants.iterateModel();
 						continue;
+					} catch (StackOverflowError e) {
+						// in case of stack overflow, report it (in log only),
+						// store as PrismException in result, and go on to the next model
+						errorLog(e.toString() + "\n" + StackTraceHelper.asString(e, STACK_TRACE_LIMIT));
+						setMultipleErrors(definedMFConstants, null, new PrismException("Stack overflow"));
+						undefinedConstants.iterateModel();
+						continue;
 					}
 
 					// collect information for simulation if required
@@ -290,6 +300,13 @@ public class GUIExperiment
 							setMultipleErrors(definedMFConstants, null, e);
 							undefinedConstants.iterateModel();
 							continue;
+						} catch (StackOverflowError e) {
+							// in case of stack overflow, report it (in log only),
+							// store as PrismException in result, and go on to the next model
+							errorLog(e.toString() + "\n" + StackTraceHelper.asString(e, STACK_TRACE_LIMIT));
+							setMultipleErrors(definedMFConstants, null, new PrismException("Stack overflow"));
+							undefinedConstants.iterateModel();
+							continue;
 						}
 					} else {
 						// iterate through as many properties as necessary
@@ -326,6 +343,11 @@ public class GUIExperiment
 								// in case of error, report it (in log only), store exception as the result and proceed
 								errorLog(e);
 								res = new Result(e);
+							} catch (StackOverflowError e) {
+								// in case of stack overflow, report it (in log only),
+								// store as PrismException in result, and proceed
+								errorLog(e.toString() + "\n" + StackTraceHelper.asString(e, STACK_TRACE_LIMIT));
+								res = new Result(new PrismException("Stack overflow"));
 							}
 							// store result of model checking
 							SwingUtilities.invokeAndWait(new Runnable()

--- a/prism/src/userinterface/properties/computation/ModelCheckThread.java
+++ b/prism/src/userinterface/properties/computation/ModelCheckThread.java
@@ -107,6 +107,11 @@ public class ModelCheckThread extends GUIComputationThread
 			} catch (Exception e) {
 				result = new Result(e);
 				error(e);
+			} catch (StackOverflowError e) {
+				// convert the StackOverflowError to a PrismException, as the result handling
+				// expects Exception instead of Error objects
+				result = new Result(new PrismException("Stack overflow"));
+				error(e);
 			}
 			ic.interrupt();
 			try {

--- a/prism/src/userinterface/properties/computation/SimulateModelCheckThread.java
+++ b/prism/src/userinterface/properties/computation/SimulateModelCheckThread.java
@@ -121,6 +121,11 @@ public class SimulateModelCheckThread extends GUIComputationThread
 				// in the case of an error which affects all props, store/report it
 				resultError = e;
 				error(e);
+			} catch (StackOverflowError e) {
+				// in the case of an error which affects all props, store/report it
+				// convert to a PrismException for result
+				resultError = new PrismException("Stack overflow");
+				error(e);
 			}
 			//after collecting the results stop all of the clock icons
 			for (int i = 0; i < clkThreads.size(); i++) {
@@ -164,9 +169,13 @@ public class SimulateModelCheckThread extends GUIComputationThread
 					// do simulation
 					result = prism.modelCheckSimulator(pf, pf.getProperty(i), definedPFConstants, initialState, maxPathLength, method);
 					method.reset();
-				} catch (PrismException e) {
+				} catch (Exception e) {
 					result = new Result(e);
-					error(e.getMessage());
+					error(e);
+				} catch (StackOverflowError e) {
+					// store as PrismException in result
+					result = new Result(new PrismException("Stack overflow"));
+					error(e);
 				}
 				ict.interrupt();
 				while (!ict.canContinue) {


### PR DESCRIPTION
As pointed out in #77, if a stack overflow occurs in one of the computations threads (e.g., SCC analysis in a "deep" model, very heavily nested formulas/expressions, ...), the GUI does not notice that the computation thread is gone as the error handling there only catches Exceptions and not Errors. Errors are generally serious and should not be caught, but for a StackOverflowError we can gracefully recover by just ending the computation thread, the same as for other exceptions.

This PR addresses:
 - Making the stack size configurable (via -javastack x command-line parameter)
 - Gracefully handling stack overflows in the GUI (logging short stack trace to the log, short message with hint about -javastack in the pop-up) and command-line (short stack trace in the log & hint).
- If the stack overflow arises in the GUI during a model checking computation, it is recorded as the error in the result object, like other errors.

Have not tested on Linux / Windows yet, but don't expect trouble...

For the GUI, I think I covered the most likely situations (steady-state computation, verification, experiments) in testing. The test case for #77 is good for triggering the overflow in the explicit engine, either for steady-state computation or using a `S=?[ ... ]` property.