### PR TITLE
proposal for a solution for issue #170

### DIFF
--- a/prism/src/prism/Prism.java
+++ b/prism/src/prism/Prism.java
@@ -2546,7 +2546,17 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 			} else {
 				PrismLog out = getPrismLogForFile(fileToUse);
 				explicit.StateModelChecker mcExpl = createModelCheckerExplicit(null);
-				((explicit.ProbModelChecker) mcExpl).exportStateRewardsToFile(currentModelExpl, r, exportType, out);
+				try {
+					((explicit.ProbModelChecker) mcExpl).exportStateRewardsToFile(currentModelExpl, r, exportType, out);
+				} catch (PrismNotSupportedException e){
+					if(!currentRewardGenerator.getRewardStructName(r).isEmpty()){
+						mainLog.println("Error: Cannot export the rewardstructure \""  +
+								currentRewardGenerator.getRewardStructName(r) + "\" (index: " + r + "). " + e.getMessage());
+					} else {
+						mainLog.println("Error: Cannot export the rewardstructure with the index: " + r + ". " +
+								e.getMessage());
+					}
+				}
 				out.close();
 			}
 		}


### PR DESCRIPTION
This is a proposal  for solving issue #170  .
The idea is to catch the exception, wich otherwise aborts the whole process and print an error in the mainlog, so other reward structures without transition rewards can exported correctly.