### PR TITLE
Feature: Allow import all without switch

### DIFF
--- a/prism/src/prism/PrismCL.java
+++ b/prism/src/prism/PrismCL.java
@@ -1952,7 +1952,7 @@ public class PrismCL implements PrismModelListener
 	 * Process the non-switch command-line arguments,
 	 * which should be (model/properties) file names.
 	 */
-	private void processFileNames(List<String> filenameArgs)
+	private void processFileNames(List<String> filenameArgs) throws PrismException
 	{
 		if (filenameArgs.size() > 2) {
 			errorAndExit("Invalid argument syntax");
@@ -1966,6 +1966,9 @@ public class PrismCL implements PrismModelListener
 		} else {
 			if (filenameArgs.size() > 0) {
 				modelFilename = filenameArgs.get(0);
+				if (modelFilename.endsWith(".all")) {
+					processImportModelSwitch(modelFilename);
+				}
 			}
 			if (filenameArgs.size() > 1) {
 				propertiesFilename = filenameArgs.get(1);


### PR DESCRIPTION

The standard CLI expects an import switch to import
a model as matrix from text files.
If the filname is given with the extension .all,
Prism finds the relevant files automatically.

This mechanism be used to simplify the CLI for .all:

    prism -importmodel model.all properties.props ...

becomes

    prism model.all properties.props ...

This allows the user to use models given in the PRISM
languages or as explicit representation interchangable.