### PR TITLE
Explicit: Add support for CTMC steady state computations

### DIFF
--- a/prism/src/explicit/CTMCModelChecker.java
+++ b/prism/src/explicit/CTMCModelChecker.java
@@ -861,6 +861,29 @@ public class CTMCModelChecker extends ProbModelChecker
 	}
 
 	/**
+	 * Compute steady-state rewards, i.e., R=?[ S ].
+	 * @param ctmc the CTMC
+	 * @param modelRewards the (state) rewards
+	 */
+	public ModelCheckerResult computeSteadyStateRewards(CTMC ctmc, MCRewards modelRewards) throws PrismException
+	{
+		int n = ctmc.getNumStates();
+		double multRewards[] = new double[n];
+
+		for (int i = 0; i < n; i++) {
+			multRewards[i] = modelRewards.getStateReward(i);
+		}
+
+		// We construct the embedded DTMC and do the steady-state computation there
+		mainLog.println("Building embedded DTMC...");
+		DTMC dtmcEmb = ctmc.getImplicitEmbeddedDTMC();
+
+		// compute the steady-state rewards in the embedded DTMC, applying the BSCC value post-processing
+		mainLog.println("Doing steady-state computation in embedded DTMC (with exit-rate weighting for BSCC probabilities)...");
+		return createDTMCModelChecker().computeSteadyStateBackwardsProbs(dtmcEmb, multRewards, new SteadyStateBSCCPostProcessor(ctmc));
+	}
+
+	/**
 	 * Compute transient probabilities.
 	 * i.e. compute the probability of being in each state at time {@code t},
 	 * assuming the initial distribution {@code initDist}. 

--- a/prism/src/explicit/CTMCModelChecker.java
+++ b/prism/src/explicit/CTMCModelChecker.java
@@ -822,6 +822,25 @@ public class CTMCModelChecker extends ProbModelChecker
 	}
 
 	/**
+	 * Compute steady-state probabilities for an S operator, i.e., S=?[ b ].
+	 * @param ctmc the CTMC
+	 * @param b the satisfaction set of states for the inner state formula of the operators
+	 */
+	protected StateValues computeSteadyStateFormula(CTMC ctmc, BitSet b) throws PrismException
+	{
+		double multProbs[] = Utils.bitsetToDoubleArray(b, ctmc.getNumStates());
+
+		// We construct the embedded DTMC and do the steady-state computation there
+		mainLog.println("Building embedded DTMC...");
+		DTMC dtmcEmb = ctmc.getImplicitEmbeddedDTMC();
+
+		// compute the steady-state probabilities in the embedded DTMC, applying the BSCC value post-processing
+		mainLog.println("Doing steady-state computation in embedded DTMC (with exit-rate weighting for BSCC probabilities)...");
+		ModelCheckerResult res = createDTMCModelChecker().computeSteadyStateBackwardsProbs(dtmcEmb, multProbs, new SteadyStateBSCCPostProcessor(ctmc));
+		return StateValues.createFromDoubleArray(res.soln, ctmc);
+	}
+
+	/**
 	 * Compute (forwards) steady-state probabilities
 	 * i.e. compute the long-run probability of being in each state,
 	 * assuming the initial distribution {@code initDist}.

--- a/prism/src/explicit/DTMCModelChecker.java
+++ b/prism/src/explicit/DTMCModelChecker.java
@@ -2157,6 +2157,18 @@ public class DTMCModelChecker extends ProbModelChecker
 	}
 
 	/**
+	 * Compute steady-state probabilities for an S operator, i.e., S=?[ b ].
+	 * @param dtmc the DTMC
+	 * @param b the satisfaction set of states for the inner state formula of the operators
+	 */
+	protected StateValues computeSteadyStateFormula(DTMC dtmc, BitSet b) throws PrismException
+	{
+		double multProbs[] = Utils.bitsetToDoubleArray(b, dtmc.getNumStates());
+		ModelCheckerResult res = computeSteadyStateBackwardsProbs(dtmc, multProbs);
+		return StateValues.createFromDoubleArray(res.soln, dtmc);
+	}
+
+	/**
 	 * Compute (forwards) steady-state probabilities
 	 * i.e. compute the long-run probability of being in each state,
 	 * assuming the initial distribution {@code initDist}. 

--- a/prism/src/explicit/DTMCModelChecker.java
+++ b/prism/src/explicit/DTMCModelChecker.java
@@ -2169,6 +2169,34 @@ public class DTMCModelChecker extends ProbModelChecker
 	}
 
 	/**
+	 * An interface for a post-processor, taking a solution vector over
+	 * the whole state space and applying some post-processing on the
+	 * solution for a given BSCC (with the state indices given by a BitSet).
+	 * <br>
+	 * This post-processor may only assume that the values in the solution vector
+	 * corresponding to the BSCC states are valid and may only write to those values,
+	 * the other values in the vector should not be changed.
+	 */
+	@FunctionalInterface
+	public interface BSCCPostProcessor {
+		public void apply(double soln[], BitSet bscc);
+	};
+
+	/**
+	 * Compute (forwards) steady-state probabilities
+	 * i.e. compute the long-run probability of being in each state,
+	 * assuming the initial distribution {@code initDist}.
+	 * For space efficiency, the initial distribution vector will be modified and values over-written,
+	 * so if you wanted it, take a copy.
+	 * @param dtmc The DTMC
+	 * @param initDist Initial distribution (will be overwritten)
+	 */
+	public ModelCheckerResult computeSteadyStateProbs(DTMC dtmc, double initDist[]) throws PrismException
+	{
+		return computeSteadyStateProbs(dtmc, initDist, null);
+	}
+
+	/**
 	 * Compute (forwards) steady-state probabilities
 	 * i.e. compute the long-run probability of being in each state,
 	 * assuming the initial distribution {@code initDist}. 
@@ -2176,8 +2204,9 @@ public class DTMCModelChecker extends ProbModelChecker
 	 * so if you wanted it, take a copy. 
 	 * @param dtmc The DTMC
 	 * @param initDist Initial distribution (will be overwritten)
+	 * @param processor Post-processor for the values of each BSCC (optional: null means no post-processing)
 	 */
