### PR TITLE
Don't hardcode maximum dimensions for DOT graphs

### DIFF
--- a/prism-tests/functionality/export/dot/cluster.sm.dot
+++ b/prism-tests/functionality/export/dot/cluster.sm.dot
@@ -1,5 +1,4 @@
 digraph R {
-size="8,5"
 node [shape=box];
 0 -> 8 [ label="10" ];
 0 -> 10 [ label="10" ];

--- a/prism-tests/functionality/export/dot/cluster.sm.sta.dot
+++ b/prism-tests/functionality/export/dot/cluster.sm.sta.dot
@@ -1,5 +1,4 @@
 digraph R {
-size="8,5"
 node [shape=box];
 0 -> 8 [ label="10" ];
 0 -> 10 [ label="10" ];

--- a/prism-tests/functionality/export/dot/dice.pm.dot
+++ b/prism-tests/functionality/export/dot/dice.pm.dot
@@ -1,5 +1,4 @@
 digraph P {
-size="8,5"
 node [shape=box];
 0 -> 1 [ label="0.5" ];
 0 -> 2 [ label="0.5" ];

--- a/prism-tests/functionality/export/dot/dice.pm.sta.dot
+++ b/prism-tests/functionality/export/dot/dice.pm.sta.dot
@@ -1,5 +1,4 @@
 digraph P {
-size="8,5"
 node [shape=box];
 0 -> 1 [ label="0.5" ];
 0 -> 2 [ label="0.5" ];

--- a/prism-tests/functionality/export/dot/robot.prism.dot
+++ b/prism-tests/functionality/export/dot/robot.prism.dot
@@ -1,5 +1,4 @@
 digraph S {
-size="8,5"
 node [shape=box];
 0 -> n0_0 [ arrowhead=none,label="0:south" ];
 n0_0 [ shape=point,width=0.1,height=0.1,label="" ];

--- a/prism-tests/functionality/export/dot/robot.prism.sta.dot
+++ b/prism-tests/functionality/export/dot/robot.prism.sta.dot
@@ -1,5 +1,4 @@
 digraph S {
-size="8,5"
 node [shape=box];
 0 -> n0_0 [ arrowhead=none,label="0:south" ];
 n0_0 [ shape=point,width=0.1,height=0.1,label="" ];

--- a/prism/src/explicit/MDPExplicit.java
+++ b/prism/src/explicit/MDPExplicit.java
@@ -160,7 +160,7 @@ public abstract class MDPExplicit extends ModelExplicit implements MDP
 		String nij;
 		Object action;
 		String style;
-		out.print("digraph " + getModelType() + " {\nsize=\"8,5\"\nnode [shape=box];\n");
+		out.print("digraph " + getModelType() + " {\nnode [shape=box];\n");
 		for (i = 0; i < numStates; i++) {
 			if (mark != null && mark.get(i))
 				out.print(i + " [style=filled  fillcolor=\"#cccccc\"]\n");

--- a/prism/src/explicit/Model.java
+++ b/prism/src/explicit/Model.java
@@ -370,7 +370,7 @@ public interface Model
 		defaults.attributes().put("shape", "box");
 
 		// Header
-		out.print("digraph " + getModelType() + " {\nsize=\"8,5\"\nnode " + defaults.toString() + ";\n");
+		out.print("digraph " + getModelType() + " {\nnode " + defaults.toString() + ";\n");
 		int i, numStates;
 		for (i = 0, numStates = getNumStates(); i < numStates; i++) {
 			// initialize

--- a/prism/src/explicit/QuantAbstractRefine.java
+++ b/prism/src/explicit/QuantAbstractRefine.java
@@ -1267,7 +1267,7 @@ public abstract class QuantAbstractRefine extends PrismComponent
 
 		try {
 			FileWriter out = new FileWriter(filename);
-			out.write("digraph " + "STPG" + " {\nsize=\"8,5\"\nnode [shape=box];\n");
+			out.write("digraph " + "STPG" + " {\nnode [shape=box];\n");
 			for (i = 0; i < stpg.getNumStates(); i++) {
 				if (known.get(i))
 					out.write(i + " [label=\"" + i + " {" + lbSoln[i] + "}" + "\" style=filled  fillcolor=\"#cccccc\"");

--- a/prism/src/explicit/modelviews/MDPView.java
+++ b/prism/src/explicit/modelviews/MDPView.java
@@ -275,7 +275,7 @@ public abstract class MDPView extends ModelView implements MDP, Cloneable
 	@Override
 	public void exportToDotFileWithStrat(final PrismLog out, final BitSet mark, final int[] strat)
 	{
-		out.print("digraph " + getModelType() + " {\nsize=\"8,5\"\nnode [shape=box];\n");
+		out.print("digraph " + getModelType() + " {\nnode [shape=box];\n");
 		for (int state = 0, numStates = getNumStates(); state < numStates; state++) {
 			if (mark != null && mark.get(state))
 				out.print(state + " [style=filled  fillcolor=\"#cccccc\"]\n");

--- a/prism/src/mtbdd/PM_ExportMatrix.cc
+++ b/prism/src/mtbdd/PM_ExportMatrix.cc
@@ -72,7 +72,7 @@ jstring fn		// filename
 	switch (export_type) {
 	case EXPORT_PLAIN: export_string("%" PRId64 " %.0f\n", odd->eoff+odd->toff, DD_GetNumMinterms(ddman, matrix, num_rvars+num_cvars)); break;
 	case EXPORT_MATLAB: export_string("%s = sparse(%" PRId64 ",%" PRId64 ");\n", export_name, odd->eoff+odd->toff, odd->eoff+odd->toff); break;
-	case EXPORT_DOT: case EXPORT_DOT_STATES: export_string("digraph %s {\nsize=\"8,5\"\nnode [shape = box];\n", export_name); break;
+	case EXPORT_DOT: case EXPORT_DOT_STATES: export_string("digraph %s {\nnode [shape = box];\n", export_name); break;
 	}
 	
 	// print main part of file

--- a/prism/src/sparse/PS_ExportMDP.cc
+++ b/prism/src/sparse/PS_ExportMDP.cc
@@ -99,7 +99,7 @@ jstring fn		// filename
 	switch (export_type) {
 	case EXPORT_PLAIN: export_string("%d %d %ld\n", n, nc, nnz); break;
 	case EXPORT_MATLAB: for (i = 0; i < ndsm->k; i++) export_string("%s%d = sparse(%d,%d);\n", export_name, i+1, n, n); break;
-	case EXPORT_DOT: case EXPORT_DOT_STATES: export_string("digraph %s {\nsize=\"8,5\"\nnode [shape=box];\n", export_name); break;
+	case EXPORT_DOT: case EXPORT_DOT_STATES: export_string("digraph %s {\nnode [shape=box];\n", export_name); break;
 	case EXPORT_ROWS: export_string("%d %d %ld\n", n, nc, nnz); break;
 	}
 	

--- a/prism/src/sparse/PS_ExportMatrix.cc
+++ b/prism/src/sparse/PS_ExportMatrix.cc
@@ -95,7 +95,7 @@ jstring fn		// filename
 	switch (export_type) {
 	case EXPORT_PLAIN: export_string("%d %d\n", n, nnz); break;
 	case EXPORT_MATLAB: export_string("%s = sparse(%d,%d);\n", export_name, n, n); break;
-	case EXPORT_DOT: case EXPORT_DOT_STATES: export_string("digraph %s {\nsize=\"8,5\"\nnode [shape=box];\n", export_name); break;
+	case EXPORT_DOT: case EXPORT_DOT_STATES: export_string("digraph %s {\nnode [shape=box];\n", export_name); break;
 	case EXPORT_MRMC: export_string("STATES %d\nTRANSITIONS %d\n", n, nnz); break;
 	case EXPORT_ROWS: export_string("%d %d\n", n, nnz); break;
 	}


### PR DESCRIPTION
When DOT graphs of a model are exported, their maximum permitted size is hardcoded to 8 inches wide by 5 inches high, which is too small for the rendered drawing to be useful (e.g. during debugging) for all but the simplest of models. This PR removes the maximum size restriction, allowing tools like Graphviz to render the drawing with its natural dimensions. (If the 8x5 size is desirable in a particular case, `dot(1)` can be given the command line option `-Gsize=8,5`.)