### PR TITLE
Silent cast errors

### DIFF
--- a/prism/src/common/SafeCast.java
+++ b/prism/src/common/SafeCast.java
@@ -1,0 +1,94 @@
+//==============================================================================
+//	
+//	Copyright (c) 2018-
+//	Authors:
+//	* Joachim Klein <klein@tcs.inf.tu-dresden.de> (TU Dresden)
+//	* Steffen Märcker <steffen.maercker@tu-dresden.de> (TU Dresden)
+//	
+//------------------------------------------------------------------------------
+//	
+//	This file is part of PRISM.
+//	
+//	PRISM is free software; you can redistribute it and/or modify
+//	it under the terms of the GNU General Public License as published by
+//	the Free Software Foundation; either version 2 of the License, or
+//	(at your option) any later version.
+//	
+//	PRISM is distributed in the hope that it will be useful,
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//	GNU General Public License for more details.
+//	
+//	You should have received a copy of the GNU General Public License
+//	along with PRISM; if not, write to the Free Software Foundation,
+//	Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//	
+//==============================================================================
+
+package common;
+
+import prism.PrismException;
+
+/**
+ * This class provides utility methods allow detection of
+ * primitive cast errors, e.g. like overflows and special values.
+ */
+public class SafeCast
+{
+	/**
+	 * Wrapper method for toIntExcapt
+	 * converting an ArithmeticException to a PrismExeption.
+	 *
+	 * @param value {@code double} value
+	 * @return the equivalent {@code int} value
+	 * @throws ArithmeticException if the value cannot be converted to {@code int}
+	 */
+	public static int toInt(double value) throws PrismException
+	{
+		try {
+			return toIntExact(value);
+		} catch (ArithmeticException e) {
+			throw new PrismException(e.getMessage());
+		}
+	}
+
+	/**
+	 * Convert a primitive double to a primitive int value
+	 * throwing an exception if the value is a special value or not an {@code int}.
+	 *
+	 * @param value {@code double} value
+	 * @return the equivalent {@code int} value
+	 * @throws ArithmeticException if the value cannot be converted to {@code int}
+	 */
+	public static int toIntExact(double value)
+	{
+		if (Double.isInfinite(value) || Double.isNaN(value)) {
+			throw new ArithmeticException(value + " is a special value");
+		}
+
+		if ((int)value != value) {
+			throw new ArithmeticException(value + " cannot be converted to int");
+		}
+		return (int)value;
+	}
+
+	/**
+	 * Convert a primitive double to a primitive long value
+	 * throwing an exception if the value is a special value or not an {@code long}.
+	 *
+	 * @param value {@code double} value
+	 * @return the equivalent {@code long} value
+	 * @throws ArithmeticException if the value cannot be converted to {@code long}
+	 */
+	public static long toLongExact(double value)
+	{
+		if (Double.isInfinite(value) || Double.isNaN(value)) {
+			throw new ArithmeticException(value + " is a special value");
+		}
+
+		if ((long)value != value) {
+			throw new ArithmeticException(value + " cannot be converted to long");
+		}
+		return (long)value;
+	}
+}

