### PR TITLE
Fix for "Sporadic NPE during xprism startup" (#111)

### DIFF
--- a/prism/src/userinterface/GUIPlugin.java
+++ b/prism/src/userinterface/GUIPlugin.java
@@ -246,6 +246,14 @@ public abstract class GUIPlugin extends JPanel implements GUIEventListener, Pris
 	 * @param e A GUIEvent from elsewhere in the userinterface.
 	 */	
 	public abstract boolean processGUIEvent(GUIEvent e);
+
+	/**
+	 * Hook that is called for each GUIPlugin after the GUI startup has completed.
+	 */
+	public void onInitComponentsCompleted()
+	{
+		// default: do nothing
+	}
 	
 	/** Loads an XML tree stored in 'c'.
 	 * @param c The XML tree

--- a/prism/src/userinterface/GUIPrism.java
+++ b/prism/src/userinterface/GUIPrism.java
@@ -180,7 +180,7 @@ public class GUIPrism extends JFrame
 	private PrismLog theLog;
 
 	//gui components
-	private ArrayList plugs;
+	private ArrayList<GUIPlugin> plugs;
 	private JTabbedPane theTabs;
 	private GUIPlugin logPlug;
 	private GUIEventHandler eventHandle;
@@ -283,8 +283,7 @@ public class GUIPrism extends JFrame
 		});
 		//Setup pluggable screens in here
 		plugs = getPluginArray(this);
-		for (int i = 0; i < plugs.size(); i++) {
-			GUIPlugin plug = (GUIPlugin) plugs.get(i);
+		for (GUIPlugin plug : plugs) {
 			if (plug.displaysTab()) {
 				theTabs.addTab(plug.getTabText(), plug);
 				theTabs.setEnabledAt(theTabs.getComponentCount() - 1, plug.isEnabled());
@@ -397,6 +396,10 @@ public class GUIPrism extends JFrame
 		setIconImage(GUIPrism.getIconFromImage("smallPrism.png").getImage());
 		getContentPane().setSize(new java.awt.Dimension(800, 600));
 		pack();
+
+		for (GUIPlugin plug : plugs) {
+			plug.onInitComponentsCompleted();
+		}
 	}
 
 	public void passCLArgs(String args[])

--- a/prism/src/userinterface/model/GUIMultiModel.java
+++ b/prism/src/userinterface/model/GUIMultiModel.java
@@ -120,6 +120,13 @@ public class GUIMultiModel extends GUIPlugin implements PrismSettingsListener
 		}
 	}
 
+	@Override
+	public void onInitComponentsCompleted()
+	{
+		// forward to multi-model handler
+		handler.onInitComponentsCompleted();
+	}
+
 	public GUIMultiModelHandler getHandler()
 	{
 		return handler;

--- a/prism/src/userinterface/model/GUIMultiModelHandler.java
+++ b/prism/src/userinterface/model/GUIMultiModelHandler.java
@@ -225,6 +225,17 @@ public class GUIMultiModelHandler extends JPanel implements PrismModelListener
 		add(splitter, BorderLayout.CENTER);
 	}
 
+	private synchronized void restartWaitParseThread()
+	{
+		if (waiter != null) {
+			waiter.interrupt();
+		}
+		int parseDelay = theModel.getPrism().getSettings().getInteger(PrismSettings.MODEL_PARSE_DELAY);
+		waiter = new WaitParseThread(parseDelay, this);
+		waiter.start();
+		//Funky thread waiting stuff
+	}
+
 	// New model...
 
 	public void newPRISMModel()
@@ -544,13 +555,7 @@ public class GUIMultiModelHandler extends JPanel implements PrismModelListener
 			tree.makeNotUpToDate();
 			//start a new parse thread
 			if (isAutoParse()) {
-				if (waiter != null) {
-					waiter.interrupt();
-				}
-				int parseDelay = theModel.getPrism().getSettings().getInteger(PrismSettings.MODEL_PARSE_DELAY);
-				waiter = new WaitParseThread(parseDelay, this);
-				waiter.start();
-				//Funky thread waiting stuff
+				restartWaitParseThread();
 			}
 		} else if (buildAfterReceiveParseNotification) {
 			buildAfterParse();
@@ -583,13 +588,7 @@ public class GUIMultiModelHandler extends JPanel implements PrismModelListener
 			tree.makeNotUpToDate();
 			//start a new parse thread
 			if (isAutoParse()) {
-				if (waiter != null) {
-					waiter.interrupt();
-				}
-				int parseDelay = theModel.getPrism().getSettings().getInteger(PrismSettings.MODEL_PARSE_DELAY);
-				waiter = new WaitParseThread(parseDelay, this);
-				waiter.start();
-				//Funky thread waiting stuff
+				restartWaitParseThread();
 			}
 		} else {
 			buildAfterReceiveParseNotification = false;
@@ -837,13 +836,7 @@ public class GUIMultiModelHandler extends JPanel implements PrismModelListener
 
 		if (!parsing) {
 			if (isAutoParse() && attemptReparse) {
-				if (waiter != null) {
-					waiter.interrupt();
-				}
-				int parseDelay = theModel.getPrism().getSettings().getInteger(PrismSettings.MODEL_PARSE_DELAY);
-				waiter = new WaitParseThread(parseDelay, this);
-				waiter.start();
-				//Funky thread waiting stuff
+				restartWaitParseThread();
 			}
 		} else {
 			parseAfterParse = true;
@@ -955,12 +948,7 @@ public class GUIMultiModelHandler extends JPanel implements PrismModelListener
 			theModel.notifyEventListeners(new GUIModelEvent(GUIModelEvent.MODIFIED_SINCE_SAVE));
 			if (!parsing) {
 				if (isAutoParse()) {
-					if (waiter != null) {
-						waiter.interrupt();
-					}
-					int parseDelay = theModel.getPrism().getSettings().getInteger(PrismSettings.MODEL_PARSE_DELAY);
-					waiter = new WaitParseThread(parseDelay, this);
-					waiter.start();
+					restartWaitParseThread();
 				}
 			} else {
 				parseAfterParse = true;

--- a/prism/src/userinterface/model/GUIMultiModelHandler.java
+++ b/prism/src/userinterface/model/GUIMultiModelHandler.java
@@ -113,6 +113,9 @@ public class GUIMultiModelHandler extends JPanel implements PrismModelListener
 
 	private Style pepaEditorCommentFast = Style.defaultStyle();
 
+	// flag to indicate whether onInitComponentsCompleted() has already been called
+	private boolean startupCompleted = false;
+
 	// Modification Parse updater
 	private WaitParseThread waiter;
 	private boolean parsing = false;
@@ -142,8 +145,6 @@ public class GUIMultiModelHandler extends JPanel implements PrismModelListener
 		prism = theModel.getPrism();
 		prism.addModelListener(this);
 
-		int parseDelay = theModel.getPrism().getSettings().getInteger(PrismSettings.MODEL_PARSE_DELAY);
-		waiter = new WaitParseThread(parseDelay, this);
 		editor = new GUITextModelEditor("", this);
 		tree = new GUIMultiModelTree(this);
 		splitter = new JSplitPane();
@@ -227,6 +228,14 @@ public class GUIMultiModelHandler extends JPanel implements PrismModelListener
 
 	private synchronized void restartWaitParseThread()
 	{
+		// If the GUIPrism startup has not been completed, as
+		// indicated by the call to onInitComponentsCompleted(),
+		// ignore requests to start the WaitParseThread. This prevents
+		// it from triggering events that are handled by parts of the
+		// GUI that have not been completely initialised.
+		if (!startupCompleted)
+			return;
+
 		if (waiter != null) {
 			waiter.interrupt();
 		}
@@ -234,6 +243,14 @@ public class GUIMultiModelHandler extends JPanel implements PrismModelListener
 		waiter = new WaitParseThread(parseDelay, this);
 		waiter.start();
 		//Funky thread waiting stuff
+	}
+
+	public void onInitComponentsCompleted()
+	{
+		startupCompleted = true;
+
+		// initially, start WaitParseThread
+		restartWaitParseThread();
 	}
 
 	// New model...


### PR DESCRIPTION
Delays creation of WaitParseThread until all components have been initialised.

Tested with very short auto-parse delay and debug output to see when thread creation and parses happen. Looks fine, both with plain startup and with startup where a model is directly loaded.