-	public ModelCheckerResult computeSteadyStateProbs(DTMC dtmc, double initDist[]) throws PrismException
+	public ModelCheckerResult computeSteadyStateProbs(DTMC dtmc, double initDist[], BSCCPostProcessor bsccPostProcessor) throws PrismException
 	{
 		StopWatch watch = new StopWatch().start();
 
@@ -2228,6 +2257,9 @@ public class DTMCModelChecker extends ProbModelChecker
 			mainLog.println("\nInitial states are all in one BSCC (so no reachability probabilities computed)");
 			BitSet bscc = bsccs.get(initInOneBSCC);
 			computeSteadyStateProbsForBSCC(dtmc, bscc, solnProbs);
+			if (bsccPostProcessor != null) {
+				bsccPostProcessor.apply(solnProbs, bscc);
+			}
 		}
 
 		// Otherwise, have to consider all the BSCCs
@@ -2254,6 +2286,9 @@ public class DTMCModelChecker extends ProbModelChecker
 				BitSet bscc = bsccs.get(b);
 				// Compute steady-state probabilities for the BSCC
 				computeSteadyStateProbsForBSCC(dtmc, bscc, solnProbs);
+				if (bsccPostProcessor != null) {
+					bsccPostProcessor.apply(solnProbs, bscc);
+				}
 				// Multiply by BSCC reach prob
 				for (int i = bscc.nextSetBit(0); i >= 0; i = bscc.nextSetBit(i + 1))
 					solnProbs[i] *= probBSCCs[b];
@@ -2278,6 +2313,21 @@ public class DTMCModelChecker extends ProbModelChecker
 	 */
 	public ModelCheckerResult computeSteadyStateBackwardsProbs(DTMC dtmc, double multProbs[]) throws PrismException
 	{
+		return computeSteadyStateBackwardsProbs(dtmc, multProbs, null);
+	}
+
+	/**
+	 * Perform (backwards) steady-state probabilities, as required for (e.g. CSL) model checking.
+	 * Compute, for each initial state s, the sum over all states s'
+	 * of the steady-state probability of being in s'
+	 * multiplied by the corresponding probability in the vector {@code multProbs}.
+	 * If {@code multProbs} is null, it is assumed to be all 1s.
+	 * @param dtmc The DTMC
+	 * @param multProbs Multiplication vector (optional: null means all 1s)
+	 * @param bsccPostProcessor Post-processor for the values of each BSCC (optional: null means no post-processing)
+	 */
+	public ModelCheckerResult computeSteadyStateBackwardsProbs(DTMC dtmc, double multProbs[], BSCCPostProcessor bsccPostProcessor) throws PrismException
+	{
 		StopWatch watch = new StopWatch().start();
 
 		// Store num states
@@ -2299,6 +2349,9 @@ public class DTMCModelChecker extends ProbModelChecker
 			BitSet bscc = bsccs.get(b);
 			// Compute steady-state probabilities for the BSCC
 			computeSteadyStateProbsForBSCC(dtmc, bscc, ssProbs);
+			if (bsccPostProcessor != null) {
+				bsccPostProcessor.apply(ssProbs, bscc);
+			}
 			// Compute weighted sum of probabilities with multProbs
 			probBSCCs[b] = 0.0;
 			if (multProbs == null) {

--- a/prism/src/explicit/ProbModelChecker.java
+++ b/prism/src/explicit/ProbModelChecker.java
@@ -1209,6 +1209,8 @@ public class ProbModelChecker extends NonProbModelChecker
 		switch (model.getModelType()) {
 		case DTMC:
 			return ((DTMCModelChecker) this).computeSteadyStateFormula((DTMC) model, b);
+		case CTMC:
+			return ((CTMCModelChecker) this).computeSteadyStateFormula((CTMC) model, b);
 		default:
 			throw new PrismNotSupportedException("Explicit engine does not yet handle the S operator for " + model.getModelType() + "s");
 		}

--- a/prism/src/explicit/ProbModelChecker.java
+++ b/prism/src/explicit/ProbModelChecker.java
@@ -1206,16 +1206,12 @@ public class ProbModelChecker extends NonProbModelChecker
 		BitSet b = checkExpression(model, expr, null).getBitSet();
 
 		// Compute/return the probabilities
-		ModelCheckerResult res = null;
 		switch (model.getModelType()) {
 		case DTMC:
-			double multProbs[] = Utils.bitsetToDoubleArray(b, model.getNumStates());
-			res = ((DTMCModelChecker) this).computeSteadyStateBackwardsProbs((DTMC) model, multProbs);
-			break;
+			return ((DTMCModelChecker) this).computeSteadyStateFormula((DTMC) model, b);
 		default:
 			throw new PrismNotSupportedException("Explicit engine does not yet handle the S operator for " + model.getModelType() + "s");
 		}
-		return StateValues.createFromDoubleArray(res.soln, model);
 	}
 
 	// Utility methods for probability distributions

--- a/prism/src/explicit/ProbModelChecker.java
+++ b/prism/src/explicit/ProbModelChecker.java
@@ -983,6 +983,9 @@ public class ProbModelChecker extends NonProbModelChecker
 					rewards = checkRewardTotal(model, modelRewards, exprTemp, minMax);
 				}
 				break;
