### PR TITLE
Add missing null checks in IterableBitSet

### DIFF
--- a/prism/src/common/IterableBitSet.java
+++ b/prism/src/common/IterableBitSet.java
@@ -29,6 +29,7 @@ package common;
 
 import java.util.BitSet;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.PrimitiveIterator.OfInt;
 
 import common.iterable.IterableInt;
@@ -51,6 +52,7 @@ public class IterableBitSet implements IterableInt
 	 */
 	public IterableBitSet(BitSet set)
 	{
+		Objects.requireNonNull(set);
 		this.set = set;
 		this.clearBits = false;
 		this.reversed = false;
@@ -83,6 +85,7 @@ public class IterableBitSet implements IterableInt
 	 */
 	public IterableBitSet(BitSet set, Integer maxIndex, boolean clearBits, boolean reversed)
 	{
+		Objects.requireNonNull(set);
 		this.set = set;
 		this.maxIndex = maxIndex;
 		this.clearBits = clearBits;

--- a/prism/src/common/functions/ObjDoubleFunction.java
+++ b/prism/src/common/functions/ObjDoubleFunction.java
@@ -3,7 +3,6 @@
 //	Copyright (c) 2016-
 //	Authors:
 //	* Steffen Maercker <steffen.maercker@tu-dresden.de> (TU Dresden)
-//	* Joachim Klein <klein@tcs.inf.tu-dresden.de> (TU Dresden)
 //	
 //------------------------------------------------------------------------------
 //	
@@ -25,24 +24,28 @@
 //	
 //==============================================================================
 
-package common.functions.primitive;
+package common.functions;
+
+import java.util.Objects;
+import java.util.function.Function;
 
 /**
- * Functional interface for a predicate (int, int) -> boolean.
+ * Functional interface for a binary function (T, double) -> R.
  */
 @FunctionalInterface
-public interface PairPredicateInt
+public interface ObjDoubleFunction<T, R>
 {
 	/**
-	 * Evaluates this predicate on the given arguments.
+	 * Applies this function to the given arguments.
 	 */
-	boolean test(int i, int j);
+	R apply(T t, double d);
 
 	/**
-	 * Returns a predicate that represents the logical negation of this predicate.
+	 * Returns a composed function that first applies this function to
+	 * its input, and then applies the {@code after} function to the result.
 	 */
-	default PairPredicateInt negate()
-	{
-		return (i, j) -> !test(i, j);
+	default <V> ObjDoubleFunction<T, V> andThen(Function<? super R, ? extends V> after) {
+		Objects.requireNonNull(after);
+		return (T t, double d) -> after.apply(apply(t, d));
 	}
 }

--- a/prism/src/common/functions/ObjIntFunction.java
+++ b/prism/src/common/functions/ObjIntFunction.java
@@ -3,7 +3,6 @@
 //	Copyright (c) 2016-
 //	Authors:
 //	* Steffen Maercker <steffen.maercker@tu-dresden.de> (TU Dresden)
-//	* Joachim Klein <klein@tcs.inf.tu-dresden.de> (TU Dresden)
 //	
 //------------------------------------------------------------------------------
 //	
@@ -25,24 +24,28 @@
 //	
 //==============================================================================
 
-package common.functions.primitive;
+package common.functions;
+
+import java.util.Objects;
+import java.util.function.Function;
 
 /**
- * Functional interface for a predicate (int, int) -> boolean.
+ * Functional interface for a binary function (T, int) -> R.
  */
 @FunctionalInterface
-public interface PairPredicateInt
+public interface ObjIntFunction<T, R>
 {
 	/**
-	 * Evaluates this predicate on the given arguments.
+	 * Applies this function to the given arguments.
 	 */
-	boolean test(int i, int j);
+	R apply(T t, int i);
 
 	/**
-	 * Returns a predicate that represents the logical negation of this predicate.
+	 * Returns a composed function that first applies this function to
+	 * its input, and then applies the {@code after} function to the result.
 	 */
-	default PairPredicateInt negate()
-	{
-		return (i, j) -> !test(i, j);
+	default <V> ObjIntFunction<T, V> andThen(Function<? super R, ? extends V> after) {
+		Objects.requireNonNull(after);
+		return (T t, int i) -> after.apply(apply(t, i));
 	}
 }

--- a/prism/src/common/functions/ObjLongFunction.java
+++ b/prism/src/common/functions/ObjLongFunction.java
@@ -3,7 +3,6 @@
 //	Copyright (c) 2016-
 //	Authors:
 //	* Steffen Maercker <steffen.maercker@tu-dresden.de> (TU Dresden)
-//	* Joachim Klein <klein@tcs.inf.tu-dresden.de> (TU Dresden)
 //	
 //------------------------------------------------------------------------------
 //	
@@ -25,24 +24,28 @@
 //	
 //==============================================================================
 
-package common.functions.primitive;
+package common.functions;
+
+import java.util.Objects;
+import java.util.function.Function;
 
 /**
- * Functional interface for a predicate (int, int) -> boolean.
+ * Functional interface for a binary function (T, long) -> R.
  */
 @FunctionalInterface
-public interface PairPredicateInt
+public interface ObjLongFunction<T, R>
 {
 	/**
-	 * Evaluates this predicate on the given arguments.
+	 * Applies this function to the given arguments.
 	 */
-	boolean test(int i, int j);
+	R apply(T t, long l);
 
 	/**
-	 * Returns a predicate that represents the logical negation of this predicate.
+	 * Returns a composed function that first applies this function to
+	 * its input, and then applies the {@code after} function to the result.
 	 */
-	default PairPredicateInt negate()
-	{
-		return (i, j) -> !test(i, j);
+	default <V> ObjLongFunction<T, V> andThen(Function<? super R, ? extends V> after) {
+		Objects.requireNonNull(after);
+		return (T t, long l) -> after.apply(apply(t, l));
 	}
 }


### PR DESCRIPTION
The underlying BitSet was not checked to be non-null which might cause a NullPointerException later.