### PR TITLE
Travis-CI: Switch to OpenJDK for 10, add 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,12 @@ dist: trusty
 sudo: required
 language: java
 
-# we test for JDK8 and JDK9
+# we test for JDK 8,9,10,11
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
+  - openjdk10
+  - openjdk11
   
 # compile and run the test suite
 # we manually set PRISM_JAVA to the java on the PATH as the python invocation of prism-auto fiddles with the PATH variable...  


### PR DESCRIPTION
The oraclejdk10 target offered by travis is sometimes unstable due to
JDK download brittleness. We thus switch to the openjdk10
target. Additionally, add openjdk11 as a target.