--- a/prism/src/parser/ast/ExpressionBinaryOp.java
+++ b/prism/src/parser/ast/ExpressionBinaryOp.java
@@ -147,69 +147,81 @@ public class ExpressionBinaryOp extends Expression
 	{
 		switch (op) {
 		case IMPLIES:
-			return new Boolean(!operand1.evaluateBoolean(ec) || operand2.evaluateBoolean(ec));
+			return !operand1.evaluateBoolean(ec) || operand2.evaluateBoolean(ec);
 		case IFF:
-			return new Boolean(operand1.evaluateBoolean(ec) == operand2.evaluateBoolean(ec));
+			return operand1.evaluateBoolean(ec) == operand2.evaluateBoolean(ec);
 		case OR:
-			return new Boolean(operand1.evaluateBoolean(ec) || operand2.evaluateBoolean(ec));
+			return operand1.evaluateBoolean(ec) || operand2.evaluateBoolean(ec);
 		case AND:
-			return new Boolean(operand1.evaluateBoolean(ec) && operand2.evaluateBoolean(ec));
+			return operand1.evaluateBoolean(ec) && operand2.evaluateBoolean(ec);
 		case EQ:
 			if (operand1.getType() == TypeInt.getInstance() && operand2.getType() == TypeInt.getInstance()) {
-				return new Boolean(operand1.evaluateInt(ec) == operand2.evaluateInt(ec));
+				return operand1.evaluateInt(ec) == operand2.evaluateInt(ec);
 			} else {
-				return new Boolean(operand1.evaluateDouble(ec) == operand2.evaluateDouble(ec));
+				return operand1.evaluateDouble(ec) == operand2.evaluateDouble(ec);
 			}
 		case NE:
 			if (operand1.getType() == TypeInt.getInstance() && operand2.getType() == TypeInt.getInstance()) {
-				return new Boolean(operand1.evaluateInt(ec) != operand2.evaluateInt(ec));
+				return operand1.evaluateInt(ec) != operand2.evaluateInt(ec);
 			} else {
-				return new Boolean(operand1.evaluateDouble(ec) != operand2.evaluateDouble(ec));
+				return operand1.evaluateDouble(ec) != operand2.evaluateDouble(ec);
 			}
 		case GT:
 			if (operand1.getType() == TypeInt.getInstance() && operand2.getType() == TypeInt.getInstance()) {
-				return new Boolean(operand1.evaluateInt(ec) > operand2.evaluateInt(ec));
+				return operand1.evaluateInt(ec) > operand2.evaluateInt(ec);
 			} else {
-				return new Boolean(operand1.evaluateDouble(ec) > operand2.evaluateDouble(ec));
+				return operand1.evaluateDouble(ec) > operand2.evaluateDouble(ec);
 			}
 		case GE:
 			if (operand1.getType() == TypeInt.getInstance() && operand2.getType() == TypeInt.getInstance()) {
-				return new Boolean(operand1.evaluateInt(ec) >= operand2.evaluateInt(ec));
+				return operand1.evaluateInt(ec) >= operand2.evaluateInt(ec);
 			} else {
-				return new Boolean(operand1.evaluateDouble(ec) >= operand2.evaluateDouble(ec));
+				return operand1.evaluateDouble(ec) >= operand2.evaluateDouble(ec);
 			}
 		case LT:
 			if (operand1.getType() == TypeInt.getInstance() && operand2.getType() == TypeInt.getInstance()) {
-				return new Boolean(operand1.evaluateInt(ec) < operand2.evaluateInt(ec));
+				return operand1.evaluateInt(ec) < operand2.evaluateInt(ec);
 			} else {
-				return new Boolean(operand1.evaluateDouble(ec) < operand2.evaluateDouble(ec));
+				return operand1.evaluateDouble(ec) < operand2.evaluateDouble(ec);
 			}
 		case LE:
 			if (operand1.getType() == TypeInt.getInstance() && operand2.getType() == TypeInt.getInstance()) {
-				return new Boolean(operand1.evaluateInt(ec) <= operand2.evaluateInt(ec));
+				return operand1.evaluateInt(ec) <= operand2.evaluateInt(ec);
 			} else {
-				return new Boolean(operand1.evaluateDouble(ec) <= operand2.evaluateDouble(ec));
+				return operand1.evaluateDouble(ec) <= operand2.evaluateDouble(ec);
 			}
 		case PLUS:
 			if (operand1.getType() == TypeInt.getInstance() && operand2.getType() == TypeInt.getInstance()) {
-				return new Integer(operand1.evaluateInt(ec) + operand2.evaluateInt(ec));
+				try {
+					return Math.addExact(operand1.evaluateInt(ec), operand2.evaluateInt(ec));
+				} catch (ArithmeticException e) {
+					throw new PrismLangException(e.getMessage(), this);
+				}
 			} else {
-				return new Double(operand1.evaluateDouble(ec) + operand2.evaluateDouble(ec));
+				return operand1.evaluateDouble(ec) + operand2.evaluateDouble(ec);
 			}
 		case MINUS:
 			if (operand1.getType() == TypeInt.getInstance() && operand2.getType() == TypeInt.getInstance()) {
-				return new Integer(operand1.evaluateInt(ec) - operand2.evaluateInt(ec));
+				try {
+					return Math.subtractExact(operand1.evaluateInt(ec), operand2.evaluateInt(ec));
+				} catch (ArithmeticException e) {
+					throw new PrismLangException(e.getMessage(), this);
+				}
 			} else {
-				return new Double(operand1.evaluateDouble(ec) - operand2.evaluateDouble(ec));
+				return operand1.evaluateDouble(ec) - operand2.evaluateDouble(ec);
 			}
 		case TIMES:
 			if (operand1.getType() == TypeInt.getInstance() && operand2.getType() == TypeInt.getInstance()) {
-				return new Integer(operand1.evaluateInt(ec) * operand2.evaluateInt(ec));
+				try {
+					return Math.multiplyExact(operand1.evaluateInt(ec), operand2.evaluateInt(ec));
+				} catch (ArithmeticException e) {
+					throw new PrismLangException(e.getMessage(), this);
+				}
 			} else {
-				return new Double(operand1.evaluateDouble(ec) * operand2.evaluateDouble(ec));
+				return operand1.evaluateDouble(ec) * operand2.evaluateDouble(ec);
 			}
 		case DIVIDE:
-			return new Double(operand1.evaluateDouble(ec) / operand2.evaluateDouble(ec));
+			return operand1.evaluateDouble(ec) / operand2.evaluateDouble(ec);
 		}
 		throw new PrismLangException("Unknown binary operator", this);
 	}

