### PR TITLE
Tweaks for handling of nondeterminism in statistical model checker

### DIFF
--- a/prism/src/prism/ModelType.java
+++ b/prism/src/prism/ModelType.java
@@ -72,6 +72,12 @@ public enum ModelType
 		{
 			return RATE;
 		}
+
+		@Override
+		ModelType removeNondeterminism()
+		{
+			return CTMC;
+		}
 	},
 	DTMC("discrete-time Markov chain") {
 		@Override
@@ -92,9 +98,19 @@ public enum ModelType
 		{
 			return NEITHER;
 		}
+
+		@Override
+		ModelType removeNondeterminism()
+		{
+			return DTMC;
+		}
 	},
 	MDP("Markov decision process") {
-		
+		@Override
+		ModelType removeNondeterminism()
+		{
+			return DTMC;
+		}
 	},
 	PTA("probabilistic timed automaton") {
 		@Override
@@ -109,12 +125,24 @@ public enum ModelType
 		{
 			return true;
 		}
+
+		@Override
+		ModelType removeNondeterminism()
+		{
+			return DTMC;
+		}
 	},
 	SMG("stochastic multi-player game") {
 		@Override
 		public boolean multiplePlayers()
 		{
 			return true;
+		}
+
+		@Override
+		ModelType removeNondeterminism()
+		{
+			return DTMC;
 		}
 	};
 
@@ -192,6 +220,19 @@ public enum ModelType
 	public String probabilityOrRate()
 	{
 		return PROBABILITY;
+	}
+
+	/**
+	 * Return the model type that results from removing the nondeterminism
+	 * in this model type.
+	 * <br>
+	 * If there is no nondeterminism (or the removal of nondeterminism is not supported),
+	 * returns the same model type.
+	 */
+	ModelType removeNondeterminism()
+	{
+		// default: same model type
+		return this;
 	}
 
 	public static ModelType parseName(String name)

--- a/prism/src/prism/Prism.java
+++ b/prism/src/prism/Prism.java
@@ -3050,6 +3050,10 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 		if (definedPFConstants != null && definedPFConstants.getNumValues() > 0)
 			mainLog.println("Property constants: " + definedPFConstants);
 
+		if (currentModelType.nondeterministic() && currentModelType.removeNondeterminism() != currentModelType) {
+			mainLog.printWarning("For simulation, nondeterminism in " + currentModelType + " is resolved uniformly (resulting in " + currentModelType.removeNondeterminism() + ").");
+		}
+
 		// Check that property is valid for this model type
 		expr.checkValid(currentModelType);
 
@@ -3093,6 +3097,10 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 			mainLog.println("Model constants: " + currentDefinedMFConstants);
 		if (definedPFConstants != null && definedPFConstants.getNumValues() > 0)
 			mainLog.println("Property constants: " + definedPFConstants);
+
+		if (currentModelType.nondeterministic() && currentModelType.removeNondeterminism() != currentModelType) {
+			mainLog.printWarning("For simulation, nondeterminism in " + currentModelType + " is resolved uniformly (resulting in " + currentModelType.removeNondeterminism() + ").");
+		}
 
 		// Check that properties are valid for this model type
 		for (Expression expr : exprs)

--- a/prism/src/prism/Prism.java
+++ b/prism/src/prism/Prism.java
@@ -3055,7 +3055,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 		}
 
 		// Check that property is valid for this model type
-		expr.checkValid(currentModelType);
+		expr.checkValid(currentModelType.removeNondeterminism());
 
 		// Do simulation
 		res = getSimulator().modelCheckSingleProperty(currentModulesFile, propertiesFile, expr, initialState, maxPathLength, simMethod);
@@ -3104,7 +3104,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 		// Check that properties are valid for this model type
 		for (Expression expr : exprs)
-			expr.checkValid(currentModelType);
+			expr.checkValid(currentModelType.removeNondeterminism());
 
 		// Do simulation
 		res = getSimulator().modelCheckMultipleProperties(currentModulesFile, propertiesFile, exprs, initialState, maxPathLength, simMethod);


### PR DESCRIPTION
Print warning when used with nondet models and allow use of DTMC-style properties with nondet models.

Should be compatible with prism-games extension as we use ModelType functionality which knows about STPGs/SMs.