### PR TITLE
Move BSCC post processing into computation of steady-state probabilities in BSCCs

### DIFF
--- a/prism/src/explicit/CTMCModelChecker.java
+++ b/prism/src/explicit/CTMCModelChecker.java
@@ -861,6 +861,18 @@ public class CTMCModelChecker extends ProbModelChecker
 	}
 
 	/**
+	 * @see DTMCModelChecker#computeSteadyStateProbsForBSCC(DTMC, BitSet, double[], BSCCPostProcessor)
+	 */
+	public ModelCheckerResult computeSteadyStateProbsForBSCC(CTMC ctmc, BitSet states, double result[]) throws PrismException
+	{
+		// We construct the embedded DTMC and do the steady-state computation there
+		mainLog.println("Building embedded DTMC...");
+		DTMC dtmcEmb = ctmc.getImplicitEmbeddedDTMC();
+
+		return createDTMCModelChecker().computeSteadyStateProbsForBSCC(dtmcEmb, states, result, new SteadyStateBSCCPostProcessor(ctmc));
+	}
+
+	/**
 	 * Compute steady-state rewards, i.e., R=?[ S ].
 	 * @param ctmc the CTMC
 	 * @param modelRewards the (state) rewards

--- a/prism/src/explicit/DTMCModelChecker.java
+++ b/prism/src/explicit/DTMCModelChecker.java
@@ -2256,10 +2256,7 @@ public class DTMCModelChecker extends ProbModelChecker
 		if (initInOneBSCC > -1) {
 			mainLog.println("\nInitial states are all in one BSCC (so no reachability probabilities computed)");
 			BitSet bscc = bsccs.get(initInOneBSCC);
-			computeSteadyStateProbsForBSCC(dtmc, bscc, solnProbs);
-			if (bsccPostProcessor != null) {
-				bsccPostProcessor.apply(solnProbs, bscc);
-			}
+			computeSteadyStateProbsForBSCC(dtmc, bscc, solnProbs, bsccPostProcessor);
 		}
 
 		// Otherwise, have to consider all the BSCCs
@@ -2285,10 +2282,7 @@ public class DTMCModelChecker extends ProbModelChecker
 				mainLog.println("\nComputing steady-state probabilities for BSCC " + (b + 1));
 				BitSet bscc = bsccs.get(b);
 				// Compute steady-state probabilities for the BSCC
-				computeSteadyStateProbsForBSCC(dtmc, bscc, solnProbs);
-				if (bsccPostProcessor != null) {
-					bsccPostProcessor.apply(solnProbs, bscc);
-				}
+				computeSteadyStateProbsForBSCC(dtmc, bscc, solnProbs, bsccPostProcessor);
 				// Multiply by BSCC reach prob
 				for (int i = bscc.nextSetBit(0); i >= 0; i = bscc.nextSetBit(i + 1))
 					solnProbs[i] *= probBSCCs[b];
@@ -2354,10 +2348,7 @@ public class DTMCModelChecker extends ProbModelChecker
 			mainLog.println("\nComputing steady state probabilities for BSCC " + (b + 1));
 			BitSet bscc = bsccs.get(b);
 			// Compute steady-state probabilities for the BSCC
-			computeSteadyStateProbsForBSCC(dtmc, bscc, ssProbs);
-			if (bsccPostProcessor != null) {
-				bsccPostProcessor.apply(ssProbs, bscc);
-			}
+			computeSteadyStateProbsForBSCC(dtmc, bscc, ssProbs, bsccPostProcessor);
 			// Compute weighted sum of probabilities with mult
 			valueBSCCs[b] = 0.0;
 			if (mult == null) {
@@ -2448,9 +2439,10 @@ public class DTMCModelChecker extends ProbModelChecker
 	 * </p>
 	 * @param dtmc The DTMC
 	 * @param states The BSCC to be analysed
+	 * @param bsccPostProcessor Post-processor for the values of each BSCC (optional: null means no post-processing)
 	 * @param result Storage for result (ignored if null)
 	 */
-	public ModelCheckerResult computeSteadyStateProbsForBSCC(DTMC dtmc, BitSet states, double result[]) throws PrismException
+	public ModelCheckerResult computeSteadyStateProbsForBSCC(DTMC dtmc, BitSet states, double result[], BSCCPostProcessor bsccPostProcessor) throws PrismException
 	{
 		if (dtmc.getModelType() != ModelType.DTMC) {
 			throw new PrismNotSupportedException("Explicit engine currently does not support steady-state computation for " + dtmc.getModelType());
@@ -2574,11 +2566,17 @@ public class DTMCModelChecker extends ProbModelChecker
 			throw new PrismException(msg);
 		}
 
+		// Apply post processing
+		if (bsccPostProcessor != null) {
+			bsccPostProcessor.apply(result, states);
+		}
+
 		// Return results
 		ModelCheckerResult res = new ModelCheckerResult();
 		res.soln = result;
 		res.numIters = iters;
 		res.timeTaken = watch.elapsedSeconds();
+
 		return res;
 	}
 

--- a/prism/src/explicit/DTMCModelChecker.java
+++ b/prism/src/explicit/DTMCModelChecker.java
@@ -2422,6 +2422,14 @@ public class DTMCModelChecker extends ProbModelChecker
 	}
 
 	/**
+	 * @see DTMCModelChecker#computeSteadyStateProbsForBSCC(DTMC, BitSet, double[], BSCCPostProcessor)
+	 */
+	public ModelCheckerResult computeSteadyStateProbsForBSCC(DTMC dtmc, BitSet states, double result[]) throws PrismException
+	{
+		return computeSteadyStateProbsForBSCC(dtmc, states, result, null);
+	}
+
+	/**
 	 * Compute steady-state probabilities for a BSCC
 	 * i.e. compute the long-run probability of being in each state of the BSCC.
 	 * No initial distribution is specified since it does not affect the result.


### PR DESCRIPTION
I propose this refactoring for two reasons:
1. Each call to `computeSteadyStateProbsForBSCC` is followed by the application of the post processing (see commit 1). Moving it into the method prevents forgetting this step.
2. This allows to have a sound definition of the steady-state probabilities of a BSCC in CTMCs (see commit 2).
The second commit is not strictly necessary, it just provides a straight-forward interface to the steady-state probabilities of single BSCCs. Personally, I need this interface for the computation of the long-run operator `L=?` and an accompanying cache of these probabilities.