--- a/prism/src/parser/ast/ExpressionFunc.java
+++ b/prism/src/parser/ast/ExpressionFunc.java
@@ -28,6 +28,7 @@ package parser.ast;
 
 import java.util.ArrayList;
 
+import common.SafeCast;
 import param.BigRational;
 import parser.*;
 import parser.visitor.*;
@@ -221,33 +222,26 @@ public class ExpressionFunc extends Expression
 	
 	private Object evaluateMin(EvaluateContext ec) throws PrismLangException
 	{
-		int i, j, n, iMin;
-		double d, dMin;
-
 		if (type instanceof TypeInt) {
-			iMin = getOperand(0).evaluateInt(ec);
-			n = getNumOperands();
-			for (i = 1; i < n; i++) {
-				j = getOperand(i).evaluateInt(ec);
+			int iMin = getOperand(0).evaluateInt(ec);
+			for (int i = 1, n = getNumOperands(); i < n; i++) {
+				int j = getOperand(i).evaluateInt(ec);
 				iMin = (j < iMin) ? j : iMin;
 			}
-			return new Integer(iMin);
+			return iMin;
 		} else {
-			dMin = getOperand(0).evaluateDouble(ec);
-			n = getNumOperands();
-			for (i = 1; i < n; i++) {
-				d = getOperand(i).evaluateDouble(ec);
+			double dMin = getOperand(0).evaluateDouble(ec);
+			for (int i = 1, n = getNumOperands(); i < n; i++) {
+				double d = getOperand(i).evaluateDouble(ec);
 				dMin = (d < dMin) ? d : dMin;
 			}
-			return new Double(dMin);
+			return dMin;
 		}
 	}
 
 	private BigRational evaluateMinExact(EvaluateContext ec) throws PrismLangException
 	{
-		BigRational min;
-	
-		min = getOperand(0).evaluateExact(ec);
+		BigRational min = getOperand(0).evaluateExact(ec);
 		for (int i = 1, n = getNumOperands(); i < n; i++) {
 			min = min.min(getOperand(i).evaluateExact(ec));
 		}
@@ -256,33 +250,26 @@ public class ExpressionFunc extends Expression
 
 	private Object evaluateMax(EvaluateContext ec) throws PrismLangException
 	{
-		int i, j, n, iMax;
-		double d, dMax;
-
 		if (type instanceof TypeInt) {
-			iMax = getOperand(0).evaluateInt(ec);
-			n = getNumOperands();
-			for (i = 1; i < n; i++) {
-				j = getOperand(i).evaluateInt(ec);
+			int iMax = getOperand(0).evaluateInt(ec);
+			for (int i = 1, n = getNumOperands(); i < n; i++) {
+				int j = getOperand(i).evaluateInt(ec);
 				iMax = (j > iMax) ? j : iMax;
 			}
-			return new Integer(iMax);
+			return iMax;
 		} else {
-			dMax = getOperand(0).evaluateDouble(ec);
-			n = getNumOperands();
-			for (i = 1; i < n; i++) {
-				d = getOperand(i).evaluateDouble(ec);
+			double dMax = getOperand(0).evaluateDouble(ec);
+			for (int i = 1, n = getNumOperands(); i < n; i++) {
+				double d = getOperand(i).evaluateDouble(ec);
 				dMax = (d > dMax) ? d : dMax;
 			}
-			return new Double(dMax);
+			return dMax;
 		}
 	}
 
 	private BigRational evaluateMaxExact(EvaluateContext ec) throws PrismLangException
 	{
-		BigRational max;
-
-		max = getOperand(0).evaluateExact(ec);
+		BigRational max = getOperand(0).evaluateExact(ec);
 		for (int i = 1, n = getNumOperands(); i < n; i++) {
 			max = max.max(getOperand(i).evaluateExact(ec));
 		}
@@ -301,10 +288,11 @@ public class ExpressionFunc extends Expression
 
 	public static int evaluateFloor(double arg) throws PrismLangException
 	{
-		// Check for NaN or +/-inf, otherwise possible errors lost in cast to int
-		if (Double.isNaN(arg) || Double.isInfinite(arg))
-			throw new PrismLangException("Cannot take floor() of " + arg);
-		return (int) Math.floor(arg);
+		try {
+			return SafeCast.toIntExact(Math.floor(arg));
+		} catch (ArithmeticException e) {
+			throw new PrismLangException("Cannot take floor() of " + arg + ": " + e.getMessage());
+		}
 	}
 
 	public Integer evaluateCeil(EvaluateContext ec) throws PrismLangException
@@ -319,10 +307,11 @@ public class ExpressionFunc extends Expression
 
 	public static int evaluateCeil(double arg) throws PrismLangException
 	{
-		// Check for NaN or +/-inf, otherwise possible errors lost in cast to int
-		if (Double.isNaN(arg) || Double.isInfinite(arg))
-			throw new PrismLangException("Cannot take ceil() of " + arg);
-		return (int) Math.ceil(arg);
+		try {
+			return SafeCast.toIntExact(Math.ceil(arg));
+		} catch (ArithmeticException e) {
+			throw new PrismLangException("Cannot take ceil() of " + arg + ": " + e.getMessage());
+		}
 	}
 
 	public Integer evaluateRound(EvaluateContext ec) throws PrismLangException
@@ -337,10 +326,11 @@ public class ExpressionFunc extends Expression
 
 	public static int evaluateRound(double arg) throws PrismLangException
 	{
-		// Check for NaN, otherwise possible errors lost in cast to int
-		if (Double.isNaN(arg))
-			throw new PrismLangException("Cannot take round() of " + arg);
-		return (int) Math.round(arg);
+		try {
+			return SafeCast.toIntExact(Math.round(arg));
+		} catch (ArithmeticException e) {
+			throw new PrismLangException("Cannot take round() of " + arg + ": " + e.getMessage());
+		}
 	}
 
 	public BigRational evaluateFloorExact(EvaluateContext ec) throws PrismLangException
@@ -362,9 +352,9 @@ public class ExpressionFunc extends Expression
 	{
 		try {
 			if (type instanceof TypeInt) {
-				return new Integer(evaluatePowInt(getOperand(0).evaluateInt(ec), getOperand(1).evaluateInt(ec)));
+				return evaluatePowInt(getOperand(0).evaluateInt(ec), getOperand(1).evaluateInt(ec));
 			} else {
-				return new Double(evaluatePowDouble(getOperand(0).evaluateDouble(ec), getOperand(1).evaluateDouble(ec)));
+				return evaluatePowDouble(getOperand(0).evaluateDouble(ec), getOperand(1).evaluateDouble(ec));
 			}
 		} catch (PrismLangException e) {
 			e.setASTElement(this);
@@ -377,14 +367,11 @@ public class ExpressionFunc extends Expression
 		// Not allowed to do e.g. pow(2,-2) because of typing (should be pow(2.0,-2) instead)
 		if (exp < 0)
 			throw new PrismLangException("Negative exponent not allowed for integer power");
-		double res = Math.pow(base, exp);
-		// Check for overflow
-		if (res > Integer.MAX_VALUE)
-			throw new PrismLangException("Overflow evaluating integer power");
-		// Check for underflow
-		if (res < Integer.MIN_VALUE)
-			throw new PrismLangException("Underflow evaluating integer power");
-		return (int) res;
+		try {
+			return SafeCast.toIntExact(Math.pow(base, exp));
+		} catch (ArithmeticException e) {
+			throw new PrismLangException("Overflow evaluating integer power: " + e.getMessage());
+		}
 	}
 
 	public static double evaluatePowDouble(double base, double exp) throws PrismLangException
@@ -408,7 +395,7 @@ public class ExpressionFunc extends Expression
 	public Object evaluateMod(EvaluateContext ec) throws PrismLangException
 	{
 		try {
-			return new Integer(evaluateMod(getOperand(0).evaluateInt(ec), getOperand(1).evaluateInt(ec)));
+			return evaluateMod(getOperand(0).evaluateInt(ec), getOperand(1).evaluateInt(ec));
 		} catch (PrismLangException e) {
 			e.setASTElement(this);
 			throw e;
@@ -439,7 +426,7 @@ public class ExpressionFunc extends Expression
 	public Object evaluateLog(EvaluateContext ec) throws PrismLangException
 	{
 		try {
-			return new Double(evaluateLog(getOperand(0).evaluateDouble(ec), getOperand(1).evaluateDouble(ec)));
+			return evaluateLog(getOperand(0).evaluateDouble(ec), getOperand(1).evaluateDouble(ec));
 		} catch (PrismLangException e) {
 			e.setASTElement(this);
 			throw e;

--- a/prism/src/userinterface/model/GUIMultiModelHandler.java
+++ b/prism/src/userinterface/model/GUIMultiModelHandler.java
@@ -629,6 +629,9 @@ public class GUIMultiModelHandler extends JPanel implements PrismModelListener
 		try {
 			// currently, don't evaluate constants exactly
 			prism.setPRISMModelConstants(unC.getMFConstantValues(), false);
+		} catch (PrismLangException e) {
+			theModel.error(e.toString());
+			return;
 		} catch (PrismException e) {
 			theModel.error(e.getMessage());
 			return;


### PR DESCRIPTION
Currently, integer overflows and underflows are silent errors during expression evaluation. This may lead to models that are broken without a chance for the author to recognise the error.

This PR addresses issue #92 and consists of two parts:

1. Throw an error if a double cannot be casted to int
Two classes are touched that cast the result of some prism functions and operators to int values. There might be more but non-obvious places where this happens. The commit also gets rid of unnecessary manual boxing and outmost scope variable declarations in the touched code.

2. Change error message for PrismLangExceptions
This part allows to see the line and column numbers if a PrismLangException is raised, e.g., on cast errors.