### PR TITLE
Auto-switch to MTBDD engine if state space is too large

### DIFF
--- a/prism/src/prism/Prism.java
+++ b/prism/src/prism/Prism.java
@@ -2953,6 +2953,17 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 							+ "Either switch to the explicit engine or add more action labels to the model");
 			}
 
+			if (!getExplicit() && !engineSwitch) {
+				// check if we need to switch to MTBDD engine
+				long n = currentModel.getNumStates();
+				if (n == -1 || n > Integer.MAX_VALUE) {
+					mainLog.printWarning("Switching to MTBDD engine, as number of states is too large for " + engineStrings[getEngine()] + " engine.");
+					engineSwitch = true;
+					lastEngine = getEngine();
+					setEngine(Prism.MTBDD);
+				}
+			}
+
 			// Create new model checker object and do model checking
 			if (!getExplicit()) {
 				ModelChecker mc = createModelChecker(propertiesFile);


### PR DESCRIPTION
Currently, if PRISM is run with `-hybrid` (the default engine setting) or with `-sparse` and the model has more than 2^31-1 states, we throw a `PrismNotSupportedException`, as both sparse and hybrid engine is limited to `int` state indices.

With this change, after (symbolic) model building, we check if the number of states is larger than that limit and instead auto-switch to the MTBDD engine. This might lead to some 'not supported' errors later (e.g., for properties that are unsupported in the MTBDD engine), but those would have failed for the initially configured engine anyways.