### PR TITLE
prism/Makefile: generate sources JAR file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,13 @@ prism/bin/
 prism/classes/
 prism/obj/
 
+# temporary build files:
+prism/prism-sources.txt
+
 # generated JAR files:
 prism/lib/lpsolve55j.jar
+prism/lib/prism.jar
+prism/lib/prism-sources.jar
 
 # generated CUDD headers:
 cudd/include/*.h

--- a/prism/Makefile
+++ b/prism/Makefile
@@ -282,6 +282,8 @@ CLASSES_DIR =	classes
 OBJ_DIR =		obj
 LIB_DIR =		lib
 INCLUDE_DIR =	include
+IMAGES_DIR =    images
+DTDS_DIR =      dtds
 
 # Now we locate the JNI header files jni.h and jni_md.h
 # (in fact this is the only reason we need JAVA_DIR)
@@ -536,7 +538,7 @@ dist_tidy:
 
 binary:
 	@echo Generating jar file...
-	@jar cmf src/manifest.txt lib/prism.jar -C classes . -C . images dtds
+	@jar cmf $(SRC_DIR)/manifest.txt $(LIB_DIR)/prism.jar -C $(CLASSES_DIR) . -C . $(IMAGES_DIR) $(DTDS_DIR)
 
 undist:
 	@rm -rf cudd && ln -s ../cudd cudd

--- a/prism/Makefile
+++ b/prism/Makefile
@@ -537,8 +537,14 @@ dist_tidy:
 	@find etc/scripts -type f -exec chmod 755 {} \;
 
 binary:
-	@echo Generating jar file...
+	@echo "Generating JAR file ($(LIB_DIR)/prism.jar)..."
 	@jar cmf $(SRC_DIR)/manifest.txt $(LIB_DIR)/prism.jar -C $(CLASSES_DIR) . -C . $(IMAGES_DIR) $(DTDS_DIR)
+
+source-jar:
+	@echo "Generating sources JAR file ($(LIB_DIR)/prism-sources.jar)..."
+	@find $(SRC_DIR) -type f -name '*.java' -o -name '*.form' -o -name '*.jj' | sed -e "s/^$(SRC_DIR)./-C $(SRC_DIR) /" > prism-sources.txt
+	@jar cf $(LIB_DIR)/prism-sources.jar @prism-sources.txt
+	@rm -f prism-sources.txt
 
 undist:
 	@rm -rf cudd && ln -s ../cudd cudd
@@ -569,6 +575,7 @@ clean: checks
 	find $(CLASSES_DIR) -name '*.class' -exec rm {} \; ; \
 	rm -f lib/*jnilib; \
 	rm -f lib/prism.jar; \
+	rm -f $(LIB_DIR)/prism-sources.jar; \
 	rm -f $(BIN_PRISM) $(BIN_XPRISM) $(BIN_PRISM_BAT) $(BIN_XPRISM_BAT) )
 
 celan: clean


### PR DESCRIPTION
I'm using PRISM via the Java API, and ran into a problem that I found difficult to debug because the PRISM library (`lib/prism.jar`) doesn't contain source files for any of the classes, so I wasn't easily able to step through any of the PRISM code being called by my own code in my IDE.

This PR generates a sources JAR file (`lib/prism-sources.jar`) alongside `lib/prism.jar` in the `binary` target of `prism/Makefile`. By associating the two JARs in my IDE, I was more able to identify what PRISM was doing and thus fix the bug in my own code. Perhaps this might useful for others too.