### PR TITLE
Refactor clone and deepCopy for ASTElements

### DIFF
--- a/prism/src/parser/IdentUsage.java
+++ b/prism/src/parser/IdentUsage.java
@@ -34,7 +34,7 @@ import prism.PrismLangException;
 /**
  * Helper class to keep track of a set of identifiers that have been used.
  */
-public class IdentUsage
+public class IdentUsage implements Cloneable
 {
 	// Are these identifiers used in (double) quotes?
 	private boolean quoted = false;
@@ -125,11 +125,23 @@ public class IdentUsage
 		}
 	}
 
-	@SuppressWarnings("unchecked")
-	public IdentUsage deepCopy()
+	public IdentUsage deepCopyFields()
 	{
-		IdentUsage ret = new IdentUsage(quoted);
-		ret.identDecls = (HashMap<String, ASTElement>) identDecls.clone();
-		return ret;
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public IdentUsage clone()
+	{
+		try {
+			IdentUsage clone = (IdentUsage) super.clone();
+			clone.identDecls = (HashMap<String, ASTElement>) identDecls.clone();
+			clone.identUses = (HashMap<String, String>) identUses.clone();
+			clone.identLocs = (HashMap<String, String>) identLocs.clone();
+			return clone;
+		} catch (CloneNotSupportedException e) {
+			throw new InternalError("Object#clone is expected to work for Cloneable objects.", e);
+		}
 	}
 }

--- a/prism/src/parser/ast/ASTElement.java
+++ b/prism/src/parser/ast/ASTElement.java
@@ -26,12 +26,44 @@
 
 package parser.ast;
 
-import java.util.*;
+import parser.EvaluateContext;
+import parser.EvaluateContextConstants;
+import parser.EvaluateContextState;
+import parser.EvaluateContextSubstate;
+import parser.EvaluateContextValues;
+import parser.State;
+import parser.Token;
+import parser.Values;
+import parser.type.Type;
+import parser.visitor.ASTVisitor;
+import parser.visitor.ComputeProbNesting;
+import parser.visitor.EvaluatePartially;
+import parser.visitor.ExpandConstants;
+import parser.visitor.ExpandFormulas;
+import parser.visitor.ExpandLabels;
+import parser.visitor.ExpandPropRefsAndLabels;
+import parser.visitor.FindAllActions;
+import parser.visitor.FindAllConstants;
+import parser.visitor.FindAllFormulas;
+import parser.visitor.FindAllObsRefs;
+import parser.visitor.FindAllPropRefs;
+import parser.visitor.FindAllVars;
+import parser.visitor.GetAllConstants;
+import parser.visitor.GetAllFormulas;
+import parser.visitor.GetAllLabels;
+import parser.visitor.GetAllPropRefs;
+import parser.visitor.GetAllPropRefsRecursively;
+import parser.visitor.GetAllUndefinedConstantsRecursively;
+import parser.visitor.GetAllVars;
+import parser.visitor.Rename;
+import parser.visitor.SemanticCheck;
+import parser.visitor.Simplify;
+import parser.visitor.ToTreeString;
+import parser.visitor.TypeCheck;
+import prism.PrismLangException;
 
-import parser.*;
-import parser.type.*;
-import parser.visitor.*;
-import prism.*;
+import java.util.List;
+import java.util.Vector;
 
 // Abstract class for PRISM language AST elements
 
@@ -186,7 +218,15 @@ public abstract class ASTElement implements Cloneable
 	/**
 	 * Perform a deep copy.
 	 */
-	public abstract ASTElement deepCopy();
+	public ASTElement deepCopy()
+	{
+		return clone().deepCopyASTElements();
+	}
+
+	/**
+	 * Copy all internal ASTElements (should be called after clone to create deep copy).
+	 */
+	public abstract ASTElement deepCopyASTElements();
 
 	/**
 	 * Perform a shallow copy of the receiver and

--- a/prism/src/parser/ast/ASTElement.java
+++ b/prism/src/parser/ast/ASTElement.java
@@ -35,7 +35,7 @@ import prism.*;
 
 // Abstract class for PRISM language AST elements
 
-public abstract class ASTElement
+public abstract class ASTElement implements Cloneable
 {
 	// Type - default to null (unknown)
 	protected Type type = null;
@@ -187,6 +187,20 @@ public abstract class ASTElement
 	 * Perform a deep copy.
 	 */
 	public abstract ASTElement deepCopy();
+
+	/**
+	 * Perform a shallow copy of the receiver and
+	 * clone all internal containers, e.g., lists and vectors, too.
+	 */
+	@Override
+	public ASTElement clone()
+	{
+		try {
+			return (ASTElement) super.clone();
+		} catch (CloneNotSupportedException e) {
+			throw new InternalError("Object#clone is expected to work for Cloneable objects", e);
+		}
+	}
 
 	// Various methods based on AST traversals (implemented using the visitor
 	// pattern):

--- a/prism/src/parser/ast/Command.java
+++ b/prism/src/parser/ast/Command.java
@@ -26,7 +26,7 @@
 
 package parser.ast;
 
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
 import prism.PrismLangException;
 
 public class Command extends ASTElement
@@ -138,18 +138,13 @@ public class Command extends ASTElement
 		return s;
 	}
 	
-	/**
-	 * Perform a deep copy.
-	 */
-	public ASTElement deepCopy()
+	@Override
+	public Command deepCopyASTElements()
 	{
-		Command ret = new Command();
-		ret.setSynch(getSynch());
-		ret.setSynchIndex(getSynchIndex());
-		ret.setGuard(getGuard().deepCopy());
-		ret.setUpdates((Updates)getUpdates().deepCopy());
-		ret.setPosition(this);
-		return ret;
+		guard = guard.clone().deepCopyASTElements();
+		updates = updates.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/Command.java
+++ b/prism/src/parser/ast/Command.java
@@ -151,6 +151,12 @@ public class Command extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public Command clone()
+	{
+		return (Command) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/ConstantList.java
+++ b/prism/src/parser/ast/ConstantList.java
@@ -492,6 +492,20 @@ public class ConstantList extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public ConstantList clone()
+	{
+		ConstantList clone = (ConstantList) super.clone();
+
+		clone.names      = (Vector<String>)          names.clone();
+		clone.constants  = (Vector<Expression>)      constants.clone();
+		clone.types      = (Vector<Type>)            types.clone();
+		clone.nameIdents = (Vector<ExpressionIdent>) nameIdents.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/ConstantList.java
+++ b/prism/src/parser/ast/ConstantList.java
@@ -477,20 +477,13 @@ public class ConstantList extends ASTElement
 		return s;
 	}
 	
-	/**
-	 * Perform a deep copy.
-	 */
-	public ASTElement deepCopy()
+	@Override
+	public ConstantList deepCopyASTElements()
 	{
-		int i, n;
-		ConstantList ret = new ConstantList();
-		n = size();
-		for (i = 0; i < n; i++) {
-			Expression constantNew = (getConstant(i) == null) ? null : getConstant(i).deepCopy();
-			ret.addConstant((ExpressionIdent)getConstantNameIdent(i).deepCopy(), constantNew, getConstantType(i));
-		}
-		ret.setPosition(this);
-		return ret;
+		constants.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		nameIdents.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/Declaration.java
+++ b/prism/src/parser/ast/Declaration.java
@@ -150,6 +150,12 @@ public class Declaration extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public Declaration clone()
+	{
+		return (Declaration) super.clone();
+	}
 }
 
 // ------------------------------------------------------------------------------

--- a/prism/src/parser/ast/Declaration.java
+++ b/prism/src/parser/ast/Declaration.java
@@ -138,17 +138,12 @@ public class Declaration extends ASTElement
 		return s;
 	}
 
-	/**
-	 * Perform a deep copy.
-	 */
 	@Override
-	public ASTElement deepCopy()
+	public Declaration deepCopyASTElements()
 	{
-		Declaration ret = new Declaration(getName(), (DeclarationType)getDeclType().deepCopy());
-		if (getStart() != null)
-			ret.setStart(getStart().deepCopy());
-		ret.setPosition(this);
-		return ret;
+		declType = declType.clone().deepCopyASTElements();
+		start = (start == null) ? null : start.clone().deepCopyASTElements();
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/DeclarationArray.java
+++ b/prism/src/parser/ast/DeclarationArray.java
@@ -134,4 +134,10 @@ public class DeclarationArray extends DeclarationType
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public DeclarationArray clone()
+	{
+		return (DeclarationArray) super.clone();
+	}
 }

--- a/prism/src/parser/ast/DeclarationArray.java
+++ b/prism/src/parser/ast/DeclarationArray.java
@@ -27,7 +27,7 @@
 
 package parser.ast;
 
-import parser.type.*;
+import parser.type.TypeArray;
 import parser.visitor.ASTVisitor;
 import prism.PrismLangException;
 
@@ -122,17 +122,16 @@ public class DeclarationArray extends DeclarationType
 	}
 
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
 	@Override
