### PR TITLE
Fix rare crash during GUI startup

### DIFF
--- a/prism/src/userinterface/GUIPrism.java
+++ b/prism/src/userinterface/GUIPrism.java
@@ -226,7 +226,6 @@ public class GUIPrism extends JFrame
 		}
 
 		// Create new file chooser which starts in current directory
-		choose = new JFileChooser();
 		File currentDir = new File(".");
 		// If current directory is the bin directory, go up one level (mainly for Windows version)
 		try {
@@ -236,7 +235,8 @@ public class GUIPrism extends JFrame
 		} catch (IOException e) {
 			currentDir = new File(".");
 		}
-		choose.setCurrentDirectory(currentDir);
+		// create the chooser
+		choose = new JFileChooser(currentDir);
 
 		logPlug = null;
 		eventHandle = new GUIEventHandler(this);


### PR DESCRIPTION
We have observed crashes during GUI startup, during the splash screen phase, with the following exception stack trace:

```
Exception in thread "main" java.util.ConcurrentModificationException
	at java.util.Vector$Itr.checkForComodification(Vector.java:1184)
	at java.util.Vector$Itr.next(Vector.java:1137)
	at javax.swing.plaf.basic.BasicDirectoryModel$LoadFilesThread.cancelRunnables(BasicDirectoryModel.java:340)
	at javax.swing.plaf.basic.BasicDirectoryModel$LoadFilesThread.cancelRunnables(BasicDirectoryModel.java:346)
	at javax.swing.plaf.basic.BasicDirectoryModel.validateFileCache(BasicDirectoryModel.java:135)
	at javax.swing.plaf.basic.BasicDirectoryModel.propertyChange(BasicDirectoryModel.java:69)
	at java.beans.PropertyChangeSupport.fire(PropertyChangeSupport.java:335)
	at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:327)
	at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:263)
	at java.awt.Component.firePropertyChange(Component.java:8422)
	at javax.swing.JFileChooser.setCurrentDirectory(JFileChooser.java:598)
	at userinterface.GUIPrism.setupResources(GUIPrism.java:262)
	at userinterface.GUIPrism.<init>(GUIPrism.java:228)
	at userinterface.GUIPrism.main(GUIPrism.java:127)
```

The problem seems to be that creating a JFileChooser and then using setCurrentDirectory a short time later might result in some race condition in the Java platform code (the JFileChooser asynchronously pre-caches the directory contents and has to cancel these threads when the directory is changed). We have also not been able to reliably trigger it.

While this doesn't look to be our fault, we avoid this by doing the currentDir logic before creating the JFileChooser and then passing this directly during the construction of the JFileChooser.

(with Philipp Chrszon)