+			case ExpressionTemporal.R_S:
+				rewards = checkRewardSteady(model, modelRewards);
+				break;
 			default:
 				throw new PrismNotSupportedException("Explicit engine does not yet handle the " + exprTemp.getOperatorSymbol() + " reward operator");
 			}
@@ -1103,6 +1106,27 @@ public class ProbModelChecker extends NonProbModelChecker
 		default:
 			throw new PrismNotSupportedException("Explicit engine does not yet handle the " + expr.getOperatorSymbol() + " reward operator for " + model.getModelType()
 					+ "s");
+		}
+		result.setStrategy(res.strat);
+		return StateValues.createFromDoubleArray(res.soln, model);
+	}
+
+	/**
+	 * Compute expected rewards for a steady-state reward operator.
+	 */
+	protected StateValues checkRewardSteady(Model model, Rewards modelRewards) throws PrismException
+	{
+		// Compute/return the rewards
+		ModelCheckerResult res = null;
+		switch (model.getModelType()) {
+		case DTMC:
+			res = ((DTMCModelChecker) this).computeSteadyStateRewards((DTMC) model, (MCRewards) modelRewards);
+			break;
+		case CTMC:
+			res = ((CTMCModelChecker) this).computeSteadyStateRewards((CTMC) model, (MCRewards) modelRewards);
+			break;
+		default:
+			throw new PrismNotSupportedException("Explicit engine does not yet handle the steady-state reward operator for " + model.getModelType() + "s");
 		}
 		result.setStrategy(res.strat);
 		return StateValues.createFromDoubleArray(res.soln, model);

--- a/prism/src/prism/Prism.java
+++ b/prism/src/prism/Prism.java
@@ -3429,14 +3429,19 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	 */
 	protected explicit.StateValues computeSteadyStateProbabilitiesExplicit(explicit.Model model, File fileIn) throws PrismException
 	{
-		DTMCModelChecker mcDTMC;
 		explicit.StateValues probs;
-		if (model.getModelType() == ModelType.DTMC) {
-			mcDTMC = new DTMCModelChecker(this);
+		switch (model.getModelType()) {
+		case DTMC: {
+			DTMCModelChecker mcDTMC = new DTMCModelChecker(this);
 			probs = mcDTMC.doSteadyState((DTMC) model, fileIn);
-		} else if (model.getModelType() == ModelType.CTMC) {
-			throw new PrismException("Not implemented yet");
-		} else {
+			break;
+		}
+		case CTMC: {
+			CTMCModelChecker mcCTMC = new CTMCModelChecker(this);
+			probs = mcCTMC.doSteadyState((CTMC) model, fileIn);
+			break;
+		}
+		default:
 			throw new PrismException("Steady-state probabilities only computed for DTMCs/CTMCs");
 		}
 		return probs;


### PR DESCRIPTION
Add support in the explicit engine for
 1. steady-state probability computation via `-steadystate` / GUI for CTMCs
 2. `S=?[ phi ]` properties (CTMC)
 3. `R=?[ S ]`properties (DTMC/CTMC)

(2) and (3) are covered by the `testsfull` target in the Makefile, providing test coverage for basic functionality tests.

(1) is not really covered by testing (similar to most of the symbolic engines) due to the lack of approximative comparison of exported steady-state probability results in the test infrastructure.

For ease of implementation, we use the approach where the BSCC steady-state probabilities are computed in the embedded DTMC and then rescaled with the exit rates (cf. Baier et al, "Approximate Symbolic Model Checking of Continuous-Time Markov Chains", CONCUR'99).

Currently, uses the implicit embedded DTMC; in the future it might be worthwile to convert the embedded DTMC to a DTMCSparse for potentially improved performance (at the cost of more memory requirements).