### PR TITLE
Run tests from Makefile location

### DIFF
--- a/prism/Makefile
+++ b/prism/Makefile
@@ -496,7 +496,7 @@ test:
 # Optionally, extra arguments for prism-auto are picked up via variable TESTS_ARGS
 tests: testslocal
 	@if [ -d ../prism-tests ]; then \
-	  cd ../prism-tests && "$(PWD)"/etc/scripts/prism-auto -t -m . -p "$(PWD)"/bin/prism --nailgun --ngprism "$(PWD)"/bin/ngprism $(TESTS_ARGS); \
+	  etc/scripts/prism-auto -t -m ../prism-tests -p bin/prism --nailgun --ngprism bin/ngprism $(TESTS_ARGS); \
 	else \
 	  echo "Skipping tests"; \
 	fi
@@ -504,13 +504,13 @@ tests: testslocal
 # Just display the command to run the test suite on this version of PRISM
 # Optionally, extra arguments for prism-auto are picked up via variable TESTS_ARGS
 testsecho:
-	@echo etc/scripts/prism-auto -t -m --nailgun --ngprism bin/ngprism ../prism-tests -p bin/prism $(TESTS_ARGS)
+	@echo etc/scripts/prism-auto -t -m ../prism-tests -p bin/prism --nailgun --ngprism bin/ngprism $(TESTS_ARGS)
 
 # Run local tests (in ./tests)
 # Optionally, extra arguments for prism-auto are picked up via variable TESTS_ARGS
 testslocal:
 	@if [ -d tests ]; then \
-	  cd tests && "$(PWD)"/etc/scripts/prism-auto -t -m . -p "$(PWD)"/bin/prism --nailgun --ngprism "$(PWD)"/bin/ngprism $(TESTS_ARGS); \
+	  etc/scripts/prism-auto -t -m tests -p bin/prism --nailgun --ngprism bin/ngprism $(TESTS_ARGS); \
 	else \
 	  echo "Skipping local tests"; \
 	fi
@@ -521,10 +521,9 @@ testslocal:
 # - We run with --test-all, as failures for some engines should not abort the tests
 # - We run with a timeout of 1 minute, as some engines take a long time for some properties
 testsfull:
-	cd ../prism-tests && \
-	"$(PWD)"/etc/scripts/prism-auto -t -m . \
-	--skip-export-runs --skip-duplicate-runs --test-all -a all-engines.args --timeout 1m \
-	-p "$(PWD)"/bin/prism --nailgun $(TESTS_ARGS);
+	etc/scripts/prism-auto -t -m ../prism-tests \
+	--skip-export-runs --skip-duplicate-runs --test-all -a ../prism-tests/all-engines.args --timeout 1m \
+	-p bin/prism --nailgun $(TESTS_ARGS);
 
 ##########################
 # Building distributions #

--- a/prism/etc/scripts/prism-auto
+++ b/prism/etc/scripts/prism-auto
@@ -623,9 +623,9 @@ def runPrism(args, bmArgs, dir=""):
             os.makedirs(logDir)
         logFile = os.path.join(logDir, createLogFileName(args, dir))
         #f = open(logFile, 'w')
-        prismArgs = prismArgs + ['-mainlog', logFile]
-        exitCode = execute(prismArgs)
-        #exitCode = subprocess.Popen(prismArgs, cwd=dir, stdout=f).wait()
+        prismArgsExec = prismArgs + ['-mainlog', logFile]
+        exitCode = execute(prismArgsExec)
+        #exitCode = subprocess.Popen(prismArgsExec, cwd=dir, stdout=f).wait()
     elif options.test or options.ddWarnings:
         # create logfile
         if isWindows():
@@ -641,8 +641,8 @@ def runPrism(args, bmArgs, dir=""):
             f.close()
         # we want cleanup when we are done, as this is a real temporary file
         cleanupLogFile = True
-        prismArgs = prismArgs + ['-mainlog', logFile]
-        exitCode = execute(prismArgs)
+        prismArgsExec = prismArgs + ['-mainlog', logFile]
+        exitCode = execute(prismArgsExec)
     else:
         exitCode = execute(prismArgs)
     # Extract DD reference count warnings
@@ -681,6 +681,10 @@ def runPrism(args, bmArgs, dir=""):
                     printTestResult(line)
             print("To see log file, run:")
             print("edit " + logFile)
+            prismArgsPrint = prismArgs.copy()
+            prismArgsPrint[0] = options.prismExec
+            print("To re-run failing test:")
+            print(' '.join(prismArgsPrint))
         else:
             # in verbose test mode, print extra info and increment failure counter
             printColoured('FAILURE', "\n[Exit code: " + str(exitCode) + "]")


### PR DESCRIPTION
The script prism-auto gives some useful feedback if a test fails:
- A command line to run the failing test again
- A diff command to see the differences for export tests
Both command lines are given relative to the directory _prism-tests_. Since the Makefile resides in _prism_, the test are usually ran from that directory and the command lines won't work by copy + paste.

This PR rectifies this to make testing more easy.