-	public ASTElement deepCopy()
+	public DeclarationArray deepCopyASTElements()
 	{
-		Expression lowCopy = (low == null) ? null : low.deepCopy();
-		Expression highCopy = (high == null) ? null : high.deepCopy();
-		DeclarationType subtypeCopy = (DeclarationType) subtype.deepCopy();
-		DeclarationArray ret = new DeclarationArray(lowCopy, highCopy, subtypeCopy);
-		ret.setPosition(this);
-		return ret;
+		low = low.clone().deepCopyASTElements();
+		high = high.clone().deepCopyASTElements();
+		subtype = subtype.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/DeclarationBool.java
+++ b/prism/src/parser/ast/DeclarationBool.java
@@ -68,4 +68,10 @@ public class DeclarationBool extends DeclarationType
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public DeclarationBool clone()
+	{
+		return (DeclarationBool) super.clone();
+	}
 }

--- a/prism/src/parser/ast/DeclarationBool.java
+++ b/prism/src/parser/ast/DeclarationBool.java
@@ -62,11 +62,9 @@ public class DeclarationBool extends DeclarationType
 	}
 
 	@Override
-	public ASTElement deepCopy()
+	public DeclarationBool deepCopyASTElements()
 	{
-		DeclarationBool ret = new DeclarationBool();
-		ret.setPosition(this);
-		return ret;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/DeclarationClock.java
+++ b/prism/src/parser/ast/DeclarationClock.java
@@ -61,11 +61,9 @@ public class DeclarationClock extends DeclarationType
 	}
 
 	@Override
-	public ASTElement deepCopy()
+	public DeclarationClock deepCopyASTElements()
 	{
-		DeclarationClock ret = new DeclarationClock();
-		ret.setPosition(this);
-		return ret;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/DeclarationClock.java
+++ b/prism/src/parser/ast/DeclarationClock.java
@@ -67,4 +67,10 @@ public class DeclarationClock extends DeclarationType
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public DeclarationClock clone()
+	{
+		return (DeclarationClock) super.clone();
+	}
 }

--- a/prism/src/parser/ast/DeclarationInt.java
+++ b/prism/src/parser/ast/DeclarationInt.java
@@ -89,13 +89,12 @@ public class DeclarationInt extends DeclarationType
 	}
 
 	@Override
-	public ASTElement deepCopy()
+	public DeclarationInt deepCopyASTElements()
 	{
-		Expression lowCopy = (low == null) ? null : low.deepCopy();
-		Expression highCopy = (high == null) ? null : high.deepCopy();
-		DeclarationInt ret = new DeclarationInt(lowCopy, highCopy);
-		ret.setPosition(this);
-		return ret;
+		low = (low == null) ? null : low.clone().deepCopyASTElements();
+		high = (high == null) ? null : high.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/DeclarationInt.java
+++ b/prism/src/parser/ast/DeclarationInt.java
@@ -97,4 +97,10 @@ public class DeclarationInt extends DeclarationType
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public DeclarationInt clone()
+	{
+		return (DeclarationInt) super.clone();
+	}
 }

--- a/prism/src/parser/ast/DeclarationIntUnbounded.java
+++ b/prism/src/parser/ast/DeclarationIntUnbounded.java
@@ -67,4 +67,10 @@ public class DeclarationIntUnbounded extends DeclarationType
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public DeclarationIntUnbounded clone()
+	{
+		return (DeclarationIntUnbounded) super.clone();
+	}
 }

--- a/prism/src/parser/ast/DeclarationIntUnbounded.java
+++ b/prism/src/parser/ast/DeclarationIntUnbounded.java
@@ -61,11 +61,9 @@ public class DeclarationIntUnbounded extends DeclarationType
 	}
 
 	@Override
-	public ASTElement deepCopy()
+	public DeclarationIntUnbounded deepCopyASTElements()
 	{
-		DeclarationIntUnbounded ret = new DeclarationIntUnbounded();
-		ret.setPosition(this);
-		return ret;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/DeclarationType.java
+++ b/prism/src/parser/ast/DeclarationType.java
@@ -33,4 +33,10 @@ public abstract class DeclarationType extends ASTElement
 	 * Return the default start value for a variable of this type, as an Expression.
 	 */
 	public abstract Expression getDefaultStart();
+
+	@Override
+	public DeclarationType clone()
+	{
+		return (DeclarationType) super.clone();
+	}
 }

--- a/prism/src/parser/ast/DeclarationType.java
+++ b/prism/src/parser/ast/DeclarationType.java
@@ -34,6 +34,12 @@ public abstract class DeclarationType extends ASTElement
 	 */
 	public abstract Expression getDefaultStart();
 
