### PR TITLE
GUI: Path export with reward information

### DIFF
--- a/prism/src/simulator/PathFull.java
+++ b/prism/src/simulator/PathFull.java
@@ -500,10 +500,24 @@ public class PathFull extends Path implements PathFullInfo
 	 */
 	public void exportToLog(PrismLog log, boolean showTimeCumul, String colSep, ArrayList<Integer> vars) throws PrismException
 	{
+		exportToLog(log, showTimeCumul, false, colSep, vars);
+	}
+
+	/**
+	 * Export path to a PrismLog (e.g. file, stdout).
+	 * @param log PrismLog to which the path should be exported to.
+	 * @param showTimeCumul Show time in cumulative form?
+	 * @param showRewards Show rewards?
+	 * @param colSep String used to separate columns in display
+	 * @param vars Restrict printing to these variables (indices) and steps which change them (ignore if null)
+	 */
+	public void exportToLog(PrismLog log, boolean showTimeCumul, boolean showRewards, String colSep, ArrayList<Integer> vars) throws PrismException
+	{
 		PathToText displayer = new PathToText(log, modulesFile);
 		displayer.setShowTimeCumul(showTimeCumul);
 		displayer.setColSep(colSep);
 		displayer.setVarsToShow(vars);
+		displayer.setShowRewards(showRewards);
 		display(displayer);
 	}
 

--- a/prism/src/simulator/SimulatorEngine.java
+++ b/prism/src/simulator/SimulatorEngine.java
@@ -1325,7 +1325,18 @@ public class SimulatorEngine extends PrismComponent
 	 */
 	public void exportPath(File file) throws PrismException
 	{
-		exportPath(file, false, " ", null);
+		exportPath(file, false);
+	}
+
+	/**
+	 * Export the current path to a file in a simple space separated format.
+	 * (Not applicable for on-the-fly paths)
+	 * @param file File to which the path should be exported to (mainLog if null).
+	 * @param showRewards Export reward information with the path
+	 */
+	public void exportPath(File file, boolean showRewards) throws PrismException
+	{
+		exportPath(file, false, showRewards, " ", null);
 	}
 
 	/**
@@ -1337,6 +1348,20 @@ public class SimulatorEngine extends PrismComponent
 	 * @param vars Restrict printing to these variables (indices) and steps which change them (ignore if null)
 	 */
 	public void exportPath(File file, boolean timeCumul, String colSep, ArrayList<Integer> vars) throws PrismException
+	{
+		exportPath(file, timeCumul, false, colSep, vars);
+	}
+
+	/**
+	 * Export the current path to a file.
+	 * (Not applicable for on-the-fly paths)
+	 * @param file File to which the path should be exported to (mainLog if null).
+	 * @param timeCumul Show time in cumulative form?
+	 * @param showRewards Export reward information with the path
+	 * @param colSep String used to separate columns in display
+	 * @param vars Restrict printing to these variables (indices) and steps which change them (ignore if null)
+	 */
+	public void exportPath(File file, boolean timeCumul, boolean showRewards, String colSep, ArrayList<Integer> vars) throws PrismException
 	{
 		PrismLog log = null;
 		try {
@@ -1353,7 +1378,7 @@ public class SimulatorEngine extends PrismComponent
 				log = mainLog;
 				log.println();
 			}
-			((PathFull) path).exportToLog(log, timeCumul, colSep, vars);
+			((PathFull) path).exportToLog(log, timeCumul, showRewards, colSep, vars);
 			if (file != null)
 				log.close();
 		} finally {

--- a/prism/src/userinterface/simulator/GUISimulator.java
+++ b/prism/src/userinterface/simulator/GUISimulator.java
@@ -761,10 +761,16 @@ public class GUISimulator extends GUIPlugin implements MouseListener, ListSelect
 	public void a_exportPath()
 	{
 		try {
+			boolean exportRewards = false;
+			if (parsedModel != null && parsedModel.getNumRewardStructs() > 0) {
+				exportRewards = (question("Export the path with or without reward information?", new String[]{"With rewards", "Without rewards"}) == 0);
+			}
+
 			if (showSaveFileDialog(textFilter) != JFileChooser.APPROVE_OPTION)
 				return;
+
 			setComputing(true);
-			engine.exportPath(getChooserFile());
+			engine.exportPath(getChooserFile(), exportRewards);
 		} catch (PrismException e) {
 			error(e.getMessage());
 		} finally {


### PR DESCRIPTION
(Raised on the mailing list)

Exporting a path from the GUI does not include the reward information. With these changes, we now ask the user whether they'd like to get the reward information in the exported path as well.

Relatedly, I noticed that CTMC paths exported from the GUI don't include the time information; those are included in the paths generated from the command line by default.

Is the language of the question/options ok?