### PR TITLE
Short circuit evaluation

### DIFF
--- a/prism/src/parser/ast/ExpressionBinaryOp.java
+++ b/prism/src/parser/ast/ExpressionBinaryOp.java
@@ -150,8 +150,19 @@ public class ExpressionBinaryOp extends Expression
 	public Object evaluate(EvaluateContext ec) throws PrismLangException
 	{
 		Object eval1 = operand1.evaluate(ec);
-		Object eval2 = operand2.evaluate(ec);
-		return apply(eval1, eval2, ec.getEvaluationMode());
+		switch (op) {
+			// Short-circuit evaluation
+			case IMPLIES:
+				return !((boolean) eval1) || ((boolean) operand2.evaluate(ec));
+			case OR:
+				return ((boolean) eval1) || ((boolean) operand2.evaluate(ec));
+			case AND:
+				return ((boolean) eval1) && ((boolean) operand2.evaluate(ec));
+			// No short-circuit evaluation
+			default:
+				Object eval2 = operand2.evaluate(ec);
+				return apply(eval1, eval2, ec.getEvaluationMode());
+		}
 	}
 	
 	/**

--- a/prism/unit-tests/parser/ast/ExpressionBinaryOpShortCircuitTest.java
+++ b/prism/unit-tests/parser/ast/ExpressionBinaryOpShortCircuitTest.java
@@ -1,0 +1,156 @@
+package parser.ast;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static parser.ast.ExpressionBinaryOp.IMPLIES;
+import static parser.ast.ExpressionBinaryOp.OR;
+import static parser.ast.ExpressionBinaryOp.AND;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import parser.EvaluateContext;
+import parser.visitor.ASTVisitor;
+import prism.PrismLangException;
+
+import java.util.Objects;
+
+/**
+ * Test whether short-circuiting is exploited during expression evaluation.
+ */
+public class ExpressionBinaryOpShortCircuitTest
+{
+	// Dummy context for #evaluate
+	EvaluateContext ec = new EvaluateContext()
+	{
+		@Override
+		public Object getVarValue(String name, int index)
+		{
+			return null;
+		}
+	};
+
+	@ParameterizedTest
+	@CsvSource({"false, false", "false, true", "true, false", "true, true"})
+	public void testEvaluateImplies(boolean v1, boolean v2) throws PrismLangException
+	{
+		ExpressionMock op1 = new ExpressionMock(v1);
+		ExpressionMock op2 = new ExpressionMock(v2);
+
+		assertEquals(!v1 || v2, new ExpressionBinaryOp(IMPLIES, op1, op2).evaluate(ec));
+	}
+
+	@ParameterizedTest
+	@CsvSource({"false, false", "false, true"})
+	public void testShortCircuitImplies(boolean v1, boolean v2) throws PrismLangException
+	{
+		ExpressionMock op1 = new ExpressionMock(v1);
+		ExpressionMock op2 = new ExpressionMock(v2);
+
+		new ExpressionBinaryOp(IMPLIES, op1, op2).evaluate(ec);
+		assertFalse(op1.isEvaluated() && op2.isEvaluated());
+	}
+
+	@ParameterizedTest
+	@CsvSource({"false, false", "false, true", "true, false", "true, true"})
+	public void testEvaluateOr(boolean v1, boolean v2) throws PrismLangException
+	{
+		ExpressionMock op1 = new ExpressionMock(v1);
+		ExpressionMock op2 = new ExpressionMock(v2);
+
+		assertEquals(v1 || v2, new ExpressionBinaryOp(OR, op1, op2).evaluate(ec));
+	}
+
+	@ParameterizedTest
+	@CsvSource({"true, false", "true, true"})
+	public void testShortCircuitOr(boolean v1, boolean v2) throws PrismLangException
+	{
+		ExpressionMock op1 = new ExpressionMock(v1);
+		ExpressionMock op2 = new ExpressionMock(v2);
+
+		new ExpressionBinaryOp(OR, op1, op2).evaluate(ec);
+		assertFalse(op1.isEvaluated() && op2.isEvaluated());
+	}
+
+	@ParameterizedTest
+	@CsvSource({"false, false", "false, true", "true, false", "true, true"})
+	public void testEvaluateAnd(boolean v1, boolean v2) throws PrismLangException
+	{
+		ExpressionMock op1 = new ExpressionMock(v1);
+		ExpressionMock op2 = new ExpressionMock(v2);
+
+		assertEquals(v1 && v2, new ExpressionBinaryOp(AND, op1, op2).evaluate(ec));
+	}
+
+	@ParameterizedTest
+	@CsvSource({"false, false", "false, true"})
+	public void testShortCircuitAnd(boolean v1, boolean v2) throws PrismLangException
+	{
+		ExpressionMock op1 = new ExpressionMock(v1);
+		ExpressionMock op2 = new ExpressionMock(v2);
+
+		new ExpressionBinaryOp(AND, op1, op2).evaluate(ec);
+		assertFalse(op1.isEvaluated() && op2.isEvaluated());
+	}
+
+
+	/**
+	 * Mocked expression signaling whether #evaluate was invoked or not.
+	 */
+	public static class ExpressionMock extends Expression
+	{
+		protected boolean evaluated = false;
+		protected Object value;
+
+		public ExpressionMock(Object value)
+		{
+			this.value = Objects.requireNonNull(value);
+		}
+
+		public boolean isEvaluated()
+		{
+			return evaluated;
+		}
+
+		@Override
+		public Object accept(ASTVisitor v) throws PrismLangException
+		{
+			return null;
+		}
+
+		@Override
+		public String toString()
+		{
+			return "Evaluated? " + evaluated;
+		}
+
+		@Override
+		public boolean isConstant()
+		{
+			return true;
+		}
+
+		@Override
+		public boolean isProposition()
+		{
+			return true;
+		}
+
+		@Override
+		public Object evaluate(EvaluateContext ec) throws PrismLangException
+		{
+			evaluated = true;
+			return value;
+		}
+
+		@Override
+		public boolean returnsSingleValue()
+		{
+			return false;
+		}
+
+		@Override
+		public Expression deepCopy()
+		{
+			return this;
+		}
+	}
+}


### PR DESCRIPTION
Fix issue #202.
- Commit 1 introduces a unit-test to demonstrate the issue.
- Commit 2 fixes the issue in `ExpressionBinaryOp#evaluate` by first trying to short-circuit and then falling back to `#apply?.