### PR TITLE
Improve warnings for statistical MC with nondeterministic models

### DIFF
--- a/prism/src/prism/ModelType.java
+++ b/prism/src/prism/ModelType.java
@@ -74,7 +74,7 @@ public enum ModelType
 		}
 
 		@Override
-		ModelType removeNondeterminism()
+		public ModelType removeNondeterminism()
 		{
 			return CTMC;
 		}
@@ -100,14 +100,14 @@ public enum ModelType
 		}
 
 		@Override
-		ModelType removeNondeterminism()
+		public ModelType removeNondeterminism()
 		{
 			return DTMC;
 		}
 	},
 	MDP("Markov decision process") {
 		@Override
-		ModelType removeNondeterminism()
+		public ModelType removeNondeterminism()
 		{
 			return DTMC;
 		}
@@ -127,7 +127,7 @@ public enum ModelType
 		}
 
 		@Override
-		ModelType removeNondeterminism()
+		public ModelType removeNondeterminism()
 		{
 			return DTMC;
 		}
@@ -140,7 +140,7 @@ public enum ModelType
 		}
 
 		@Override
-		ModelType removeNondeterminism()
+		public ModelType removeNondeterminism()
 		{
 			return DTMC;
 		}
@@ -229,7 +229,7 @@ public enum ModelType
 	 * If there is no nondeterminism (or the removal of nondeterminism is not supported),
 	 * returns the same model type.
 	 */
-	ModelType removeNondeterminism()
+	public ModelType removeNondeterminism()
 	{
 		// default: same model type
 		return this;

--- a/prism/src/simulator/SimulatorEngine.java
+++ b/prism/src/simulator/SimulatorEngine.java
@@ -1542,6 +1542,14 @@ public class SimulatorEngine extends PrismComponent
 			}
 		}
 
+		String resultNote = "";
+		if (results.length > 0) {
+			ModelType currentModelType = modulesFile.getModelType();
+			if (currentModelType.nondeterministic() && currentModelType.removeNondeterminism() != currentModelType) {
+				resultNote += " (with nondeterminism in " + currentModelType.name() + " being resolved uniformly)";
+			}
+		}
+
 		// Display results to log
 		if (results.length == 1) {
 			mainLog.print("\nSimulation method parameters: ");
@@ -1549,7 +1557,7 @@ public class SimulatorEngine extends PrismComponent
 			mainLog.print("\nSimulation result details: ");
 			mainLog.println((indices[0] == -1) ? "no simulation" : propertySamplers.get(indices[0]).getSimulationMethodResultExplanation());
 			if (!(results[0] instanceof PrismException))
-				mainLog.println("\nResult: " + results[0]);
+				mainLog.println("\nResult: " + results[0] + resultNote);
 		} else {
 			mainLog.println("\nSimulation method parameters:");
 			for (int i = 0; i < results.length; i++) {
@@ -1563,7 +1571,7 @@ public class SimulatorEngine extends PrismComponent
 			}
 			mainLog.println("\nResults:");
 			for (int i = 0; i < results.length; i++)
-				mainLog.println(exprs.get(i) + " : " + results[i]);
+				mainLog.println(exprs.get(i) + " : " + results[i] + resultNote);
 		}
 
 		return results;

--- a/prism/src/userinterface/properties/computation/SimulateModelCheckThread.java
+++ b/prism/src/userinterface/properties/computation/SimulateModelCheckThread.java
@@ -139,11 +139,18 @@ public class SimulateModelCheckThread extends GUIComputationThread
 					}
 				}
 			}
+
 			// store results
+			ModelType currentModelType = prism.getModelType();
+			String methodString = "Simulation";
+			if (currentModelType.nondeterministic() && currentModelType.removeNondeterminism() != currentModelType) {
+				methodString += " (nondeterminism in " + currentModelType.name() + " resolved uniformly)";
+			}
+
 			for (int i = 0; i < guiProps.size(); i++) {
 				GUIProperty gp = guiProps.get(i);
 				gp.setResult((results == null) ? new Result(resultError) : results[i]);
-				gp.setMethodString("Simulation");
+				gp.setMethodString(methodString);
 				gp.setNumberOfWarnings(prism.getMainLog().getNumberOfWarnings());
 			}
 		}


### PR DESCRIPTION
When using the statistical model checking engine in PRISM (-sim/Simulate in the GUI), nondeterminism in the model is resolved uniformly. Obviously, this does not match the usual semantics of `Pmax/Pmin` etc, ranging over all schedulers. Nevertheless, in practice and if you know what you are doing, this mode can be useful.

In #84, we added a warning message to the log file, to alert/remind the user of this special handling of nondeterminism. We had some further internal discussions whether that is sufficient, especially as the warnings in the log might be overlooked if used in the GUI.

The proposed changes here add some more visible warnings.

1. In the log file, the `Result:` lines get a note:
`Result: 1.0 (with nondeterminism in MDP being resolved uniformly)`
2. In the GUI, in the property results dialog, the `Method: Simulation` is changed to
`Method: Simulation (nondeterminism in MDP resolved uniformly)`

Some further options:

-  Completely forbid `Pmin/max`, `Rmin/max` for statistical model checking. But then, how to handle `P>...` and `P<...` which also have different semantics for MDPs and DTMCs and thus might be surprising.
- A bit less restrictive: For the `min/max` operators, print the warning
`Warning: "Pmin=?" and "Pmax=?" operators are identical to "P=?" for DTMCs/CTMCs` that is printed by the other engines when they are used with models without nondeterminism.
- In the GUI, when running `Simulate` on a property, we could have a note in the `Simulation option` dialog that pops up, highlighting the scheduler semantics.