+	/**
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
+	 */
+	@Override
+	public abstract DeclarationType deepCopyASTElements();
+
 	@Override
 	public DeclarationType clone()
 	{

--- a/prism/src/parser/ast/Expression.java
+++ b/prism/src/parser/ast/Expression.java
@@ -126,6 +126,13 @@ public abstract class Expression extends ASTElement
 	 */
 	public abstract Expression deepCopy();
 
+	// Override version of clone() from superclass (to reduce casting).
+	@Override
+	public Expression clone()
+	{
+		return (Expression) super.clone();
+	}
+
 	// Utility methods:
 
 	/**

--- a/prism/src/parser/ast/Expression.java
+++ b/prism/src/parser/ast/Expression.java
@@ -119,12 +119,19 @@ public abstract class Expression extends ASTElement
 	 */
 	public abstract boolean returnsSingleValue();
 	
-	// Overrided version of deepCopy() from superclass ASTElement (to reduce casting).
+	// Overwritten version of deepCopy() and deepCopyASTElements() from superclass ASTElement (to reduce casting).
+
+	@Override
+	public abstract Expression deepCopyASTElements();
 
 	/**
 	 * Perform a deep copy.
 	 */
-	public abstract Expression deepCopy();
+	@Override
+	public Expression deepCopy()
+	{
+		return (Expression) super.deepCopy();
+	}
 
 	// Override version of clone() from superclass (to reduce casting).
 	@Override

--- a/prism/src/parser/ast/ExpressionBinaryOp.java
+++ b/prism/src/parser/ast/ExpressionBinaryOp.java
@@ -342,6 +342,12 @@ public class ExpressionBinaryOp extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionBinaryOp clone()
+	{
+		return (ExpressionBinaryOp) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionBinaryOp.java
+++ b/prism/src/parser/ast/ExpressionBinaryOp.java
@@ -334,12 +334,12 @@ public class ExpressionBinaryOp extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionBinaryOp deepCopyASTElements()
 	{
-		ExpressionBinaryOp expr = new ExpressionBinaryOp(op, operand1.deepCopy(), operand2.deepCopy());
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		operand1 = operand1.clone().deepCopyASTElements();
+		operand2 = operand2.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionConstant.java
+++ b/prism/src/parser/ast/ExpressionConstant.java
@@ -108,6 +108,12 @@ public class ExpressionConstant extends Expression
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public ExpressionConstant clone()
+	{
+		return (ExpressionConstant) super.clone();
+	}
 	
 	// Standard methods
 	

--- a/prism/src/parser/ast/ExpressionConstant.java
+++ b/prism/src/parser/ast/ExpressionConstant.java
@@ -102,11 +102,9 @@ public class ExpressionConstant extends Expression
 	}
 	
 	@Override
-	public Expression deepCopy()
+	public ExpressionConstant deepCopyASTElements()
 	{
-		Expression ret = new ExpressionConstant(name, type);
-		ret.setPosition(this);
-		return ret;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionExists.java
+++ b/prism/src/parser/ast/ExpressionExists.java
@@ -102,6 +102,12 @@ public class ExpressionExists extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionExists clone()
+	{
+		return (ExpressionExists) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionExists.java
+++ b/prism/src/parser/ast/ExpressionExists.java
@@ -94,12 +94,11 @@ public class ExpressionExists extends Expression
 	}
 	
 	@Override
-	public Expression deepCopy()
+	public ExpressionExists deepCopyASTElements()
 	{
-		ExpressionExists expr = new ExpressionExists(expression.deepCopy());
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		expression = expression.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionFilter.java
+++ b/prism/src/parser/ast/ExpressionFilter.java
@@ -495,6 +495,12 @@ public class ExpressionFilter extends Expression
 
 		return e;
 	}
+
+	@Override
+	public ExpressionFilter clone()
+	{
+		return (ExpressionFilter) super.clone();
+	}
 	
 	// Standard methods
 	

--- a/prism/src/parser/ast/ExpressionFilter.java
+++ b/prism/src/parser/ast/ExpressionFilter.java
@@ -484,16 +484,12 @@ public class ExpressionFilter extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionFilter deepCopyASTElements()
 	{
-		ExpressionFilter e;
-		e = new ExpressionFilter(opName, operand.deepCopy(), filter == null ? null : filter.deepCopy());
-		e.setInvisible(invisible);
-		e.setType(type);
-		e.setPosition(this);
-		e.param = this.param;
+		operand = operand.clone().deepCopyASTElements();
+		filter = (filter == null) ? null : filter.clone().deepCopyASTElements();
 
-		return e;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionForAll.java
+++ b/prism/src/parser/ast/ExpressionForAll.java
@@ -94,12 +94,11 @@ public class ExpressionForAll extends Expression
 	}
 	
 	@Override
-	public Expression deepCopy()
+	public ExpressionForAll deepCopyASTElements()
 	{
-		ExpressionForAll expr = new ExpressionForAll(expression.deepCopy());
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		expression = expression.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionForAll.java
+++ b/prism/src/parser/ast/ExpressionForAll.java
@@ -102,6 +102,12 @@ public class ExpressionForAll extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionForAll clone()
+	{
+		return (ExpressionForAll) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionFormula.java
+++ b/prism/src/parser/ast/ExpressionFormula.java
@@ -121,6 +121,12 @@ public class ExpressionFormula extends Expression
 		return ret;
 	}
 
+	@Override
+	public ExpressionFormula clone()
+	{
+		return (ExpressionFormula) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionFormula.java
+++ b/prism/src/parser/ast/ExpressionFormula.java
@@ -113,12 +113,11 @@ public class ExpressionFormula extends Expression
 	}
 		
 	@Override
-	public Expression deepCopy()
+	public ExpressionFormula deepCopyASTElements()
 	{
-		ExpressionFormula ret = new ExpressionFormula(name);
-		ret.setDefinition(definition == null ? null : definition.deepCopy());
-		ret.setPosition(this);
-		return ret;
+		definition = (definition == null) ? null : definition.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionFunc.java
+++ b/prism/src/parser/ast/ExpressionFunc.java
@@ -615,21 +615,11 @@ public class ExpressionFunc extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionFunc deepCopyASTElements()
 	{
-		int i, n;
-		ExpressionFunc e;
+		operands.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
 
-		e = new ExpressionFunc(name);
-		e.setOldStyle(oldStyle);
-		n = getNumOperands();
-		for (i = 0; i < n; i++) {
-			e.addOperand((Expression) getOperand(i).deepCopy());
-		}
-		e.setType(type);
-		e.setPosition(this);
-
-		return e;
+		return this;
 	}
 
 

--- a/prism/src/parser/ast/ExpressionFunc.java
+++ b/prism/src/parser/ast/ExpressionFunc.java
@@ -26,17 +26,18 @@
 
 package parser.ast;
 
-import java.math.BigInteger;
-import java.util.ArrayList;
-
 import common.SafeCast;
 import param.BigRational;
-import parser.*;
+import parser.EvaluateContext;
 import parser.EvaluateContext.EvalMode;
-import parser.visitor.*;
+import parser.type.TypeDouble;
+import parser.type.TypeInt;
+import parser.visitor.ASTVisitor;
 import prism.PrismLangException;
 import prism.PrismUtils;
-import parser.type.*;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
 
 public class ExpressionFunc extends Expression
 {
@@ -629,6 +630,18 @@ public class ExpressionFunc extends Expression
 		e.setPosition(this);
 
 		return e;
+	}
+
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public ExpressionFunc clone()
+	{
+		ExpressionFunc clone = (ExpressionFunc) super.clone();
+
+		clone.operands = (ArrayList<Expression>) operands.clone();
+
+		return clone;
 	}
 	
 	// Standard methods

--- a/prism/src/parser/ast/ExpressionITE.java
+++ b/prism/src/parser/ast/ExpressionITE.java
@@ -137,6 +137,12 @@ public class ExpressionITE extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionITE clone()
+	{
+		return (ExpressionITE) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionITE.java
+++ b/prism/src/parser/ast/ExpressionITE.java
@@ -129,12 +129,13 @@ public class ExpressionITE extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionITE deepCopyASTElements()
 	{
-		ExpressionITE expr = new ExpressionITE(operand1.deepCopy(), operand2.deepCopy(), operand3.deepCopy());
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		operand1 = operand1.clone().deepCopyASTElements();
+		operand2 = operand2.clone().deepCopyASTElements();
+		operand3 = operand3.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionIdent.java
+++ b/prism/src/parser/ast/ExpressionIdent.java
@@ -107,6 +107,12 @@ public class ExpressionIdent extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionIdent clone()
+	{
+		return (ExpressionIdent) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionIdent.java
+++ b/prism/src/parser/ast/ExpressionIdent.java
@@ -99,12 +99,9 @@ public class ExpressionIdent extends Expression
 	}
 	
 	@Override
-	public Expression deepCopy()
+	public ExpressionIdent deepCopyASTElements()
 	{
-		ExpressionIdent expr = new ExpressionIdent(name);
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionLabel.java
+++ b/prism/src/parser/ast/ExpressionLabel.java
@@ -100,12 +100,9 @@ public class ExpressionLabel extends Expression
 	}
 	
 	@Override
-	public Expression deepCopy()
+	public ExpressionLabel deepCopyASTElements()
 	{
-		ExpressionLabel expr = new ExpressionLabel(name);
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionLabel.java
+++ b/prism/src/parser/ast/ExpressionLabel.java
@@ -108,6 +108,12 @@ public class ExpressionLabel extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionLabel clone()
+	{
+		return (ExpressionLabel) super.clone();
+	}
+
 	// Standard methods
 
 	@Override

--- a/prism/src/parser/ast/ExpressionLiteral.java
+++ b/prism/src/parser/ast/ExpressionLiteral.java
@@ -133,11 +133,9 @@ public class ExpressionLiteral extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionLiteral deepCopyASTElements()
 	{
-		Expression expr = new ExpressionLiteral(type, value, string);
-		expr.setPosition(this);
-		return expr;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionLiteral.java
+++ b/prism/src/parser/ast/ExpressionLiteral.java
@@ -140,6 +140,12 @@ public class ExpressionLiteral extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionLiteral clone()
+	{
+		return (ExpressionLiteral) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionObs.java
+++ b/prism/src/parser/ast/ExpressionObs.java
@@ -122,6 +122,12 @@ public class ExpressionObs extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionObs clone()
+	{
+		return (ExpressionObs) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionObs.java
+++ b/prism/src/parser/ast/ExpressionObs.java
@@ -113,13 +113,9 @@ public class ExpressionObs extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionObs deepCopyASTElements()
 	{
-		ExpressionObs expr = new ExpressionObs(name);
-		expr.setType(type);
-		expr.setIndex(index);
-		expr.setPosition(this);
-		return expr;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionProb.java
+++ b/prism/src/parser/ast/ExpressionProb.java
@@ -139,16 +139,11 @@ public class ExpressionProb extends ExpressionQuant
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionProb deepCopyASTElements()
 	{
-		ExpressionProb expr = new ExpressionProb();
-		expr.setExpression(getExpression() == null ? null : getExpression().deepCopy());
-		expr.setRelOp(getRelOp());
-		expr.setBound(getBound() == null ? null : getBound().deepCopy());
-		expr.setFilter(getFilter() == null ? null : (Filter)getFilter().deepCopy());
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		super.deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionProb.java
+++ b/prism/src/parser/ast/ExpressionProb.java
@@ -151,6 +151,12 @@ public class ExpressionProb extends ExpressionQuant
 		return expr;
 	}
 
+	@Override
+	public ExpressionProb clone()
+	{
+		return (ExpressionProb) super.clone();
+	}
+
 	// Standard methods
 
 	@Override

--- a/prism/src/parser/ast/ExpressionProp.java
+++ b/prism/src/parser/ast/ExpressionProp.java
@@ -96,6 +96,12 @@ public class ExpressionProp extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionProp clone()
+	{
+		return (ExpressionProp) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionProp.java
+++ b/prism/src/parser/ast/ExpressionProp.java
@@ -88,12 +88,9 @@ public class ExpressionProp extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionProp deepCopyASTElements()
 	{
-		ExpressionProp expr = new ExpressionProp(name);
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionQuant.java
+++ b/prism/src/parser/ast/ExpressionQuant.java
@@ -162,6 +162,12 @@ public abstract class ExpressionQuant extends Expression
 	}
 
 	// Standard methods
+
+	@Override
+	public ExpressionQuant clone()
+	{
+		return (ExpressionQuant) super.clone();
+	}
 	
 	@Override
 	public int hashCode()

--- a/prism/src/parser/ast/ExpressionQuant.java
+++ b/prism/src/parser/ast/ExpressionQuant.java
@@ -170,6 +170,16 @@ public abstract class ExpressionQuant extends Expression
 	}
 	
 	@Override
+	public ExpressionQuant deepCopyASTElements()
+	{
+		bound = (bound == null) ? null : bound.clone().deepCopyASTElements();
+		filter = (filter == null) ? null : filter.clone().deepCopyASTElements();
+		expression = (expression == null) ? null : expression.clone().deepCopyASTElements();
+
+		return this;
+	}
+
+	@Override
 	public int hashCode()
 	{
 		final int prime = 31;

--- a/prism/src/parser/ast/ExpressionReward.java
+++ b/prism/src/parser/ast/ExpressionReward.java
@@ -26,8 +26,6 @@
 
 package parser.ast;
 
-import java.util.List;
-
 import parser.EvaluateContext;
 import parser.Values;
 import parser.visitor.ASTVisitor;
@@ -35,6 +33,8 @@ import prism.OpRelOpBound;
 import prism.PrismException;
 import prism.PrismLangException;
 import prism.RewardGenerator;
+
+import java.util.List;
 
 public class ExpressionReward extends ExpressionQuant
 {
@@ -275,20 +275,18 @@ public class ExpressionReward extends ExpressionQuant
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionReward deepCopyASTElements()
 	{
-		ExpressionReward expr = new ExpressionReward();
-		expr.setExpression(getExpression() == null ? null : getExpression().deepCopy());
-		expr.setRelOp(getRelOp());
-		expr.setBound(getBound() == null ? null : getBound().deepCopy());
-		if (rewardStructIndex != null && rewardStructIndex instanceof Expression) expr.setRewardStructIndex(((Expression)rewardStructIndex).deepCopy());
-		else expr.setRewardStructIndex(rewardStructIndex);
-		if (rewardStructIndexDiv != null && rewardStructIndexDiv instanceof Expression) expr.setRewardStructIndexDiv(((Expression)rewardStructIndexDiv).deepCopy());
-		else expr.setRewardStructIndexDiv(rewardStructIndexDiv);
-		expr.setFilter(getFilter() == null ? null : (Filter)getFilter().deepCopy());
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		super.deepCopyASTElements();
+
+		if (rewardStructIndex != null && rewardStructIndex instanceof Expression) {
+			rewardStructIndex = ((Expression) rewardStructIndex).clone().deepCopyASTElements();
+		}
+		if (rewardStructIndexDiv != null && rewardStructIndexDiv instanceof Expression) {
+			rewardStructIndexDiv = ((Expression) rewardStructIndexDiv).clone().deepCopyASTElements();
+		}
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionReward.java
+++ b/prism/src/parser/ast/ExpressionReward.java
@@ -291,6 +291,12 @@ public class ExpressionReward extends ExpressionQuant
 		return expr;
 	}
 
+	@Override
+	public ExpressionReward clone()
+	{
+		return (ExpressionReward) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionSS.java
+++ b/prism/src/parser/ast/ExpressionSS.java
@@ -126,16 +126,11 @@ public class ExpressionSS extends ExpressionQuant
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionSS deepCopyASTElements()
 	{
-		ExpressionSS expr = new ExpressionSS();
-		expr.setExpression(getExpression() == null ? null : getExpression().deepCopy());
-		expr.setRelOp(getRelOp());
-		expr.setBound(getBound() == null ? null : getBound().deepCopy());
-		expr.setFilter(getFilter() == null ? null : (Filter)getFilter().deepCopy());
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		super.deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionSS.java
+++ b/prism/src/parser/ast/ExpressionSS.java
@@ -138,6 +138,12 @@ public class ExpressionSS extends ExpressionQuant
 		return expr;
 	}
 
+	@Override
+	public ExpressionSS clone()
+	{
+		return (ExpressionSS) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionStrategy.java
+++ b/prism/src/parser/ast/ExpressionStrategy.java
@@ -194,18 +194,11 @@ public class ExpressionStrategy extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionStrategy deepCopyASTElements()
 	{
-		ExpressionStrategy expr = new ExpressionStrategy();
-		expr.setThereExists(isThereExists());
-		expr.coalition = new Coalition(coalition);
-		for (Expression operand : operands) {
-			expr.addOperand((Expression) operand.deepCopy());
-		}
-		expr.singleOperand = singleOperand;
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		operands.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/ExpressionStrategy.java
+++ b/prism/src/parser/ast/ExpressionStrategy.java
@@ -46,7 +46,7 @@ public class ExpressionStrategy extends Expression
 	protected Coalition coalition = new Coalition(); 
 	
 	/** Child expression(s) */
-	protected List<Expression> operands = new ArrayList<Expression>();
+	protected ArrayList<Expression> operands = new ArrayList<Expression>();
 	
 	/** Is there just a single operand (P/R operator)? If not, the operand list will be parenthesised. **/
 	protected boolean singleOperand = false;
@@ -206,6 +206,18 @@ public class ExpressionStrategy extends Expression
 		expr.setType(type);
 		expr.setPosition(this);
 		return expr;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public ExpressionStrategy clone()
+	{
+		ExpressionStrategy clone = (ExpressionStrategy) super.clone();
+
+		clone.coalition = new Coalition(coalition);
+		clone.operands  = (ArrayList<Expression>) operands.clone();
+
+		return clone;
 	}
 
 	// Standard methods

--- a/prism/src/parser/ast/ExpressionTemporal.java
+++ b/prism/src/parser/ast/ExpressionTemporal.java
@@ -267,20 +267,14 @@ public class ExpressionTemporal extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionTemporal deepCopyASTElements()
 	{
-		ExpressionTemporal expr = new ExpressionTemporal();
-		expr.setOperator(op);
-		if (operand1 != null)
-			expr.setOperand1(operand1.deepCopy());
-		if (operand2 != null)
-			expr.setOperand2(operand2.deepCopy());
-		expr.setLowerBound(lBound == null ? null : lBound.deepCopy(), lBoundStrict);
-		expr.setUpperBound(uBound == null ? null : uBound.deepCopy(), uBoundStrict);
-		expr.equals = equals;
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		operand1 = (operand1 == null) ? null : operand1.clone().deepCopyASTElements();
+		operand2 = (operand2 == null) ? null : operand2.clone().deepCopyASTElements();
+		lBound = (lBound == null) ? null : lBound.clone().deepCopyASTElements();
+		uBound = (uBound == null) ? null : uBound.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionTemporal.java
+++ b/prism/src/parser/ast/ExpressionTemporal.java
@@ -283,6 +283,12 @@ public class ExpressionTemporal extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionTemporal clone()
+	{
+		return (ExpressionTemporal) super.clone();
+	}
+
 	// Standard methods
 
 	@Override

--- a/prism/src/parser/ast/ExpressionUnaryOp.java
+++ b/prism/src/parser/ast/ExpressionUnaryOp.java
@@ -179,12 +179,11 @@ public class ExpressionUnaryOp extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionUnaryOp deepCopyASTElements()
 	{
-		ExpressionUnaryOp expr = new ExpressionUnaryOp(op, operand.deepCopy());
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		operand = operand.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionUnaryOp.java
+++ b/prism/src/parser/ast/ExpressionUnaryOp.java
@@ -187,6 +187,12 @@ public class ExpressionUnaryOp extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionUnaryOp clone()
+	{
+		return (ExpressionUnaryOp) super.clone();
+	}
+
 	// Standard methods
 
 	@Override

--- a/prism/src/parser/ast/ExpressionVar.java
+++ b/prism/src/parser/ast/ExpressionVar.java
@@ -120,6 +120,12 @@ public class ExpressionVar extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionVar clone()
+	{
+		return (ExpressionVar) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionVar.java
+++ b/prism/src/parser/ast/ExpressionVar.java
@@ -112,12 +112,9 @@ public class ExpressionVar extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionVar deepCopyASTElements()
 	{
-		ExpressionVar expr = new ExpressionVar(name, type);
-		expr.setIndex(index);
-		expr.setPosition(this);
-		return expr;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/Filter.java
+++ b/prism/src/parser/ast/Filter.java
@@ -127,6 +127,12 @@ public class Filter extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public Filter clone()
+	{
+		return (Filter) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/Filter.java
+++ b/prism/src/parser/ast/Filter.java
@@ -117,15 +117,14 @@ public class Filter extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public Filter deepCopyASTElements()
 	{
-		Filter ret = new Filter(expr.deepCopy());
-		ret.setMinRequested(minReq);
-		ret.setMaxRequested(maxReq);
-		ret.setPosition(this);
-		return ret;
+		expr = expr.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ForLoop.java
+++ b/prism/src/parser/ast/ForLoop.java
@@ -154,6 +154,12 @@ public class ForLoop extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public ForLoop clone()
+	{
+		return (ForLoop) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/ForLoop.java
+++ b/prism/src/parser/ast/ForLoop.java
@@ -140,19 +140,16 @@ public class ForLoop extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public ForLoop deepCopyASTElements()
 	{
-		ForLoop ret = new ForLoop();
-		ret.lhs = lhs;
-		ret.from = from.deepCopy();
-		ret.to = to.deepCopy();
-		ret.step = step.deepCopy();
-		ret.pc = pc;
-		ret.between = between;
-		ret.setPosition(this);
-		return ret;
+		to = to.clone().deepCopyASTElements();
+		from = from.clone().deepCopyASTElements();
+		step = step.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/FormulaList.java
+++ b/prism/src/parser/ast/FormulaList.java
@@ -169,6 +169,19 @@ public class FormulaList extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public FormulaList clone()
+	{
+		FormulaList clone = (FormulaList) super.clone();
+
+		clone.names      = (Vector<String>)          names.clone();
+		clone.formulas   = (Vector<Expression>)      formulas.clone();
+		clone.nameIdents = (Vector<ExpressionIdent>) nameIdents.clone();
+
+		return clone;
+	}
 }
 
 // ------------------------------------------------------------------------------

--- a/prism/src/parser/ast/FormulaList.java
+++ b/prism/src/parser/ast/FormulaList.java
@@ -156,18 +156,15 @@ public class FormulaList extends ASTElement
 	}
 
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public FormulaList deepCopyASTElements()
 	{
-		int i, n;
-		FormulaList ret = new FormulaList();
-		n = size();
-		for (i = 0; i < n; i++) {
-			ret.addFormula((ExpressionIdent)getFormulaNameIdent(i).deepCopy(), getFormula(i).deepCopy());
-		}
-		ret.setPosition(this);
-		return ret;
+		formulas.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		nameIdents.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/LabelList.java
+++ b/prism/src/parser/ast/LabelList.java
@@ -136,18 +136,15 @@ public class LabelList extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public LabelList deepCopyASTElements()
 	{
-		int i, n;
-		LabelList ret = new LabelList();
-		n = size();
-		for (i = 0; i < n; i++) {
-			ret.addLabel((ExpressionIdent)getLabelNameIdent(i).deepCopy(), getLabel(i).deepCopy());
-		}
-		ret.setPosition(this);
-		return ret;
+		labels.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		nameIdents.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/LabelList.java
+++ b/prism/src/parser/ast/LabelList.java
@@ -38,7 +38,7 @@ import prism.PrismLangException;
 public class LabelList extends ASTElement
 {
 	// Name/expression pairs to define labels
-	private List<String> names;
+	private ArrayList<String> names;
 	private Vector<Expression> labels;
 	// We also store an ExpressionIdent to match each name.
 	// This is to just to provide positional info.
@@ -148,6 +148,19 @@ public class LabelList extends ASTElement
 		}
 		ret.setPosition(this);
 		return ret;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public LabelList clone()
+	{
+		LabelList clone = (LabelList) super.clone();
+
+		clone.names      = (ArrayList<String>)       names.clone();
+		clone.labels     = (Vector<Expression>)      labels.clone();
+		clone.nameIdents = (Vector<ExpressionIdent>) nameIdents.clone();
+
+		return clone;
 	}
 }
 

--- a/prism/src/parser/ast/Module.java
+++ b/prism/src/parser/ast/Module.java
@@ -304,6 +304,19 @@ public class Module extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Module clone()
+	{
+		Module clone = (Module) super.clone();
+
+		clone.decls    = (ArrayList<Declaration>) decls.clone();
+		clone.commands = (ArrayList<Command>) commands.clone();
+		clone.alphabet = (Vector<String>) alphabet.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/Module.java
+++ b/prism/src/parser/ast/Module.java
@@ -283,26 +283,18 @@ public class Module extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public Module deepCopyASTElements()
 	{
-		int i, n;
-		Module ret = new Module(name);
-		if (nameASTElement != null)
-			ret.setNameASTElement((ExpressionIdent)nameASTElement.deepCopy());
-		n = getNumDeclarations();
-		for (i = 0; i < n; i++) {
-			ret.addDeclaration((Declaration)getDeclaration(i).deepCopy());
-		}
-		n = getNumCommands();
-		for (i = 0; i < n; i++) {
-			ret.addCommand((Command)getCommand(i).deepCopy());
-		}
-		if (invariant != null)
-			ret.setInvariant(invariant.deepCopy());
-		ret.setPosition(this);
-		return ret;
+		invariant = (invariant == null) ? null : invariant.clone().deepCopyASTElements();
+		nameASTElement = (nameASTElement == null) ? null : nameASTElement.clone().deepCopyASTElements();
+
+		decls.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		commands.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -313,7 +305,7 @@ public class Module extends ASTElement
 
 		clone.decls    = (ArrayList<Declaration>) decls.clone();
 		clone.commands = (ArrayList<Command>) commands.clone();
-		clone.alphabet = (Vector<String>) alphabet.clone();
+		clone.alphabet = (alphabet == null) ? null : (Vector<String>) alphabet.clone();
 
 		return clone;
 	}

--- a/prism/src/parser/ast/ModulesFile.java
+++ b/prism/src/parser/ast/ModulesFile.java
@@ -1640,66 +1640,35 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 	}
 
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	@SuppressWarnings("unchecked")
-	public ASTElement deepCopy()
+	@Override
+	public ModulesFile deepCopyASTElements()
 	{
-		int i, n;
-		ModulesFile ret = new ModulesFile();
-		
-		// Copy ASTElement stuff
-		ret.setPosition(this);
-		// Copy type
-		ret.setModelTypeInFile(modelTypeInFile);
-		ret.setModelType(modelType);
 		// Deep copy main components
-		ret.setFormulaList((FormulaList) formulaList.deepCopy());
-		ret.setLabelList((LabelList) labelList.deepCopy());
-		ret.setConstantList((ConstantList) constantList.deepCopy());
-		n = getNumGlobals();
-		for (i = 0; i < n; i++) {
-			ret.addGlobal((Declaration) getGlobal(i).deepCopy());
+		labelList = labelList.clone().deepCopyASTElements();
+		formulaList = formulaList.clone().deepCopyASTElements();
+		constantList = constantList.clone().deepCopyASTElements();
+		initStates = (initStates == null) ? null : initStates.clone().deepCopyASTElements();
+		identUsage = (identUsage == null) ? null : identUsage.clone().deepCopyFields();
+		quotedIdentUsage = (quotedIdentUsage == null) ? null : quotedIdentUsage.clone().deepCopyFields();
+
+		// deepCopy all elements inside collections
+		globals.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		varDecls.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		systemDefns.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		observables.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		rewardStructs.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		observableDefns.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		observableVarLists.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		for (int i = 0, n = getNumModules(); i < n; i++) {
+			Module mod = getModule(i);
+			if (mod != null) {
+				setModule(i, mod.clone().deepCopyASTElements());
+			}
 		}
-		n = getNumModules();
-		for (i = 0; i < n; i++) {
-			ret.addModule((Module) getModule(i).deepCopy());
-		}
-		n = getNumSystemDefns();
-		for (i = 0; i < n; i++) {
-			ret.addSystemDefn(getSystemDefn(i).deepCopy(), getSystemDefnName(i));
-		}
-		n = getNumRewardStructs();
-		for (i = 0; i < n; i++) {
-			ret.addRewardStruct((RewardStruct) getRewardStruct(i).deepCopy());
-		}
-		if (initStates != null)
-			ret.setInitialStates(initStates.deepCopy());
-		for (ObservableVars obsVars : observableVarLists)
-			ret.observableVarLists.add(obsVars.deepCopy());
-		for (Observable obs : observableDefns)
-			ret.observableDefns.add(obs.deepCopy());
-		// Copy other (generated) info
-		ret.identUsage = (identUsage == null) ? null : identUsage.deepCopy();
-		ret.quotedIdentUsage = (quotedIdentUsage == null) ? null : quotedIdentUsage.deepCopy();
-		ret.moduleNames = (moduleNames == null) ? null : moduleNames.clone();
-		ret.synchs = (synchs == null) ? null : (Vector<String>)synchs.clone();
-		if (varDecls != null) {
-			ret.varDecls = new Vector<Declaration>();
-			for (Declaration d : varDecls)
-				ret.varDecls.add((Declaration) d.deepCopy());
-		}
-		ret.varNames = (varNames == null) ? null : (Vector<String>)varNames.clone();
-		ret.varTypes = (varTypes == null) ? null : (Vector<Type>)varTypes.clone();
-		ret.varModules = (varModules == null) ? null : (Vector<Integer>)varModules.clone();
-		for (Observable obs : observables)
-			ret.observables.add(obs.deepCopy());
-		ret.observableNames = (observableNames == null) ? null : new ArrayList<>(observableNames);
-		ret.observableTypes = (observableTypes == null) ? null : new ArrayList<>(observableTypes);
-		ret.observableVars = (observableVars == null) ? null : new ArrayList<>(observableVars);
-		ret.constantValues = (constantValues == null) ? null : new Values(constantValues);
-		
-		return ret;
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/ModulesFile.java
+++ b/prism/src/parser/ast/ModulesFile.java
@@ -66,10 +66,10 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 	private ArrayList<SystemDefn> systemDefns; // System definitions (system...endsystem constructs)
 	private ArrayList<String> systemDefnNames; // System definition names (system...endsystem constructs)
 	private ArrayList<RewardStruct> rewardStructs; // Rewards structures
-	private List<String> rewardStructNames; // Names of reward structures
+	private ArrayList<String> rewardStructNames; // Names of reward structures
 	private Expression initStates; // Initial states specification
-	private List<ObservableVars> observableVarLists; // Observable variables lists
-	private List<Observable> observableDefns; // Standalone observable definitions
+	private ArrayList<ObservableVars> observableVarLists; // Observable variables lists
+	private ArrayList<Observable> observableDefns; // Standalone observable definitions
 	
 	// Info about all identifiers used
 	private IdentUsage identUsage;
@@ -84,10 +84,10 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 	private Vector<Type> varTypes;
 	private Vector<Integer> varModules;
 	// Lists of observable info
-	private List<Observable> observables;
-	private List<String> observableNames;
-	private List<Type> observableTypes;
-	private List<String> observableVars;
+	private ArrayList<Observable> observables;
+	private ArrayList<String> observableNames;
+	private ArrayList<Type> observableTypes;
+	private ArrayList<String> observableVars;
 
 	// Values set for undefined constants (null if none)
 	private Values undefinedConstantValues;
@@ -1700,6 +1700,43 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 		ret.constantValues = (constantValues == null) ? null : new Values(constantValues);
 		
 		return ret;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public ModulesFile clone()
+	{
+		ModulesFile clone = (ModulesFile) super.clone();
+
+		// clone main components
+		clone.globals            = (Vector<Declaration>) globals.clone();
+		clone.modules            = (Vector<Object>) modules.clone();
+		clone.systemDefns        = (ArrayList<SystemDefn>) systemDefns.clone();
+		clone.systemDefnNames    = (ArrayList<String>) systemDefnNames.clone();
+		clone.rewardStructs      = (ArrayList<RewardStruct>) rewardStructs.clone();
+		clone.rewardStructNames  = (ArrayList<String>) rewardStructNames.clone();
+		clone.observableVarLists = (ArrayList<ObservableVars>) observableVarLists.clone();
+		clone.observableDefns    = (ArrayList<Observable>) observableDefns.clone();
+		clone.varDecls           = (Vector<Declaration>) varDecls.clone();
+		clone.varNames           = (Vector<String>) varNames.clone();
+		clone.varTypes           = (Vector<Type>) varTypes.clone();
+		clone.varModules         = (Vector<Integer>) varModules.clone();
+		clone.observables        = (ArrayList<Observable>) observables.clone();
+		clone.observableNames    = (ArrayList<String>) observableNames.clone();
+		clone.observableTypes    = (ArrayList<Type>) observableTypes.clone();
+		clone.observableVars     = (ArrayList<String>) observableVars.clone();
+
+		// clone other (generated) info
+		if (constantValues != null)
+			clone.constantValues = constantValues.clone();
+		if (undefinedConstantValues != null)
+			clone.undefinedConstantValues = undefinedConstantValues.clone();
+		if (moduleNames != null)
+			clone.moduleNames = moduleNames.clone();
+		if (synchs != null)
+			clone.synchs =  (Vector<String>) synchs.clone();
+
+		return clone;
 	}
 }
 

--- a/prism/src/parser/ast/Observable.java
+++ b/prism/src/parser/ast/Observable.java
@@ -102,13 +102,14 @@ public class Observable extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public Observable deepCopy()
+	@Override
+	public Observable deepCopyASTElements()
 	{
-		Observable ret = new Observable(name, definition.deepCopy());
-		ret.setPosition(this);
-		return ret;
+		definition = definition.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/Observable.java
+++ b/prism/src/parser/ast/Observable.java
@@ -110,6 +110,12 @@ public class Observable extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public Observable clone()
+	{
+		return (Observable) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/ObservableVars.java
+++ b/prism/src/parser/ast/ObservableVars.java
@@ -27,7 +27,6 @@
 package parser.ast;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.stream.Collectors;
 
 import parser.visitor.ASTVisitor;
@@ -126,16 +125,14 @@ public class ObservableVars extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ObservableVars deepCopy()
+	@Override
+	public ObservableVars deepCopyASTElements()
 	{
-		ObservableVars ret = new ObservableVars();
-		for (Expression var : vars) {
-			ret.addVar(var.deepCopy());
-		}
-		ret.setPosition(this);
-		return ret;
+		vars.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/ObservableVars.java
+++ b/prism/src/parser/ast/ObservableVars.java
@@ -41,7 +41,7 @@ public class ObservableVars extends ASTElement
 	/**
 	 * List of variables (stored as AST elements referencing them)
 	 */
-	private List<Expression> vars;
+	private ArrayList<Expression> vars;
 	
 	// Constructor
 	
@@ -136,6 +136,15 @@ public class ObservableVars extends ASTElement
 		}
 		ret.setPosition(this);
 		return ret;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public ObservableVars clone()
+	{
+		ObservableVars clone = (ObservableVars) super.clone();
+		clone.vars = (ArrayList<Expression>) vars.clone();
+		return clone;
 	}
 }
 

--- a/prism/src/parser/ast/PropertiesFile.java
+++ b/prism/src/parser/ast/PropertiesFile.java
@@ -673,6 +673,24 @@ public class PropertiesFile extends ASTElement
 
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public PropertiesFile clone()
+	{
+		PropertiesFile clone = (PropertiesFile) super.clone();
+
+		// clone main components
+		clone.properties = (Vector<Property>) properties.clone();
+
+		// clone other (generated) info
+		if (constantValues != null)
+			clone.constantValues = constantValues.clone();
+		if (undefinedConstantValues != null)
+			clone.undefinedConstantValues = undefinedConstantValues.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/PropertiesFile.java
+++ b/prism/src/parser/ast/PropertiesFile.java
@@ -649,29 +649,20 @@ public class PropertiesFile extends ASTElement
 		return s;
 	}
 
-	/**
-	 * Perform a deep copy.
-	 */
-	public ASTElement deepCopy()
+	@Override
+	public PropertiesFile deepCopyASTElements()
 	{
-		int i, n;
-		PropertiesFile ret = new PropertiesFile(modelInfo);
-		// Copy ASTElement stuff
-		ret.setPosition(this);
-		// Deep copy main components
-		ret.setFormulaList((FormulaList) formulaList.deepCopy());
-		ret.setLabelList((LabelList) labelList.deepCopy());
-		ret.combinedLabelList = (LabelList) combinedLabelList.deepCopy();
-		ret.setConstantList((ConstantList) constantList.deepCopy());
-		n = getNumProperties();
-		for (i = 0; i < n; i++) {
-			ret.addProperty((Property) getPropertyObject(i).deepCopy());
-		}
-		// Copy other (generated) info
-		ret.identUsage = (identUsage == null) ? null : identUsage.deepCopy();
-		ret.constantValues = (constantValues == null) ? null : new Values(constantValues);
+		quotedIdentUsage = new IdentUsage(true);
+		labelList = labelList.clone().deepCopyASTElements();
+		formulaList = formulaList.clone().deepCopyASTElements();
+		constantList = constantList.clone().deepCopyASTElements();
+		combinedLabelList = combinedLabelList.clone().deepCopyASTElements();
+		identUsage = (identUsage == null) ? null : identUsage.clone().deepCopyFields();
 
-		return ret;
+		// deepCopy all elements inside collections
+		properties.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/Property.java
+++ b/prism/src/parser/ast/Property.java
@@ -303,12 +303,11 @@ public class Property extends ASTElement
 	}
 
 	@Override
-	public Property deepCopy()
+	public Property deepCopyASTElements()
 	{
-		Property prop = new Property(expr.deepCopy(), name, comment);
-		prop.setType(type);
-		prop.setPosition(this);
-		return prop;
+		expr = expr.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/Property.java
+++ b/prism/src/parser/ast/Property.java
@@ -310,6 +310,12 @@ public class Property extends ASTElement
 		prop.setPosition(this);
 		return prop;
 	}
+
+	@Override
+	public Property clone()
+	{
+		return (Property) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/RenamedModule.java
+++ b/prism/src/parser/ast/RenamedModule.java
@@ -185,20 +185,17 @@ public class RenamedModule extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public RenamedModule deepCopyASTElements()
 	{
-		int i, n;
-		RenamedModule ret = new RenamedModule(name, baseModule);
-		ret.setNameASTElement((ExpressionIdent)nameASTElement.deepCopy());
-		ret.setBaseModuleASTElement((ExpressionIdent)baseModuleASTElement.deepCopy());
-		n = oldNames.size();
-		for (i = 0; i < n; i++) {
-			ret.addRename(oldNames.get(i), newNames.get(i));
-		}
-		ret.setPosition(this);
-		return ret;
+		nameASTElement = nameASTElement.clone().deepCopyASTElements();
+		baseModuleASTElement = baseModuleASTElement.clone().deepCopyASTElements();
+		oldNameASTElements.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		newNameASTElements.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/RenamedModule.java
+++ b/prism/src/parser/ast/RenamedModule.java
@@ -200,6 +200,20 @@ public class RenamedModule extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public RenamedModule clone()
+	{
+		RenamedModule clone = (RenamedModule) super.clone();
+
+		clone.newNameASTElements = (ArrayList<ExpressionIdent>) newNameASTElements.clone();
+		clone.newNames           = (ArrayList<String>) newNames.clone();
+		clone.oldNameASTElements = (ArrayList<ExpressionIdent>) oldNameASTElements.clone();
+		clone.oldNames           = (ArrayList<String>) oldNames.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/RewardStruct.java
+++ b/prism/src/parser/ast/RewardStruct.java
@@ -146,19 +146,14 @@ public class RewardStruct extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public RewardStruct deepCopyASTElements()
 	{
-		int i, n;
-		RewardStruct ret = new RewardStruct();
-		ret.setName(name);
-		n = getNumItems();
-		for (i = 0; i < n; i++) {
-			ret.addItem((RewardStructItem)getRewardStructItem(i).deepCopy());
-		}
-		ret.setPosition(this);
-		return ret;
+		items.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/RewardStruct.java
+++ b/prism/src/parser/ast/RewardStruct.java
@@ -160,6 +160,17 @@ public class RewardStruct extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public RewardStruct clone()
+	{
+		RewardStruct clone = (RewardStruct) super.clone();
+
+		clone.items = (Vector<RewardStructItem>) items.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/RewardStructItem.java
+++ b/prism/src/parser/ast/RewardStructItem.java
@@ -140,14 +140,15 @@ public class RewardStructItem extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public RewardStructItem deepCopyASTElements()
 	{
-		RewardStructItem ret = new RewardStructItem(synch, states.deepCopy(), reward.deepCopy());
-		ret.setSynchIndex(getSynchIndex());
-		ret.setPosition(this);
-		return ret;
+		states = states.clone().deepCopyASTElements();
+		reward = reward.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/RewardStructItem.java
+++ b/prism/src/parser/ast/RewardStructItem.java
@@ -149,6 +149,12 @@ public class RewardStructItem extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public RewardStructItem clone()
+	{
+		return (RewardStructItem) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemBrackets.java
+++ b/prism/src/parser/ast/SystemBrackets.java
@@ -114,11 +114,11 @@ public class SystemBrackets extends SystemDefn
 	}
 	
 	@Override
-	public SystemDefn deepCopy()
+	public SystemBrackets deepCopyASTElements()
 	{
-		SystemDefn ret = new SystemBrackets(getOperand().deepCopy());
-		ret.setPosition(this);
-		return ret;
+		operand = operand.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/SystemBrackets.java
+++ b/prism/src/parser/ast/SystemBrackets.java
@@ -120,6 +120,12 @@ public class SystemBrackets extends SystemDefn
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public SystemBrackets clone()
+	{
+		return (SystemBrackets) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemDefn.java
+++ b/prism/src/parser/ast/SystemDefn.java
@@ -30,12 +30,19 @@ import java.util.Vector;
 
 public abstract class SystemDefn extends ASTElement
 {
-	// Overrided version of deepCopy() from superclass ASTElement (to reduce casting).
+	// Overwritten version of deepCopy() and deepCopyASTElements() from superclass ASTElement (to reduce casting).
+
+	@Override
+	public abstract SystemDefn deepCopyASTElements();
 
 	/**
 	 * Perform a deep copy.
 	 */
-	public abstract SystemDefn deepCopy();
+	@Override
+	public SystemDefn deepCopy()
+	{
+		return (SystemDefn) super.deepCopy();
+	}
 
 	@Override
 	public SystemDefn clone()

--- a/prism/src/parser/ast/SystemDefn.java
+++ b/prism/src/parser/ast/SystemDefn.java
@@ -37,6 +37,12 @@ public abstract class SystemDefn extends ASTElement
 	 */
 	public abstract SystemDefn deepCopy();
 
+	@Override
+	public SystemDefn clone()
+	{
+		return (SystemDefn) super.clone();
+	}
+
 	// Methods required for SystemDefn (all subclasses should implement):
 
 	/**

--- a/prism/src/parser/ast/SystemFullParallel.java
+++ b/prism/src/parser/ast/SystemFullParallel.java
@@ -161,6 +161,17 @@ public class SystemFullParallel extends SystemDefn
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public SystemFullParallel clone()
+	{
+		SystemFullParallel clone = (SystemFullParallel) super.clone();
+
+		clone.operands = (Vector<SystemDefn>) operands.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemFullParallel.java
+++ b/prism/src/parser/ast/SystemFullParallel.java
@@ -150,16 +150,11 @@ public class SystemFullParallel extends SystemDefn
 	}
 	
 	@Override
-	public SystemDefn deepCopy()
+	public SystemFullParallel deepCopyASTElements()
 	{
-		int i, n;
-		SystemFullParallel ret = new SystemFullParallel();
-		n = getNumOperands();
-		for (i = 0; i < n; i++) {
-			ret.addOperand(getOperand(i).deepCopy());
-		}
-		ret.setPosition(this);
-		return ret;
+		operands.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/SystemHide.java
+++ b/prism/src/parser/ast/SystemHide.java
@@ -165,6 +165,17 @@ public class SystemHide extends SystemDefn
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public SystemHide clone()
+	{
+		SystemHide clone = (SystemHide) super.clone();
+
+		clone.actions = (Vector<String>) actions.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemHide.java
+++ b/prism/src/parser/ast/SystemHide.java
@@ -154,16 +154,11 @@ public class SystemHide extends SystemDefn
 	}
 	
 	@Override
-	public SystemDefn deepCopy()
+	public SystemHide deepCopyASTElements()
 	{
-		int i, n;
-		SystemHide ret = new SystemHide(getOperand().deepCopy());
-		n = getNumActions();
-		for (i = 0; i < n; i++) {
-			ret.addAction(getAction(i));
-		}
-		ret.setPosition(this);
-		return ret;
+		operand = operand.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/SystemInterleaved.java
+++ b/prism/src/parser/ast/SystemInterleaved.java
@@ -161,6 +161,17 @@ public class SystemInterleaved extends SystemDefn
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public SystemInterleaved clone()
+	{
+		SystemInterleaved clone = (SystemInterleaved) super.clone();
+
+		clone.operands = (Vector<SystemDefn>) operands.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemInterleaved.java
+++ b/prism/src/parser/ast/SystemInterleaved.java
@@ -150,16 +150,11 @@ public class SystemInterleaved extends SystemDefn
 	}
 	
 	@Override
-	public SystemDefn deepCopy()
+	public SystemInterleaved deepCopyASTElements()
 	{
-		int i, n;
-		SystemInterleaved ret = new SystemInterleaved();
-		n = getNumOperands();
-		for (i = 0; i < n; i++) {
-			ret.addOperand(getOperand(i).deepCopy());
-		}
-		ret.setPosition(this);
-		return ret;
+		operands.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/SystemModule.java
+++ b/prism/src/parser/ast/SystemModule.java
@@ -114,6 +114,12 @@ public class SystemModule extends SystemDefn
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public SystemModule clone()
+	{
+		return (SystemModule) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemModule.java
+++ b/prism/src/parser/ast/SystemModule.java
@@ -108,11 +108,9 @@ public class SystemModule extends SystemDefn
 	}
 	
 	@Override
-	public SystemDefn deepCopy()
+	public SystemModule deepCopyASTElements()
 	{
-		SystemDefn ret = new SystemModule(name);
-		ret.setPosition(this);
-		return ret;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/SystemParallel.java
+++ b/prism/src/parser/ast/SystemParallel.java
@@ -169,15 +169,12 @@ public class SystemParallel extends SystemDefn
 	}
 	
 	@Override
-	@SuppressWarnings("unchecked")
-	public SystemDefn deepCopy()
+	public SystemParallel deepCopyASTElements()
 	{
-		SystemParallel ret = new SystemParallel();
-		ret.setOperand1(getOperand1().deepCopy());
-		ret.setOperand2(getOperand2().deepCopy());
-		ret.actions = (actions == null) ? null : (Vector<String>)actions.clone();
-		ret.setPosition(this);
-		return ret;
+		operand1 = operand1.clone().deepCopyASTElements();
+		operand2 = operand2.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/SystemParallel.java
+++ b/prism/src/parser/ast/SystemParallel.java
@@ -179,6 +179,17 @@ public class SystemParallel extends SystemDefn
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public SystemParallel clone()
+	{
+		SystemParallel clone = (SystemParallel) super.clone();
+
+		clone.actions = (Vector<String>) actions.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemReference.java
+++ b/prism/src/parser/ast/SystemReference.java
@@ -119,6 +119,12 @@ public class SystemReference extends SystemDefn
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public SystemReference clone()
+	{
+		return (SystemReference) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemReference.java
+++ b/prism/src/parser/ast/SystemReference.java
@@ -113,11 +113,9 @@ public class SystemReference extends SystemDefn
 	}
 	
 	@Override
-	public SystemDefn deepCopy()
+	public SystemReference deepCopyASTElements()
 	{
-		SystemDefn ret = new SystemReference(name);
-		ret.setPosition(this);
-		return ret;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/SystemRename.java
+++ b/prism/src/parser/ast/SystemRename.java
@@ -197,16 +197,11 @@ public class SystemRename extends SystemDefn
 	}
 
 	@Override
-	public SystemDefn deepCopy()
+	public SystemRename deepCopyASTElements()
 	{
-		int i, n;
-		SystemRename ret = new SystemRename(getOperand().deepCopy());
-		n = getNumRenames();
-		for (i = 0; i < n; i++) {
-			ret.addRename(getFrom(i), getTo(i));
-		}
-		ret.setPosition(this);
-		return ret;
+		operand = operand.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/SystemRename.java
+++ b/prism/src/parser/ast/SystemRename.java
@@ -208,6 +208,18 @@ public class SystemRename extends SystemDefn
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public SystemRename clone()
+	{
+		SystemRename clone = (SystemRename) super.clone();
+
+		clone.from = (Vector<String>) from.clone();
+		clone.to   = (Vector<String>) to.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/Update.java
+++ b/prism/src/parser/ast/Update.java
@@ -319,14 +319,11 @@ public class Update extends ASTElement implements Iterable<UpdateElement>
 	}
 
 	@Override
-	public ASTElement deepCopy()
+	public Update deepCopyASTElements()
 	{
-		Update ret = new Update();
-		for (UpdateElement e : this) {
-			ret.addElement(e.deepCopy());
-		}
-		ret.setPosition(this);
-		return ret;
+		elements.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/Update.java
+++ b/prism/src/parser/ast/Update.java
@@ -328,6 +328,17 @@ public class Update extends ASTElement implements Iterable<UpdateElement>
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Update clone()
+	{
+		Update clone = (Update) super.clone();
+
+		clone.elements = (ArrayList<UpdateElement>) elements.clone();
+
+		return clone;
+	}
 	
 	// Other methods:
 	

--- a/prism/src/parser/ast/UpdateElement.java
+++ b/prism/src/parser/ast/UpdateElement.java
@@ -202,12 +202,12 @@ public class UpdateElement extends ASTElement
 	}
 
 	@Override
-	public UpdateElement deepCopy()
+	public UpdateElement deepCopyASTElements()
 	{
-		UpdateElement result = new UpdateElement((ExpressionIdent)ident.deepCopy(), expr.deepCopy());
-		result.type = type;
-		result.index = index;
-		return result;
+		ident = ident.clone().deepCopyASTElements();
+		expr = expr.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/UpdateElement.java
+++ b/prism/src/parser/ast/UpdateElement.java
@@ -209,6 +209,12 @@ public class UpdateElement extends ASTElement
 		result.index = index;
 		return result;
 	}
+
+	@Override
+	public UpdateElement clone()
+	{
+		return (UpdateElement) super.clone();
+	}
 	
 	// Other methods:
 	

--- a/prism/src/parser/ast/Updates.java
+++ b/prism/src/parser/ast/Updates.java
@@ -175,22 +175,15 @@ public class Updates extends ASTElement
 	}
 
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public Updates deepCopyASTElements()
 	{
-		int i, n;
-		Expression p;
-		Updates ret = new Updates();
-		n = getNumUpdates();
-		for (i = 0; i < n; i++) {
-			p = getProbability(i);
-			if (p != null)
-				p = p.deepCopy();
-			ret.addUpdate(p, (Update) getUpdate(i).deepCopy());
-		}
-		ret.setPosition(this);
-		return ret;
+		probs.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		updates.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/Updates.java
+++ b/prism/src/parser/ast/Updates.java
@@ -192,6 +192,18 @@ public class Updates extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Updates clone()
+	{
+		Updates clone = (Updates) super.clone();
+
+		clone.probs   = (ArrayList<Expression>) probs.clone();
+		clone.updates = (ArrayList<Update>) updates.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/prism/ResultsExporter.java
+++ b/prism/src/prism/ResultsExporter.java
@@ -395,7 +395,7 @@ public abstract class ResultsExporter
 			Map<String, Integer> nameCounts = new HashMap<>();
 			// 1. Ensure each property is given a name and count names
 			for (int i=0, size=properties.size(); i<size; i++) {
-				Property property = properties.get(i).deepCopy();
+				Property property = (Property) properties.get(i).deepCopy();
 				String name = property.getName();
 				if (name == null || name.isEmpty()) {
 					// Create copy with new name
@@ -449,7 +449,7 @@ public abstract class ResultsExporter
 				// Ensure property has a name
 				String name = property.getName();
 				if (name == null || name.isEmpty()) {
-					property = property.deepCopy();
+					property = (Property) property.deepCopy();
 					property.setName("Property_1");
 				}
 			}

--- a/prism/unit-tests/parser/ast/ExpressionBinaryOpShortCircuitTest.java
+++ b/prism/unit-tests/parser/ast/ExpressionBinaryOpShortCircuitTest.java
@@ -123,6 +123,12 @@ public class ExpressionBinaryOpShortCircuitTest
 		}
 
 		@Override
+		public ExpressionMock deepCopyASTElements()
+		{
+			return this;
+		}
+
+		@Override
 		public boolean isConstant()
 		{
 			return true;


### PR DESCRIPTION
This PR separates deep-copying an AST element in its two logical steps:

1. Creating a shallow copy of the AST node
2. Recursively cloning the fields and child nodes

This enables the programmer to create both shallow copies (aka clones in Java terminology) and deep copies. To adapt existing and new subclasses of `ASTElement`, a programmer hast to:

- Override `#clone` such that a) the type of the callee is returned and b) all collection fields are cloned, too. See `Command#clone` and `ConstantList#clone` .
- Override the abstract method `#deepCopyASTElements` (which is now called in `#deepCopy`) such that it a) returns the type of the callee and b) deep copies of it's child nodes and fields. Using `.clone().deepCopyASTElements()` instead of `deepCopy()` for this purpose avoids casts.

Performance-wise, the impact of this structural change to gain flexibility is negligible.