### PR TITLE
Refactor clone and adding a DeepCopy-Visitor

### DIFF
--- a/prism/src/parser/IdentUsage.java
+++ b/prism/src/parser/IdentUsage.java
@@ -34,7 +34,7 @@ import prism.PrismLangException;
 /**
  * Helper class to keep track of a set of identifiers that have been used.
  */
-public class IdentUsage
+public class IdentUsage implements Cloneable
 {
 	// Are these identifiers used in (double) quotes?
 	private boolean quoted = false;
@@ -125,11 +125,23 @@ public class IdentUsage
 		}
 	}
 
-	@SuppressWarnings("unchecked")
-	public IdentUsage deepCopy()
+	public IdentUsage deepCopyFields()
 	{
-		IdentUsage ret = new IdentUsage(quoted);
-		ret.identDecls = (HashMap<String, ASTElement>) identDecls.clone();
-		return ret;
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public IdentUsage clone()
+	{
+		try {
+			IdentUsage clone = (IdentUsage) super.clone();
+			clone.identDecls = (HashMap<String, ASTElement>) identDecls.clone();
+			clone.identUses = (HashMap<String, String>) identUses.clone();
+			clone.identLocs = (HashMap<String, String>) identLocs.clone();
+			return clone;
+		} catch (CloneNotSupportedException e) {
+			throw new InternalError("Object#clone is expected to work for Cloneable objects.", e);
+		}
 	}
 }

--- a/prism/src/parser/IdentUsage.java
+++ b/prism/src/parser/IdentUsage.java
@@ -125,9 +125,9 @@ public class IdentUsage implements Cloneable
 		}
 	}
 
-	public IdentUsage deepCopyFields()
+	public IdentUsage deepCopy()
 	{
-		return this;
+		return clone();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/ASTElement.java
+++ b/prism/src/parser/ast/ASTElement.java
@@ -37,6 +37,7 @@ import parser.Values;
 import parser.type.Type;
 import parser.visitor.ASTVisitor;
 import parser.visitor.ComputeProbNesting;
+import parser.visitor.DeepCopy;
 import parser.visitor.EvaluatePartially;
 import parser.visitor.ExpandConstants;
 import parser.visitor.ExpandFormulas;
@@ -220,13 +221,23 @@ public abstract class ASTElement implements Cloneable
 	 */
 	public ASTElement deepCopy()
 	{
-		return clone().deepCopyASTElements();
+		try {
+			return new DeepCopy().copy(this);
+		} catch (PrismLangException e) {
+			throw new Error(e);
+		}
 	}
 
 	/**
-	 * Copy all internal ASTElements (should be called after clone to create deep copy).
+	 * Perform a deep copy of all internal ASTElements using a deep copy visitor.
+	 * This method is usually called after {@code clone()} and must return the receiver.
+	 *
+	 * @param copier the copy visitor
+	 * @return the receiver with deep-copied subcomponents
+	 * @throws PrismLangException
+	 * @see #clone()
 	 */
-	public abstract ASTElement deepCopyASTElements();
+	public abstract ASTElement deepCopy(DeepCopy copier) throws PrismLangException;
 
 	/**
 	 * Perform a shallow copy of the receiver and

--- a/prism/src/parser/ast/ASTElement.java
+++ b/prism/src/parser/ast/ASTElement.java
@@ -26,12 +26,44 @@
 
 package parser.ast;
 
-import java.util.*;
+import parser.EvaluateContext;
+import parser.EvaluateContextConstants;
+import parser.EvaluateContextState;
+import parser.EvaluateContextSubstate;
+import parser.EvaluateContextValues;
+import parser.State;
+import parser.Token;
+import parser.Values;
+import parser.type.Type;
+import parser.visitor.ASTVisitor;
+import parser.visitor.ComputeProbNesting;
+import parser.visitor.EvaluatePartially;
+import parser.visitor.ExpandConstants;
+import parser.visitor.ExpandFormulas;
+import parser.visitor.ExpandLabels;
+import parser.visitor.ExpandPropRefsAndLabels;
+import parser.visitor.FindAllActions;
+import parser.visitor.FindAllConstants;
+import parser.visitor.FindAllFormulas;
+import parser.visitor.FindAllObsRefs;
+import parser.visitor.FindAllPropRefs;
+import parser.visitor.FindAllVars;
+import parser.visitor.GetAllConstants;
+import parser.visitor.GetAllFormulas;
+import parser.visitor.GetAllLabels;
+import parser.visitor.GetAllPropRefs;
+import parser.visitor.GetAllPropRefsRecursively;
+import parser.visitor.GetAllUndefinedConstantsRecursively;
+import parser.visitor.GetAllVars;
+import parser.visitor.Rename;
+import parser.visitor.SemanticCheck;
+import parser.visitor.Simplify;
+import parser.visitor.ToTreeString;
+import parser.visitor.TypeCheck;
+import prism.PrismLangException;
 
-import parser.*;
-import parser.type.*;
-import parser.visitor.*;
-import prism.*;
+import java.util.List;
+import java.util.Vector;
 
 // Abstract class for PRISM language AST elements
 
@@ -186,7 +218,15 @@ public abstract class ASTElement implements Cloneable
 	/**
 	 * Perform a deep copy.
 	 */
-	public abstract ASTElement deepCopy();
+	public ASTElement deepCopy()
+	{
+		return clone().deepCopyASTElements();
+	}
+
+	/**
+	 * Copy all internal ASTElements (should be called after clone to create deep copy).
+	 */
+	public abstract ASTElement deepCopyASTElements();
 
 	/**
 	 * Perform a shallow copy of the receiver and

--- a/prism/src/parser/ast/ASTElement.java
+++ b/prism/src/parser/ast/ASTElement.java
@@ -35,7 +35,7 @@ import prism.*;
 
 // Abstract class for PRISM language AST elements
 
-public abstract class ASTElement
+public abstract class ASTElement implements Cloneable
 {
 	// Type - default to null (unknown)
 	protected Type type = null;
@@ -187,6 +187,20 @@ public abstract class ASTElement
 	 * Perform a deep copy.
 	 */
 	public abstract ASTElement deepCopy();
+
+	/**
+	 * Perform a shallow copy of the receiver and
+	 * clone all internal containers, e.g., lists and vectors, too.
+	 */
+	@Override
+	public ASTElement clone()
+	{
+		try {
+			return (ASTElement) super.clone();
+		} catch (CloneNotSupportedException e) {
+			throw new InternalError("Object#clone is expected to work for Cloneable objects", e);
+		}
+	}
 
 	// Various methods based on AST traversals (implemented using the visitor
 	// pattern):

--- a/prism/src/parser/ast/Command.java
+++ b/prism/src/parser/ast/Command.java
@@ -26,7 +26,7 @@
 
 package parser.ast;
 
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
 import prism.PrismLangException;
 
 public class Command extends ASTElement
@@ -138,18 +138,13 @@ public class Command extends ASTElement
 		return s;
 	}
 	
-	/**
-	 * Perform a deep copy.
-	 */
-	public ASTElement deepCopy()
+	@Override
+	public Command deepCopyASTElements()
 	{
-		Command ret = new Command();
-		ret.setSynch(getSynch());
-		ret.setSynchIndex(getSynchIndex());
-		ret.setGuard(getGuard().deepCopy());
-		ret.setUpdates((Updates)getUpdates().deepCopy());
-		ret.setPosition(this);
-		return ret;
+		guard = guard.clone().deepCopyASTElements();
+		updates = updates.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/Command.java
+++ b/prism/src/parser/ast/Command.java
@@ -151,6 +151,12 @@ public class Command extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public Command clone()
+	{
+		return (Command) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/Command.java
+++ b/prism/src/parser/ast/Command.java
@@ -27,6 +27,7 @@
 package parser.ast;
 
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class Command extends ASTElement
@@ -139,10 +140,10 @@ public class Command extends ASTElement
 	}
 	
 	@Override
-	public Command deepCopyASTElements()
+	public Command deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		guard = guard.clone().deepCopyASTElements();
-		updates = updates.clone().deepCopyASTElements();
+		guard = copier.copy(guard);
+		setUpdates(copier.copy(updates));
 
 		return this;
 	}

--- a/prism/src/parser/ast/ConstantList.java
+++ b/prism/src/parser/ast/ConstantList.java
@@ -492,6 +492,20 @@ public class ConstantList extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public ConstantList clone()
+	{
+		ConstantList clone = (ConstantList) super.clone();
+
+		clone.names      = (Vector<String>)          names.clone();
+		clone.constants  = (Vector<Expression>)      constants.clone();
+		clone.types      = (Vector<Type>)            types.clone();
+		clone.nameIdents = (Vector<ExpressionIdent>) nameIdents.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/ConstantList.java
+++ b/prism/src/parser/ast/ConstantList.java
@@ -478,10 +478,10 @@ public class ConstantList extends ASTElement
 	}
 	
 	@Override
-	public ConstantList deepCopyASTElements()
+	public ConstantList deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		constants.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
-		nameIdents.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		copier.copyAll(constants);
+		copier.copyAll(nameIdents);
 
 		return this;
 	}

--- a/prism/src/parser/ast/ConstantList.java
+++ b/prism/src/parser/ast/ConstantList.java
@@ -477,20 +477,13 @@ public class ConstantList extends ASTElement
 		return s;
 	}
 	
-	/**
-	 * Perform a deep copy.
-	 */
-	public ASTElement deepCopy()
+	@Override
+	public ConstantList deepCopyASTElements()
 	{
-		int i, n;
-		ConstantList ret = new ConstantList();
-		n = size();
-		for (i = 0; i < n; i++) {
-			Expression constantNew = (getConstant(i) == null) ? null : getConstant(i).deepCopy();
-			ret.addConstant((ExpressionIdent)getConstantNameIdent(i).deepCopy(), constantNew, getConstantType(i));
-		}
-		ret.setPosition(this);
-		return ret;
+		constants.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		nameIdents.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/Declaration.java
+++ b/prism/src/parser/ast/Declaration.java
@@ -150,6 +150,12 @@ public class Declaration extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public Declaration clone()
+	{
+		return (Declaration) super.clone();
+	}
 }
 
 // ------------------------------------------------------------------------------

--- a/prism/src/parser/ast/Declaration.java
+++ b/prism/src/parser/ast/Declaration.java
@@ -138,17 +138,12 @@ public class Declaration extends ASTElement
 		return s;
 	}
 
-	/**
-	 * Perform a deep copy.
-	 */
 	@Override
-	public ASTElement deepCopy()
+	public Declaration deepCopyASTElements()
 	{
-		Declaration ret = new Declaration(getName(), (DeclarationType)getDeclType().deepCopy());
-		if (getStart() != null)
-			ret.setStart(getStart().deepCopy());
-		ret.setPosition(this);
-		return ret;
+		declType = declType.clone().deepCopyASTElements();
+		start = (start == null) ? null : start.clone().deepCopyASTElements();
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/Declaration.java
+++ b/prism/src/parser/ast/Declaration.java
@@ -27,7 +27,8 @@
 
 package parser.ast;
 
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 /**
@@ -139,10 +140,10 @@ public class Declaration extends ASTElement
 	}
 
 	@Override
-	public Declaration deepCopyASTElements()
+	public Declaration deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		declType = declType.clone().deepCopyASTElements();
-		start = (start == null) ? null : start.clone().deepCopyASTElements();
+		declType = copier.copy(declType);
+		start = copier.copy(start);
 		return this;
 	}
 

--- a/prism/src/parser/ast/DeclarationArray.java
+++ b/prism/src/parser/ast/DeclarationArray.java
@@ -134,4 +134,10 @@ public class DeclarationArray extends DeclarationType
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public DeclarationArray clone()
+	{
+		return (DeclarationArray) super.clone();
+	}
 }

--- a/prism/src/parser/ast/DeclarationArray.java
+++ b/prism/src/parser/ast/DeclarationArray.java
@@ -29,6 +29,7 @@ package parser.ast;
 
 import parser.type.TypeArray;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class DeclarationArray extends DeclarationType
@@ -125,11 +126,11 @@ public class DeclarationArray extends DeclarationType
 	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
 	@Override
-	public DeclarationArray deepCopyASTElements()
+	public DeclarationArray deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		low = low.clone().deepCopyASTElements();
-		high = high.clone().deepCopyASTElements();
-		subtype = subtype.clone().deepCopyASTElements();
+		low = copier.copy(low);
+		high = copier.copy(high);
+		subtype = copier.copy(subtype);
 
 		return this;
 	}

--- a/prism/src/parser/ast/DeclarationArray.java
+++ b/prism/src/parser/ast/DeclarationArray.java
@@ -27,7 +27,7 @@
 
 package parser.ast;
 
-import parser.type.*;
+import parser.type.TypeArray;
 import parser.visitor.ASTVisitor;
 import prism.PrismLangException;
 
@@ -122,17 +122,16 @@ public class DeclarationArray extends DeclarationType
 	}
 
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
 	@Override
-	public ASTElement deepCopy()
+	public DeclarationArray deepCopyASTElements()
 	{
-		Expression lowCopy = (low == null) ? null : low.deepCopy();
-		Expression highCopy = (high == null) ? null : high.deepCopy();
-		DeclarationType subtypeCopy = (DeclarationType) subtype.deepCopy();
-		DeclarationArray ret = new DeclarationArray(lowCopy, highCopy, subtypeCopy);
-		ret.setPosition(this);
-		return ret;
+		low = low.clone().deepCopyASTElements();
+		high = high.clone().deepCopyASTElements();
+		subtype = subtype.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/DeclarationBool.java
+++ b/prism/src/parser/ast/DeclarationBool.java
@@ -29,6 +29,7 @@ package parser.ast;
 
 import parser.type.TypeBool;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class DeclarationBool extends DeclarationType
@@ -62,7 +63,7 @@ public class DeclarationBool extends DeclarationType
 	}
 
 	@Override
-	public DeclarationBool deepCopyASTElements()
+	public DeclarationBool deepCopy(DeepCopy copier)
 	{
 		return this;
 	}

--- a/prism/src/parser/ast/DeclarationBool.java
+++ b/prism/src/parser/ast/DeclarationBool.java
@@ -68,4 +68,10 @@ public class DeclarationBool extends DeclarationType
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public DeclarationBool clone()
+	{
+		return (DeclarationBool) super.clone();
+	}
 }

--- a/prism/src/parser/ast/DeclarationBool.java
+++ b/prism/src/parser/ast/DeclarationBool.java
@@ -62,11 +62,9 @@ public class DeclarationBool extends DeclarationType
 	}
 
 	@Override
-	public ASTElement deepCopy()
+	public DeclarationBool deepCopyASTElements()
 	{
-		DeclarationBool ret = new DeclarationBool();
-		ret.setPosition(this);
-		return ret;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/DeclarationClock.java
+++ b/prism/src/parser/ast/DeclarationClock.java
@@ -26,8 +26,9 @@
 
 package parser.ast;
 
-import parser.type.*;
+import parser.type.TypeClock;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class DeclarationClock extends DeclarationType
@@ -61,7 +62,7 @@ public class DeclarationClock extends DeclarationType
 	}
 
 	@Override
-	public DeclarationClock deepCopyASTElements()
+	public DeclarationClock deepCopy(DeepCopy copier)
 	{
 		return this;
 	}

--- a/prism/src/parser/ast/DeclarationClock.java
+++ b/prism/src/parser/ast/DeclarationClock.java
@@ -61,11 +61,9 @@ public class DeclarationClock extends DeclarationType
 	}
 
 	@Override
-	public ASTElement deepCopy()
+	public DeclarationClock deepCopyASTElements()
 	{
-		DeclarationClock ret = new DeclarationClock();
-		ret.setPosition(this);
-		return ret;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/DeclarationClock.java
+++ b/prism/src/parser/ast/DeclarationClock.java
@@ -67,4 +67,10 @@ public class DeclarationClock extends DeclarationType
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public DeclarationClock clone()
+	{
+		return (DeclarationClock) super.clone();
+	}
 }

--- a/prism/src/parser/ast/DeclarationInt.java
+++ b/prism/src/parser/ast/DeclarationInt.java
@@ -89,13 +89,12 @@ public class DeclarationInt extends DeclarationType
 	}
 
 	@Override
-	public ASTElement deepCopy()
+	public DeclarationInt deepCopyASTElements()
 	{
-		Expression lowCopy = (low == null) ? null : low.deepCopy();
-		Expression highCopy = (high == null) ? null : high.deepCopy();
-		DeclarationInt ret = new DeclarationInt(lowCopy, highCopy);
-		ret.setPosition(this);
-		return ret;
+		low = (low == null) ? null : low.clone().deepCopyASTElements();
+		high = (high == null) ? null : high.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/DeclarationInt.java
+++ b/prism/src/parser/ast/DeclarationInt.java
@@ -27,8 +27,9 @@
 
 package parser.ast;
 
-import parser.type.*;
+import parser.type.TypeInt;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class DeclarationInt extends DeclarationType
@@ -89,10 +90,10 @@ public class DeclarationInt extends DeclarationType
 	}
 
 	@Override
-	public DeclarationInt deepCopyASTElements()
+	public DeclarationInt deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		low = (low == null) ? null : low.clone().deepCopyASTElements();
-		high = (high == null) ? null : high.clone().deepCopyASTElements();
+		low = copier.copy(low);
+		high = copier.copy(high);
 
 		return this;
 	}

--- a/prism/src/parser/ast/DeclarationInt.java
+++ b/prism/src/parser/ast/DeclarationInt.java
@@ -97,4 +97,10 @@ public class DeclarationInt extends DeclarationType
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public DeclarationInt clone()
+	{
+		return (DeclarationInt) super.clone();
+	}
 }

--- a/prism/src/parser/ast/DeclarationIntUnbounded.java
+++ b/prism/src/parser/ast/DeclarationIntUnbounded.java
@@ -67,4 +67,10 @@ public class DeclarationIntUnbounded extends DeclarationType
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public DeclarationIntUnbounded clone()
+	{
+		return (DeclarationIntUnbounded) super.clone();
+	}
 }

--- a/prism/src/parser/ast/DeclarationIntUnbounded.java
+++ b/prism/src/parser/ast/DeclarationIntUnbounded.java
@@ -61,11 +61,9 @@ public class DeclarationIntUnbounded extends DeclarationType
 	}
 
 	@Override
-	public ASTElement deepCopy()
+	public DeclarationIntUnbounded deepCopyASTElements()
 	{
-		DeclarationIntUnbounded ret = new DeclarationIntUnbounded();
-		ret.setPosition(this);
-		return ret;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/DeclarationIntUnbounded.java
+++ b/prism/src/parser/ast/DeclarationIntUnbounded.java
@@ -28,6 +28,7 @@ package parser.ast;
 
 import parser.type.*;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class DeclarationIntUnbounded extends DeclarationType
@@ -61,7 +62,7 @@ public class DeclarationIntUnbounded extends DeclarationType
 	}
 
 	@Override
-	public DeclarationIntUnbounded deepCopyASTElements()
+	public DeclarationIntUnbounded deepCopy(DeepCopy copier)
 	{
 		return this;
 	}

--- a/prism/src/parser/ast/DeclarationType.java
+++ b/prism/src/parser/ast/DeclarationType.java
@@ -33,4 +33,10 @@ public abstract class DeclarationType extends ASTElement
 	 * Return the default start value for a variable of this type, as an Expression.
 	 */
 	public abstract Expression getDefaultStart();
+
+	@Override
+	public DeclarationType clone()
+	{
+		return (DeclarationType) super.clone();
+	}
 }

--- a/prism/src/parser/ast/DeclarationType.java
+++ b/prism/src/parser/ast/DeclarationType.java
@@ -34,6 +34,12 @@ public abstract class DeclarationType extends ASTElement
 	 */
 	public abstract Expression getDefaultStart();
 
+	/**
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
+	 */
+	@Override
+	public abstract DeclarationType deepCopyASTElements();
+
 	@Override
 	public DeclarationType clone()
 	{

--- a/prism/src/parser/ast/DeclarationType.java
+++ b/prism/src/parser/ast/DeclarationType.java
@@ -27,6 +27,9 @@
 
 package parser.ast;
 
+import parser.visitor.DeepCopy;
+import prism.PrismLangException;
+
 public abstract class DeclarationType extends ASTElement
 {
 	/**
@@ -38,7 +41,7 @@ public abstract class DeclarationType extends ASTElement
 	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
 	@Override
-	public abstract DeclarationType deepCopyASTElements();
+	public abstract DeclarationType deepCopy(DeepCopy copier) throws PrismLangException;
 
 	@Override
 	public DeclarationType clone()

--- a/prism/src/parser/ast/Expression.java
+++ b/prism/src/parser/ast/Expression.java
@@ -126,6 +126,13 @@ public abstract class Expression extends ASTElement
 	 */
 	public abstract Expression deepCopy();
 
+	// Override version of clone() from superclass (to reduce casting).
+	@Override
+	public Expression clone()
+	{
+		return (Expression) super.clone();
+	}
+
 	// Utility methods:
 
 	/**

--- a/prism/src/parser/ast/Expression.java
+++ b/prism/src/parser/ast/Expression.java
@@ -44,6 +44,7 @@ import parser.type.TypePathBool;
 import parser.visitor.ASTTraverse;
 import parser.visitor.CheckValid;
 import parser.visitor.ConvertForJltl2ba;
+import parser.visitor.DeepCopy;
 import parser.visitor.ExpressionTraverseNonNested;
 import prism.ModelType;
 import prism.PrismException;
@@ -119,10 +120,10 @@ public abstract class Expression extends ASTElement
 	 */
 	public abstract boolean returnsSingleValue();
 	
-	// Overwritten version of deepCopy() and deepCopyASTElements() from superclass ASTElement (to reduce casting).
+	// Overwritten version of deepCopy() and deepCopy(DeepCopy copier) from superclass ASTElement (to reduce casting).
 
 	@Override
-	public abstract Expression deepCopyASTElements();
+	public abstract Expression deepCopy(DeepCopy copier) throws PrismLangException;
 
 	/**
 	 * Perform a deep copy.

--- a/prism/src/parser/ast/Expression.java
+++ b/prism/src/parser/ast/Expression.java
@@ -119,12 +119,19 @@ public abstract class Expression extends ASTElement
 	 */
 	public abstract boolean returnsSingleValue();
 	
-	// Overrided version of deepCopy() from superclass ASTElement (to reduce casting).
+	// Overwritten version of deepCopy() and deepCopyASTElements() from superclass ASTElement (to reduce casting).
+
+	@Override
+	public abstract Expression deepCopyASTElements();
 
 	/**
 	 * Perform a deep copy.
 	 */
-	public abstract Expression deepCopy();
+	@Override
+	public Expression deepCopy()
+	{
+		return (Expression) super.deepCopy();
+	}
 
 	// Override version of clone() from superclass (to reduce casting).
 	@Override

--- a/prism/src/parser/ast/ExpressionBinaryOp.java
+++ b/prism/src/parser/ast/ExpressionBinaryOp.java
@@ -342,6 +342,12 @@ public class ExpressionBinaryOp extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionBinaryOp clone()
+	{
+		return (ExpressionBinaryOp) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionBinaryOp.java
+++ b/prism/src/parser/ast/ExpressionBinaryOp.java
@@ -34,6 +34,7 @@ import parser.EvaluateContext.EvalMode;
 import parser.type.TypeDouble;
 import parser.type.TypeInt;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class ExpressionBinaryOp extends Expression
@@ -334,10 +335,10 @@ public class ExpressionBinaryOp extends Expression
 	}
 
 	@Override
-	public ExpressionBinaryOp deepCopyASTElements()
+	public ExpressionBinaryOp deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		operand1 = operand1.clone().deepCopyASTElements();
-		operand2 = operand2.clone().deepCopyASTElements();
+		operand1 = copier.copy(operand1);
+		operand2 = copier.copy(operand2);
 
 		return this;
 	}

--- a/prism/src/parser/ast/ExpressionBinaryOp.java
+++ b/prism/src/parser/ast/ExpressionBinaryOp.java
@@ -334,12 +334,12 @@ public class ExpressionBinaryOp extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionBinaryOp deepCopyASTElements()
 	{
-		ExpressionBinaryOp expr = new ExpressionBinaryOp(op, operand1.deepCopy(), operand2.deepCopy());
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		operand1 = operand1.clone().deepCopyASTElements();
+		operand2 = operand2.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionConstant.java
+++ b/prism/src/parser/ast/ExpressionConstant.java
@@ -108,6 +108,12 @@ public class ExpressionConstant extends Expression
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public ExpressionConstant clone()
+	{
+		return (ExpressionConstant) super.clone();
+	}
 	
 	// Standard methods
 	

--- a/prism/src/parser/ast/ExpressionConstant.java
+++ b/prism/src/parser/ast/ExpressionConstant.java
@@ -29,6 +29,7 @@ package parser.ast;
 import parser.EvaluateContext;
 import parser.type.Type;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class ExpressionConstant extends Expression
@@ -102,7 +103,7 @@ public class ExpressionConstant extends Expression
 	}
 	
 	@Override
-	public ExpressionConstant deepCopyASTElements()
+	public ExpressionConstant deepCopy(DeepCopy copier)
 	{
 		return this;
 	}

--- a/prism/src/parser/ast/ExpressionConstant.java
+++ b/prism/src/parser/ast/ExpressionConstant.java
@@ -102,11 +102,9 @@ public class ExpressionConstant extends Expression
 	}
 	
 	@Override
-	public Expression deepCopy()
+	public ExpressionConstant deepCopyASTElements()
 	{
-		Expression ret = new ExpressionConstant(name, type);
-		ret.setPosition(this);
-		return ret;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionExists.java
+++ b/prism/src/parser/ast/ExpressionExists.java
@@ -102,6 +102,12 @@ public class ExpressionExists extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionExists clone()
+	{
+		return (ExpressionExists) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionExists.java
+++ b/prism/src/parser/ast/ExpressionExists.java
@@ -28,6 +28,7 @@ package parser.ast;
 
 import parser.EvaluateContext;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class ExpressionExists extends Expression
@@ -94,9 +95,9 @@ public class ExpressionExists extends Expression
 	}
 	
 	@Override
-	public ExpressionExists deepCopyASTElements()
+	public ExpressionExists deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		expression = expression.clone().deepCopyASTElements();
+		expression = copier.copy(expression);
 
 		return this;
 	}

--- a/prism/src/parser/ast/ExpressionExists.java
+++ b/prism/src/parser/ast/ExpressionExists.java
@@ -94,12 +94,11 @@ public class ExpressionExists extends Expression
 	}
 	
 	@Override
-	public Expression deepCopy()
+	public ExpressionExists deepCopyASTElements()
 	{
-		ExpressionExists expr = new ExpressionExists(expression.deepCopy());
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		expression = expression.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionFilter.java
+++ b/prism/src/parser/ast/ExpressionFilter.java
@@ -32,6 +32,7 @@ import parser.type.TypeBool;
 import parser.type.TypeDouble;
 import parser.type.TypeInt;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.Accuracy;
 import prism.PrismException;
 import prism.PrismLangException;
@@ -484,10 +485,10 @@ public class ExpressionFilter extends Expression
 	}
 
 	@Override
-	public ExpressionFilter deepCopyASTElements()
+	public ExpressionFilter deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		operand = operand.clone().deepCopyASTElements();
-		filter = (filter == null) ? null : filter.clone().deepCopyASTElements();
+		operand = copier.copy(operand);
+		filter = copier.copy(filter);
 
 		return this;
 	}

--- a/prism/src/parser/ast/ExpressionFilter.java
+++ b/prism/src/parser/ast/ExpressionFilter.java
@@ -495,6 +495,12 @@ public class ExpressionFilter extends Expression
 
 		return e;
 	}
+
+	@Override
+	public ExpressionFilter clone()
+	{
+		return (ExpressionFilter) super.clone();
+	}
 	
 	// Standard methods
 	

--- a/prism/src/parser/ast/ExpressionFilter.java
+++ b/prism/src/parser/ast/ExpressionFilter.java
@@ -484,16 +484,12 @@ public class ExpressionFilter extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionFilter deepCopyASTElements()
 	{
-		ExpressionFilter e;
-		e = new ExpressionFilter(opName, operand.deepCopy(), filter == null ? null : filter.deepCopy());
-		e.setInvisible(invisible);
-		e.setType(type);
-		e.setPosition(this);
-		e.param = this.param;
+		operand = operand.clone().deepCopyASTElements();
+		filter = (filter == null) ? null : filter.clone().deepCopyASTElements();
 
-		return e;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionForAll.java
+++ b/prism/src/parser/ast/ExpressionForAll.java
@@ -94,12 +94,11 @@ public class ExpressionForAll extends Expression
 	}
 	
 	@Override
-	public Expression deepCopy()
+	public ExpressionForAll deepCopyASTElements()
 	{
-		ExpressionForAll expr = new ExpressionForAll(expression.deepCopy());
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		expression = expression.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionForAll.java
+++ b/prism/src/parser/ast/ExpressionForAll.java
@@ -102,6 +102,12 @@ public class ExpressionForAll extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionForAll clone()
+	{
+		return (ExpressionForAll) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionForAll.java
+++ b/prism/src/parser/ast/ExpressionForAll.java
@@ -28,6 +28,7 @@ package parser.ast;
 
 import parser.EvaluateContext;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class ExpressionForAll extends Expression
@@ -94,9 +95,9 @@ public class ExpressionForAll extends Expression
 	}
 	
 	@Override
-	public ExpressionForAll deepCopyASTElements()
+	public ExpressionForAll deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		expression = expression.clone().deepCopyASTElements();
+		expression = copier.copy(expression);
 
 		return this;
 	}

--- a/prism/src/parser/ast/ExpressionFormula.java
+++ b/prism/src/parser/ast/ExpressionFormula.java
@@ -121,6 +121,12 @@ public class ExpressionFormula extends Expression
 		return ret;
 	}
 
+	@Override
+	public ExpressionFormula clone()
+	{
+		return (ExpressionFormula) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionFormula.java
+++ b/prism/src/parser/ast/ExpressionFormula.java
@@ -113,12 +113,11 @@ public class ExpressionFormula extends Expression
 	}
 		
 	@Override
-	public Expression deepCopy()
+	public ExpressionFormula deepCopyASTElements()
 	{
-		ExpressionFormula ret = new ExpressionFormula(name);
-		ret.setDefinition(definition == null ? null : definition.deepCopy());
-		ret.setPosition(this);
-		return ret;
+		definition = (definition == null) ? null : definition.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionFormula.java
+++ b/prism/src/parser/ast/ExpressionFormula.java
@@ -28,6 +28,7 @@ package parser.ast;
 
 import parser.EvaluateContext;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class ExpressionFormula extends Expression
@@ -113,9 +114,9 @@ public class ExpressionFormula extends Expression
 	}
 		
 	@Override
-	public ExpressionFormula deepCopyASTElements()
+	public ExpressionFormula deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		definition = (definition == null) ? null : definition.clone().deepCopyASTElements();
+		definition = copier.copy(definition);
 
 		return this;
 	}

--- a/prism/src/parser/ast/ExpressionFunc.java
+++ b/prism/src/parser/ast/ExpressionFunc.java
@@ -33,6 +33,7 @@ import parser.EvaluateContext.EvalMode;
 import parser.type.TypeDouble;
 import parser.type.TypeInt;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 import prism.PrismUtils;
 
@@ -615,9 +616,9 @@ public class ExpressionFunc extends Expression
 	}
 
 	@Override
-	public ExpressionFunc deepCopyASTElements()
+	public ExpressionFunc deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		operands.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		copier.copyAll(operands);
 
 		return this;
 	}

--- a/prism/src/parser/ast/ExpressionFunc.java
+++ b/prism/src/parser/ast/ExpressionFunc.java
@@ -615,21 +615,11 @@ public class ExpressionFunc extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionFunc deepCopyASTElements()
 	{
-		int i, n;
-		ExpressionFunc e;
+		operands.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
 
-		e = new ExpressionFunc(name);
-		e.setOldStyle(oldStyle);
-		n = getNumOperands();
-		for (i = 0; i < n; i++) {
-			e.addOperand((Expression) getOperand(i).deepCopy());
-		}
-		e.setType(type);
-		e.setPosition(this);
-
-		return e;
+		return this;
 	}
 
 

--- a/prism/src/parser/ast/ExpressionFunc.java
+++ b/prism/src/parser/ast/ExpressionFunc.java
@@ -26,17 +26,18 @@
 
 package parser.ast;
 
-import java.math.BigInteger;
-import java.util.ArrayList;
-
 import common.SafeCast;
 import param.BigRational;
-import parser.*;
+import parser.EvaluateContext;
 import parser.EvaluateContext.EvalMode;
-import parser.visitor.*;
+import parser.type.TypeDouble;
+import parser.type.TypeInt;
+import parser.visitor.ASTVisitor;
 import prism.PrismLangException;
 import prism.PrismUtils;
-import parser.type.*;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
 
 public class ExpressionFunc extends Expression
 {
@@ -629,6 +630,18 @@ public class ExpressionFunc extends Expression
 		e.setPosition(this);
 
 		return e;
+	}
+
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public ExpressionFunc clone()
+	{
+		ExpressionFunc clone = (ExpressionFunc) super.clone();
+
+		clone.operands = (ArrayList<Expression>) operands.clone();
+
+		return clone;
 	}
 	
 	// Standard methods

--- a/prism/src/parser/ast/ExpressionITE.java
+++ b/prism/src/parser/ast/ExpressionITE.java
@@ -137,6 +137,12 @@ public class ExpressionITE extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionITE clone()
+	{
+		return (ExpressionITE) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionITE.java
+++ b/prism/src/parser/ast/ExpressionITE.java
@@ -30,6 +30,7 @@ import parser.EvaluateContext;
 import parser.EvaluateContext.EvalMode;
 import parser.type.TypeBool;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class ExpressionITE extends Expression
@@ -129,11 +130,11 @@ public class ExpressionITE extends Expression
 	}
 
 	@Override
-	public ExpressionITE deepCopyASTElements()
+	public ExpressionITE deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		operand1 = operand1.clone().deepCopyASTElements();
-		operand2 = operand2.clone().deepCopyASTElements();
-		operand3 = operand3.clone().deepCopyASTElements();
+		operand1 = copier.copy(operand1);
+		operand2 = copier.copy(operand2);
+		operand3 = copier.copy(operand3);
 
 		return this;
 	}

--- a/prism/src/parser/ast/ExpressionITE.java
+++ b/prism/src/parser/ast/ExpressionITE.java
@@ -129,12 +129,13 @@ public class ExpressionITE extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionITE deepCopyASTElements()
 	{
-		ExpressionITE expr = new ExpressionITE(operand1.deepCopy(), operand2.deepCopy(), operand3.deepCopy());
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		operand1 = operand1.clone().deepCopyASTElements();
+		operand2 = operand2.clone().deepCopyASTElements();
+		operand3 = operand3.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionIdent.java
+++ b/prism/src/parser/ast/ExpressionIdent.java
@@ -107,6 +107,12 @@ public class ExpressionIdent extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionIdent clone()
+	{
+		return (ExpressionIdent) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionIdent.java
+++ b/prism/src/parser/ast/ExpressionIdent.java
@@ -28,6 +28,7 @@ package parser.ast;
 
 import parser.EvaluateContext;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class ExpressionIdent extends Expression
@@ -99,7 +100,7 @@ public class ExpressionIdent extends Expression
 	}
 	
 	@Override
-	public ExpressionIdent deepCopyASTElements()
+	public ExpressionIdent deepCopy(DeepCopy copier)
 	{
 		return this;
 	}

--- a/prism/src/parser/ast/ExpressionIdent.java
+++ b/prism/src/parser/ast/ExpressionIdent.java
@@ -99,12 +99,9 @@ public class ExpressionIdent extends Expression
 	}
 	
 	@Override
-	public Expression deepCopy()
+	public ExpressionIdent deepCopyASTElements()
 	{
-		ExpressionIdent expr = new ExpressionIdent(name);
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionLabel.java
+++ b/prism/src/parser/ast/ExpressionLabel.java
@@ -100,12 +100,9 @@ public class ExpressionLabel extends Expression
 	}
 	
 	@Override
-	public Expression deepCopy()
+	public ExpressionLabel deepCopyASTElements()
 	{
-		ExpressionLabel expr = new ExpressionLabel(name);
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionLabel.java
+++ b/prism/src/parser/ast/ExpressionLabel.java
@@ -28,6 +28,7 @@ package parser.ast;
 
 import parser.EvaluateContext;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class ExpressionLabel extends Expression
@@ -100,7 +101,7 @@ public class ExpressionLabel extends Expression
 	}
 	
 	@Override
-	public ExpressionLabel deepCopyASTElements()
+	public ExpressionLabel deepCopy(DeepCopy copier)
 	{
 		return this;
 	}

--- a/prism/src/parser/ast/ExpressionLabel.java
+++ b/prism/src/parser/ast/ExpressionLabel.java
@@ -108,6 +108,12 @@ public class ExpressionLabel extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionLabel clone()
+	{
+		return (ExpressionLabel) super.clone();
+	}
+
 	// Standard methods
 
 	@Override

--- a/prism/src/parser/ast/ExpressionLiteral.java
+++ b/prism/src/parser/ast/ExpressionLiteral.java
@@ -133,11 +133,9 @@ public class ExpressionLiteral extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionLiteral deepCopyASTElements()
 	{
-		Expression expr = new ExpressionLiteral(type, value, string);
-		expr.setPosition(this);
-		return expr;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionLiteral.java
+++ b/prism/src/parser/ast/ExpressionLiteral.java
@@ -35,6 +35,7 @@ import parser.type.Type;
 import parser.type.TypeDouble;
 import parser.type.TypeInt;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 public class ExpressionLiteral extends Expression
 {
@@ -133,7 +134,7 @@ public class ExpressionLiteral extends Expression
 	}
 
 	@Override
-	public ExpressionLiteral deepCopyASTElements()
+	public ExpressionLiteral deepCopy(DeepCopy copier)
 	{
 		return this;
 	}

--- a/prism/src/parser/ast/ExpressionLiteral.java
+++ b/prism/src/parser/ast/ExpressionLiteral.java
@@ -140,6 +140,12 @@ public class ExpressionLiteral extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionLiteral clone()
+	{
+		return (ExpressionLiteral) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionObs.java
+++ b/prism/src/parser/ast/ExpressionObs.java
@@ -122,6 +122,12 @@ public class ExpressionObs extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionObs clone()
+	{
+		return (ExpressionObs) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionObs.java
+++ b/prism/src/parser/ast/ExpressionObs.java
@@ -113,13 +113,9 @@ public class ExpressionObs extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionObs deepCopyASTElements()
 	{
-		ExpressionObs expr = new ExpressionObs(name);
-		expr.setType(type);
-		expr.setIndex(index);
-		expr.setPosition(this);
-		return expr;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionObs.java
+++ b/prism/src/parser/ast/ExpressionObs.java
@@ -28,6 +28,7 @@ package parser.ast;
 
 import parser.EvaluateContext;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 /*
@@ -113,7 +114,7 @@ public class ExpressionObs extends Expression
 	}
 
 	@Override
-	public ExpressionObs deepCopyASTElements()
+	public ExpressionObs deepCopy(DeepCopy copier)
 	{
 		return this;
 	}

--- a/prism/src/parser/ast/ExpressionProb.java
+++ b/prism/src/parser/ast/ExpressionProb.java
@@ -139,16 +139,11 @@ public class ExpressionProb extends ExpressionQuant
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionProb deepCopyASTElements()
 	{
-		ExpressionProb expr = new ExpressionProb();
-		expr.setExpression(getExpression() == null ? null : getExpression().deepCopy());
-		expr.setRelOp(getRelOp());
-		expr.setBound(getBound() == null ? null : getBound().deepCopy());
-		expr.setFilter(getFilter() == null ? null : (Filter)getFilter().deepCopy());
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		super.deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionProb.java
+++ b/prism/src/parser/ast/ExpressionProb.java
@@ -29,6 +29,7 @@ package parser.ast;
 import parser.EvaluateContext;
 import parser.Values;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.OpRelOpBound;
 import prism.PrismLangException;
 
@@ -139,10 +140,9 @@ public class ExpressionProb extends ExpressionQuant
 	}
 
 	@Override
-	public ExpressionProb deepCopyASTElements()
+	public ExpressionProb deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		super.deepCopyASTElements();
-
+		super.deepCopy(copier);
 		return this;
 	}
 

--- a/prism/src/parser/ast/ExpressionProb.java
+++ b/prism/src/parser/ast/ExpressionProb.java
@@ -151,6 +151,12 @@ public class ExpressionProb extends ExpressionQuant
 		return expr;
 	}
 
+	@Override
+	public ExpressionProb clone()
+	{
+		return (ExpressionProb) super.clone();
+	}
+
 	// Standard methods
 
 	@Override

--- a/prism/src/parser/ast/ExpressionProp.java
+++ b/prism/src/parser/ast/ExpressionProp.java
@@ -96,6 +96,12 @@ public class ExpressionProp extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionProp clone()
+	{
+		return (ExpressionProp) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionProp.java
+++ b/prism/src/parser/ast/ExpressionProp.java
@@ -88,12 +88,9 @@ public class ExpressionProp extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionProp deepCopyASTElements()
 	{
-		ExpressionProp expr = new ExpressionProp(name);
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionProp.java
+++ b/prism/src/parser/ast/ExpressionProp.java
@@ -28,6 +28,7 @@ package parser.ast;
 
 import parser.EvaluateContext;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 /**
@@ -88,7 +89,7 @@ public class ExpressionProp extends Expression
 	}
 
 	@Override
-	public ExpressionProp deepCopyASTElements()
+	public ExpressionProp deepCopy(DeepCopy copier)
 	{
 		return this;
 	}

--- a/prism/src/parser/ast/ExpressionQuant.java
+++ b/prism/src/parser/ast/ExpressionQuant.java
@@ -27,8 +27,10 @@
 package parser.ast;
 
 import parser.Values;
+import parser.visitor.DeepCopy;
 import prism.OpRelOpBound;
 import prism.PrismException;
+import prism.PrismLangException;
 
 /**
  * Abstract class for representing "quantitative" operators (P,R,S),
@@ -170,11 +172,11 @@ public abstract class ExpressionQuant extends Expression
 	}
 	
 	@Override
-	public ExpressionQuant deepCopyASTElements()
+	public ExpressionQuant deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		bound = (bound == null) ? null : bound.clone().deepCopyASTElements();
-		filter = (filter == null) ? null : filter.clone().deepCopyASTElements();
-		expression = (expression == null) ? null : expression.clone().deepCopyASTElements();
+		bound = copier.copy(bound);
+		filter = copier.copy(filter);
+		expression = copier.copy(expression);
 
 		return this;
 	}

--- a/prism/src/parser/ast/ExpressionQuant.java
+++ b/prism/src/parser/ast/ExpressionQuant.java
@@ -162,6 +162,12 @@ public abstract class ExpressionQuant extends Expression
 	}
 
 	// Standard methods
+
+	@Override
+	public ExpressionQuant clone()
+	{
+		return (ExpressionQuant) super.clone();
+	}
 	
 	@Override
 	public int hashCode()

--- a/prism/src/parser/ast/ExpressionQuant.java
+++ b/prism/src/parser/ast/ExpressionQuant.java
@@ -170,6 +170,16 @@ public abstract class ExpressionQuant extends Expression
 	}
 	
 	@Override
+	public ExpressionQuant deepCopyASTElements()
+	{
+		bound = (bound == null) ? null : bound.clone().deepCopyASTElements();
+		filter = (filter == null) ? null : filter.clone().deepCopyASTElements();
+		expression = (expression == null) ? null : expression.clone().deepCopyASTElements();
+
+		return this;
+	}
+
+	@Override
 	public int hashCode()
 	{
 		final int prime = 31;

--- a/prism/src/parser/ast/ExpressionReward.java
+++ b/prism/src/parser/ast/ExpressionReward.java
@@ -26,8 +26,6 @@
 
 package parser.ast;
 
-import java.util.List;
-
 import parser.EvaluateContext;
 import parser.Values;
 import parser.visitor.ASTVisitor;
@@ -35,6 +33,8 @@ import prism.OpRelOpBound;
 import prism.PrismException;
 import prism.PrismLangException;
 import prism.RewardGenerator;
+
+import java.util.List;
 
 public class ExpressionReward extends ExpressionQuant
 {
@@ -275,20 +275,18 @@ public class ExpressionReward extends ExpressionQuant
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionReward deepCopyASTElements()
 	{
-		ExpressionReward expr = new ExpressionReward();
-		expr.setExpression(getExpression() == null ? null : getExpression().deepCopy());
-		expr.setRelOp(getRelOp());
-		expr.setBound(getBound() == null ? null : getBound().deepCopy());
-		if (rewardStructIndex != null && rewardStructIndex instanceof Expression) expr.setRewardStructIndex(((Expression)rewardStructIndex).deepCopy());
-		else expr.setRewardStructIndex(rewardStructIndex);
-		if (rewardStructIndexDiv != null && rewardStructIndexDiv instanceof Expression) expr.setRewardStructIndexDiv(((Expression)rewardStructIndexDiv).deepCopy());
-		else expr.setRewardStructIndexDiv(rewardStructIndexDiv);
-		expr.setFilter(getFilter() == null ? null : (Filter)getFilter().deepCopy());
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		super.deepCopyASTElements();
+
+		if (rewardStructIndex != null && rewardStructIndex instanceof Expression) {
+			rewardStructIndex = ((Expression) rewardStructIndex).clone().deepCopyASTElements();
+		}
+		if (rewardStructIndexDiv != null && rewardStructIndexDiv instanceof Expression) {
+			rewardStructIndexDiv = ((Expression) rewardStructIndexDiv).clone().deepCopyASTElements();
+		}
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionReward.java
+++ b/prism/src/parser/ast/ExpressionReward.java
@@ -29,6 +29,7 @@ package parser.ast;
 import parser.EvaluateContext;
 import parser.Values;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.OpRelOpBound;
 import prism.PrismException;
 import prism.PrismLangException;
@@ -275,15 +276,15 @@ public class ExpressionReward extends ExpressionQuant
 	}
 
 	@Override
-	public ExpressionReward deepCopyASTElements()
+	public ExpressionReward deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		super.deepCopyASTElements();
+		super.deepCopy(copier);
 
 		if (rewardStructIndex != null && rewardStructIndex instanceof Expression) {
-			rewardStructIndex = ((Expression) rewardStructIndex).clone().deepCopyASTElements();
+			rewardStructIndex = copier.copy((Expression) rewardStructIndex);
 		}
 		if (rewardStructIndexDiv != null && rewardStructIndexDiv instanceof Expression) {
-			rewardStructIndexDiv = ((Expression) rewardStructIndexDiv).clone().deepCopyASTElements();
+			rewardStructIndexDiv = copier.copy((Expression) rewardStructIndexDiv);
 		}
 
 		return this;

--- a/prism/src/parser/ast/ExpressionReward.java
+++ b/prism/src/parser/ast/ExpressionReward.java
@@ -291,6 +291,12 @@ public class ExpressionReward extends ExpressionQuant
 		return expr;
 	}
 
+	@Override
+	public ExpressionReward clone()
+	{
+		return (ExpressionReward) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionSS.java
+++ b/prism/src/parser/ast/ExpressionSS.java
@@ -29,6 +29,7 @@ package parser.ast;
 import parser.EvaluateContext;
 import parser.Values;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.OpRelOpBound;
 import prism.PrismException;
 import prism.PrismLangException;
@@ -126,11 +127,9 @@ public class ExpressionSS extends ExpressionQuant
 	}
 
 	@Override
-	public ExpressionSS deepCopyASTElements()
+	public ExpressionSS deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		super.deepCopyASTElements();
-
-		return this;
+		return (ExpressionSS) super.deepCopy(copier);
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionSS.java
+++ b/prism/src/parser/ast/ExpressionSS.java
@@ -126,16 +126,11 @@ public class ExpressionSS extends ExpressionQuant
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionSS deepCopyASTElements()
 	{
-		ExpressionSS expr = new ExpressionSS();
-		expr.setExpression(getExpression() == null ? null : getExpression().deepCopy());
-		expr.setRelOp(getRelOp());
-		expr.setBound(getBound() == null ? null : getBound().deepCopy());
-		expr.setFilter(getFilter() == null ? null : (Filter)getFilter().deepCopy());
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		super.deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionSS.java
+++ b/prism/src/parser/ast/ExpressionSS.java
@@ -138,6 +138,12 @@ public class ExpressionSS extends ExpressionQuant
 		return expr;
 	}
 
+	@Override
+	public ExpressionSS clone()
+	{
+		return (ExpressionSS) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionStrategy.java
+++ b/prism/src/parser/ast/ExpressionStrategy.java
@@ -194,18 +194,11 @@ public class ExpressionStrategy extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionStrategy deepCopyASTElements()
 	{
-		ExpressionStrategy expr = new ExpressionStrategy();
-		expr.setThereExists(isThereExists());
-		expr.coalition = new Coalition(coalition);
-		for (Expression operand : operands) {
-			expr.addOperand((Expression) operand.deepCopy());
-		}
-		expr.singleOperand = singleOperand;
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		operands.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/ExpressionStrategy.java
+++ b/prism/src/parser/ast/ExpressionStrategy.java
@@ -46,7 +46,7 @@ public class ExpressionStrategy extends Expression
 	protected Coalition coalition = new Coalition(); 
 	
 	/** Child expression(s) */
-	protected List<Expression> operands = new ArrayList<Expression>();
+	protected ArrayList<Expression> operands = new ArrayList<Expression>();
 	
 	/** Is there just a single operand (P/R operator)? If not, the operand list will be parenthesised. **/
 	protected boolean singleOperand = false;
@@ -206,6 +206,18 @@ public class ExpressionStrategy extends Expression
 		expr.setType(type);
 		expr.setPosition(this);
 		return expr;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public ExpressionStrategy clone()
+	{
+		ExpressionStrategy clone = (ExpressionStrategy) super.clone();
+
+		clone.coalition = new Coalition(coalition);
+		clone.operands  = (ArrayList<Expression>) operands.clone();
+
+		return clone;
 	}
 
 	// Standard methods

--- a/prism/src/parser/ast/ExpressionStrategy.java
+++ b/prism/src/parser/ast/ExpressionStrategy.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import parser.EvaluateContext;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 /**
@@ -194,9 +195,9 @@ public class ExpressionStrategy extends Expression
 	}
 
 	@Override
-	public ExpressionStrategy deepCopyASTElements()
+	public ExpressionStrategy deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		operands.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		copier.copyAll(operands);
 
 		return this;
 	}

--- a/prism/src/parser/ast/ExpressionTemporal.java
+++ b/prism/src/parser/ast/ExpressionTemporal.java
@@ -267,20 +267,14 @@ public class ExpressionTemporal extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionTemporal deepCopyASTElements()
 	{
-		ExpressionTemporal expr = new ExpressionTemporal();
-		expr.setOperator(op);
-		if (operand1 != null)
-			expr.setOperand1(operand1.deepCopy());
-		if (operand2 != null)
-			expr.setOperand2(operand2.deepCopy());
-		expr.setLowerBound(lBound == null ? null : lBound.deepCopy(), lBoundStrict);
-		expr.setUpperBound(uBound == null ? null : uBound.deepCopy(), uBoundStrict);
-		expr.equals = equals;
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		operand1 = (operand1 == null) ? null : operand1.clone().deepCopyASTElements();
+		operand2 = (operand2 == null) ? null : operand2.clone().deepCopyASTElements();
+		lBound = (lBound == null) ? null : lBound.clone().deepCopyASTElements();
+		uBound = (uBound == null) ? null : uBound.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionTemporal.java
+++ b/prism/src/parser/ast/ExpressionTemporal.java
@@ -28,6 +28,7 @@ package parser.ast;
 
 import parser.EvaluateContext;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class ExpressionTemporal extends Expression
@@ -267,12 +268,12 @@ public class ExpressionTemporal extends Expression
 	}
 
 	@Override
-	public ExpressionTemporal deepCopyASTElements()
+	public ExpressionTemporal deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		operand1 = (operand1 == null) ? null : operand1.clone().deepCopyASTElements();
-		operand2 = (operand2 == null) ? null : operand2.clone().deepCopyASTElements();
-		lBound = (lBound == null) ? null : lBound.clone().deepCopyASTElements();
-		uBound = (uBound == null) ? null : uBound.clone().deepCopyASTElements();
+		operand1 = copier.copy(operand1);
+		operand2 = copier.copy(operand2);
+		lBound = copier.copy(lBound);
+		uBound = copier.copy(uBound);
 
 		return this;
 	}

--- a/prism/src/parser/ast/ExpressionTemporal.java
+++ b/prism/src/parser/ast/ExpressionTemporal.java
@@ -283,6 +283,12 @@ public class ExpressionTemporal extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionTemporal clone()
+	{
+		return (ExpressionTemporal) super.clone();
+	}
+
 	// Standard methods
 
 	@Override

--- a/prism/src/parser/ast/ExpressionUnaryOp.java
+++ b/prism/src/parser/ast/ExpressionUnaryOp.java
@@ -179,12 +179,11 @@ public class ExpressionUnaryOp extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionUnaryOp deepCopyASTElements()
 	{
-		ExpressionUnaryOp expr = new ExpressionUnaryOp(op, operand.deepCopy());
-		expr.setType(type);
-		expr.setPosition(this);
-		return expr;
+		operand = operand.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionUnaryOp.java
+++ b/prism/src/parser/ast/ExpressionUnaryOp.java
@@ -179,9 +179,9 @@ public class ExpressionUnaryOp extends Expression
 	}
 
 	@Override
-	public ExpressionUnaryOp deepCopyASTElements()
+	public ExpressionUnaryOp deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		operand = operand.clone().deepCopyASTElements();
+		operand = copier.copy(operand);
 
 		return this;
 	}

--- a/prism/src/parser/ast/ExpressionUnaryOp.java
+++ b/prism/src/parser/ast/ExpressionUnaryOp.java
@@ -187,6 +187,12 @@ public class ExpressionUnaryOp extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionUnaryOp clone()
+	{
+		return (ExpressionUnaryOp) super.clone();
+	}
+
 	// Standard methods
 
 	@Override

--- a/prism/src/parser/ast/ExpressionVar.java
+++ b/prism/src/parser/ast/ExpressionVar.java
@@ -120,6 +120,12 @@ public class ExpressionVar extends Expression
 		return expr;
 	}
 
+	@Override
+	public ExpressionVar clone()
+	{
+		return (ExpressionVar) super.clone();
+	}
+
 	// Standard methods
 	
 	@Override

--- a/prism/src/parser/ast/ExpressionVar.java
+++ b/prism/src/parser/ast/ExpressionVar.java
@@ -112,12 +112,9 @@ public class ExpressionVar extends Expression
 	}
 
 	@Override
-	public Expression deepCopy()
+	public ExpressionVar deepCopyASTElements()
 	{
-		ExpressionVar expr = new ExpressionVar(name, type);
-		expr.setIndex(index);
-		expr.setPosition(this);
-		return expr;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/ExpressionVar.java
+++ b/prism/src/parser/ast/ExpressionVar.java
@@ -29,6 +29,7 @@ package parser.ast;
 import parser.EvaluateContext;
 import parser.type.Type;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class ExpressionVar extends Expression
@@ -112,7 +113,7 @@ public class ExpressionVar extends Expression
 	}
 
 	@Override
-	public ExpressionVar deepCopyASTElements()
+	public ExpressionVar deepCopy(DeepCopy copier)
 	{
 		return this;
 	}

--- a/prism/src/parser/ast/Filter.java
+++ b/prism/src/parser/ast/Filter.java
@@ -127,6 +127,12 @@ public class Filter extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public Filter clone()
+	{
+		return (Filter) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/Filter.java
+++ b/prism/src/parser/ast/Filter.java
@@ -117,15 +117,14 @@ public class Filter extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public Filter deepCopyASTElements()
 	{
-		Filter ret = new Filter(expr.deepCopy());
-		ret.setMinRequested(minReq);
-		ret.setMaxRequested(maxReq);
-		ret.setPosition(this);
-		return ret;
+		expr = expr.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/Filter.java
+++ b/prism/src/parser/ast/Filter.java
@@ -26,7 +26,8 @@
 
 package parser.ast;
 
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 /**
@@ -117,12 +118,12 @@ public class Filter extends ASTElement
 	}
 	
 	/**
-	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
+	 * Perform a deep copy.
 	 */
 	@Override
-	public Filter deepCopyASTElements()
+	public Filter deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		expr = expr.clone().deepCopyASTElements();
+		expr = copier.copy(expr);
 
 		return this;
 	}

--- a/prism/src/parser/ast/ForLoop.java
+++ b/prism/src/parser/ast/ForLoop.java
@@ -154,6 +154,12 @@ public class ForLoop extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public ForLoop clone()
+	{
+		return (ForLoop) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/ForLoop.java
+++ b/prism/src/parser/ast/ForLoop.java
@@ -26,9 +26,10 @@
 
 package parser.ast;
 
-import parser.visitor.*;
+import parser.type.TypeInt;
+import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
-import parser.type.*;
 public class ForLoop extends ASTElement
 {
 	// For loop info
@@ -140,14 +141,14 @@ public class ForLoop extends ASTElement
 	}
 	
 	/**
-	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
+	 * Perform a deep copy.
 	 */
 	@Override
-	public ForLoop deepCopyASTElements()
+	public ForLoop deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		to = to.clone().deepCopyASTElements();
-		from = from.clone().deepCopyASTElements();
-		step = step.clone().deepCopyASTElements();
+		to = copier.copy(to);
+		from = copier.copy(from);
+		step = copier.copy(step);
 
 		return this;
 	}

--- a/prism/src/parser/ast/ForLoop.java
+++ b/prism/src/parser/ast/ForLoop.java
@@ -140,19 +140,16 @@ public class ForLoop extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public ForLoop deepCopyASTElements()
 	{
-		ForLoop ret = new ForLoop();
-		ret.lhs = lhs;
-		ret.from = from.deepCopy();
-		ret.to = to.deepCopy();
-		ret.step = step.deepCopy();
-		ret.pc = pc;
-		ret.between = between;
-		ret.setPosition(this);
-		return ret;
+		to = to.clone().deepCopyASTElements();
+		from = from.clone().deepCopyASTElements();
+		step = step.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/FormulaList.java
+++ b/prism/src/parser/ast/FormulaList.java
@@ -28,7 +28,8 @@ package parser.ast;
 
 import java.util.Vector;
 
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 import prism.PrismUtils;
 
@@ -156,13 +157,13 @@ public class FormulaList extends ASTElement
 	}
 
 	/**
-	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
+	 * Perform a deep copy.
 	 */
 	@Override
-	public FormulaList deepCopyASTElements()
+	public FormulaList deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		formulas.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
-		nameIdents.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		copier.copyAll(formulas);
+		copier.copyAll(nameIdents);
 
 		return this;
 	}

--- a/prism/src/parser/ast/FormulaList.java
+++ b/prism/src/parser/ast/FormulaList.java
@@ -169,6 +169,19 @@ public class FormulaList extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public FormulaList clone()
+	{
+		FormulaList clone = (FormulaList) super.clone();
+
+		clone.names      = (Vector<String>)          names.clone();
+		clone.formulas   = (Vector<Expression>)      formulas.clone();
+		clone.nameIdents = (Vector<ExpressionIdent>) nameIdents.clone();
+
+		return clone;
+	}
 }
 
 // ------------------------------------------------------------------------------

--- a/prism/src/parser/ast/FormulaList.java
+++ b/prism/src/parser/ast/FormulaList.java
@@ -156,18 +156,15 @@ public class FormulaList extends ASTElement
 	}
 
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public FormulaList deepCopyASTElements()
 	{
-		int i, n;
-		FormulaList ret = new FormulaList();
-		n = size();
-		for (i = 0; i < n; i++) {
-			ret.addFormula((ExpressionIdent)getFormulaNameIdent(i).deepCopy(), getFormula(i).deepCopy());
-		}
-		ret.setPosition(this);
-		return ret;
+		formulas.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		nameIdents.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/LabelList.java
+++ b/prism/src/parser/ast/LabelList.java
@@ -136,18 +136,15 @@ public class LabelList extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public LabelList deepCopyASTElements()
 	{
-		int i, n;
-		LabelList ret = new LabelList();
-		n = size();
-		for (i = 0; i < n; i++) {
-			ret.addLabel((ExpressionIdent)getLabelNameIdent(i).deepCopy(), getLabel(i).deepCopy());
-		}
-		ret.setPosition(this);
-		return ret;
+		labels.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		nameIdents.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/LabelList.java
+++ b/prism/src/parser/ast/LabelList.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Vector;
 
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 // class to store list of labels
@@ -136,13 +137,13 @@ public class LabelList extends ASTElement
 	}
 	
 	/**
-	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
+	 * Perform a deep copy.
 	 */
 	@Override
-	public LabelList deepCopyASTElements()
+	public LabelList deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		labels.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
-		nameIdents.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		copier.copyAll(labels);
+		copier.copyAll(nameIdents);
 
 		return this;
 	}

--- a/prism/src/parser/ast/LabelList.java
+++ b/prism/src/parser/ast/LabelList.java
@@ -38,7 +38,7 @@ import prism.PrismLangException;
 public class LabelList extends ASTElement
 {
 	// Name/expression pairs to define labels
-	private List<String> names;
+	private ArrayList<String> names;
 	private Vector<Expression> labels;
 	// We also store an ExpressionIdent to match each name.
 	// This is to just to provide positional info.
@@ -148,6 +148,19 @@ public class LabelList extends ASTElement
 		}
 		ret.setPosition(this);
 		return ret;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public LabelList clone()
+	{
+		LabelList clone = (LabelList) super.clone();
+
+		clone.names      = (ArrayList<String>)       names.clone();
+		clone.labels     = (Vector<Expression>)      labels.clone();
+		clone.nameIdents = (Vector<ExpressionIdent>) nameIdents.clone();
+
+		return clone;
 	}
 }
 

--- a/prism/src/parser/ast/Module.java
+++ b/prism/src/parser/ast/Module.java
@@ -26,10 +26,13 @@
 
 package parser.ast;
 
-import java.util.*;
-
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Vector;
 
 public class Module extends ASTElement
 {
@@ -286,13 +289,13 @@ public class Module extends ASTElement
 	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
 	@Override
-	public Module deepCopyASTElements()
+	public Module deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		invariant = (invariant == null) ? null : invariant.clone().deepCopyASTElements();
-		nameASTElement = (nameASTElement == null) ? null : nameASTElement.clone().deepCopyASTElements();
+		invariant = copier.copy(invariant);
+		nameASTElement = copier.copy(nameASTElement);
 
-		decls.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
-		commands.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		copier.copyAll(decls);
+		copier.copyAll(commands);
 
 		return this;
 	}

--- a/prism/src/parser/ast/Module.java
+++ b/prism/src/parser/ast/Module.java
@@ -304,6 +304,19 @@ public class Module extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Module clone()
+	{
+		Module clone = (Module) super.clone();
+
+		clone.decls    = (ArrayList<Declaration>) decls.clone();
+		clone.commands = (ArrayList<Command>) commands.clone();
+		clone.alphabet = (Vector<String>) alphabet.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/Module.java
+++ b/prism/src/parser/ast/Module.java
@@ -283,26 +283,18 @@ public class Module extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public Module deepCopyASTElements()
 	{
-		int i, n;
-		Module ret = new Module(name);
-		if (nameASTElement != null)
-			ret.setNameASTElement((ExpressionIdent)nameASTElement.deepCopy());
-		n = getNumDeclarations();
-		for (i = 0; i < n; i++) {
-			ret.addDeclaration((Declaration)getDeclaration(i).deepCopy());
-		}
-		n = getNumCommands();
-		for (i = 0; i < n; i++) {
-			ret.addCommand((Command)getCommand(i).deepCopy());
-		}
-		if (invariant != null)
-			ret.setInvariant(invariant.deepCopy());
-		ret.setPosition(this);
-		return ret;
+		invariant = (invariant == null) ? null : invariant.clone().deepCopyASTElements();
+		nameASTElement = (nameASTElement == null) ? null : nameASTElement.clone().deepCopyASTElements();
+
+		decls.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		commands.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -313,7 +305,7 @@ public class Module extends ASTElement
 
 		clone.decls    = (ArrayList<Declaration>) decls.clone();
 		clone.commands = (ArrayList<Command>) commands.clone();
-		clone.alphabet = (Vector<String>) alphabet.clone();
+		clone.alphabet = (alphabet == null) ? null : (Vector<String>) alphabet.clone();
 
 		return clone;
 	}

--- a/prism/src/parser/ast/ModulesFile.java
+++ b/prism/src/parser/ast/ModulesFile.java
@@ -26,10 +26,7 @@
 
 package parser.ast;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Vector;
+import java.util.*;
 
 import param.BigRational;
 import parser.IdentUsage;
@@ -39,6 +36,7 @@ import parser.VarList;
 import parser.type.Type;
 import parser.visitor.ASTTraverse;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import parser.visitor.ModulesFileSemanticCheck;
 import parser.visitor.ModulesFileSemanticCheckAfterConstants;
 import prism.ModelInfo;
@@ -1643,30 +1641,27 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
 	@Override
-	public ModulesFile deepCopyASTElements()
+	public ModulesFile deepCopy(DeepCopy copier) throws PrismLangException
 	{
 		// Deep copy main components
-		labelList = labelList.clone().deepCopyASTElements();
-		formulaList = formulaList.clone().deepCopyASTElements();
-		constantList = constantList.clone().deepCopyASTElements();
-		initStates = (initStates == null) ? null : initStates.clone().deepCopyASTElements();
-		identUsage = (identUsage == null) ? null : identUsage.clone().deepCopyFields();
-		quotedIdentUsage = (quotedIdentUsage == null) ? null : quotedIdentUsage.clone().deepCopyFields();
+		labelList = copier.copy(labelList);
+		formulaList = copier.copy(formulaList);
+		constantList = copier.copy(constantList);
+		initStates = copier.copy(initStates);
+		identUsage = identUsage.deepCopy();
+		quotedIdentUsage = quotedIdentUsage.deepCopy();
 
-		// deepCopy all elements inside collections
-		globals.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
-		varDecls.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
-		systemDefns.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
-		observables.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
-		rewardStructs.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
-		observableDefns.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
-		observableVarLists.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		copier.copyAll(globals);
+		copier.copyAll(varDecls);
+		copier.copyAll(systemDefns);
+		copier.copyAll(observables);
+		copier.copyAll(rewardStructs);
+		copier.copyAll(observableDefns);
+		copier.copyAll(observableVarLists);
 
 		for (int i = 0, n = getNumModules(); i < n; i++) {
-			Module mod = getModule(i);
-			if (mod != null) {
-				setModule(i, mod.clone().deepCopyASTElements());
-			}
+			Module mod = Objects.requireNonNull(getModule(i));
+			setModule(i, copier.copy(mod));
 		}
 		return this;
 	}

--- a/prism/src/parser/ast/ModulesFile.java
+++ b/prism/src/parser/ast/ModulesFile.java
@@ -1640,66 +1640,35 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 	}
 
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	@SuppressWarnings("unchecked")
-	public ASTElement deepCopy()
+	@Override
+	public ModulesFile deepCopyASTElements()
 	{
-		int i, n;
-		ModulesFile ret = new ModulesFile();
-		
-		// Copy ASTElement stuff
-		ret.setPosition(this);
-		// Copy type
-		ret.setModelTypeInFile(modelTypeInFile);
-		ret.setModelType(modelType);
 		// Deep copy main components
-		ret.setFormulaList((FormulaList) formulaList.deepCopy());
-		ret.setLabelList((LabelList) labelList.deepCopy());
-		ret.setConstantList((ConstantList) constantList.deepCopy());
-		n = getNumGlobals();
-		for (i = 0; i < n; i++) {
-			ret.addGlobal((Declaration) getGlobal(i).deepCopy());
+		labelList = labelList.clone().deepCopyASTElements();
+		formulaList = formulaList.clone().deepCopyASTElements();
+		constantList = constantList.clone().deepCopyASTElements();
+		initStates = (initStates == null) ? null : initStates.clone().deepCopyASTElements();
+		identUsage = (identUsage == null) ? null : identUsage.clone().deepCopyFields();
+		quotedIdentUsage = (quotedIdentUsage == null) ? null : quotedIdentUsage.clone().deepCopyFields();
+
+		// deepCopy all elements inside collections
+		globals.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		varDecls.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		systemDefns.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		observables.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		rewardStructs.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		observableDefns.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		observableVarLists.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		for (int i = 0, n = getNumModules(); i < n; i++) {
+			Module mod = getModule(i);
+			if (mod != null) {
+				setModule(i, mod.clone().deepCopyASTElements());
+			}
 		}
-		n = getNumModules();
-		for (i = 0; i < n; i++) {
-			ret.addModule((Module) getModule(i).deepCopy());
-		}
-		n = getNumSystemDefns();
-		for (i = 0; i < n; i++) {
-			ret.addSystemDefn(getSystemDefn(i).deepCopy(), getSystemDefnName(i));
-		}
-		n = getNumRewardStructs();
-		for (i = 0; i < n; i++) {
-			ret.addRewardStruct((RewardStruct) getRewardStruct(i).deepCopy());
-		}
-		if (initStates != null)
-			ret.setInitialStates(initStates.deepCopy());
-		for (ObservableVars obsVars : observableVarLists)
-			ret.observableVarLists.add(obsVars.deepCopy());
-		for (Observable obs : observableDefns)
-			ret.observableDefns.add(obs.deepCopy());
-		// Copy other (generated) info
-		ret.identUsage = (identUsage == null) ? null : identUsage.deepCopy();
-		ret.quotedIdentUsage = (quotedIdentUsage == null) ? null : quotedIdentUsage.deepCopy();
-		ret.moduleNames = (moduleNames == null) ? null : moduleNames.clone();
-		ret.synchs = (synchs == null) ? null : (Vector<String>)synchs.clone();
-		if (varDecls != null) {
-			ret.varDecls = new Vector<Declaration>();
-			for (Declaration d : varDecls)
-				ret.varDecls.add((Declaration) d.deepCopy());
-		}
-		ret.varNames = (varNames == null) ? null : (Vector<String>)varNames.clone();
-		ret.varTypes = (varTypes == null) ? null : (Vector<Type>)varTypes.clone();
-		ret.varModules = (varModules == null) ? null : (Vector<Integer>)varModules.clone();
-		for (Observable obs : observables)
-			ret.observables.add(obs.deepCopy());
-		ret.observableNames = (observableNames == null) ? null : new ArrayList<>(observableNames);
-		ret.observableTypes = (observableTypes == null) ? null : new ArrayList<>(observableTypes);
-		ret.observableVars = (observableVars == null) ? null : new ArrayList<>(observableVars);
-		ret.constantValues = (constantValues == null) ? null : new Values(constantValues);
-		
-		return ret;
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/ModulesFile.java
+++ b/prism/src/parser/ast/ModulesFile.java
@@ -66,10 +66,10 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 	private ArrayList<SystemDefn> systemDefns; // System definitions (system...endsystem constructs)
 	private ArrayList<String> systemDefnNames; // System definition names (system...endsystem constructs)
 	private ArrayList<RewardStruct> rewardStructs; // Rewards structures
-	private List<String> rewardStructNames; // Names of reward structures
+	private ArrayList<String> rewardStructNames; // Names of reward structures
 	private Expression initStates; // Initial states specification
-	private List<ObservableVars> observableVarLists; // Observable variables lists
-	private List<Observable> observableDefns; // Standalone observable definitions
+	private ArrayList<ObservableVars> observableVarLists; // Observable variables lists
+	private ArrayList<Observable> observableDefns; // Standalone observable definitions
 	
 	// Info about all identifiers used
 	private IdentUsage identUsage;
@@ -84,10 +84,10 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 	private Vector<Type> varTypes;
 	private Vector<Integer> varModules;
 	// Lists of observable info
-	private List<Observable> observables;
-	private List<String> observableNames;
-	private List<Type> observableTypes;
-	private List<String> observableVars;
+	private ArrayList<Observable> observables;
+	private ArrayList<String> observableNames;
+	private ArrayList<Type> observableTypes;
+	private ArrayList<String> observableVars;
 
 	// Values set for undefined constants (null if none)
 	private Values undefinedConstantValues;
@@ -1700,6 +1700,43 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 		ret.constantValues = (constantValues == null) ? null : new Values(constantValues);
 		
 		return ret;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public ModulesFile clone()
+	{
+		ModulesFile clone = (ModulesFile) super.clone();
+
+		// clone main components
+		clone.globals            = (Vector<Declaration>) globals.clone();
+		clone.modules            = (Vector<Object>) modules.clone();
+		clone.systemDefns        = (ArrayList<SystemDefn>) systemDefns.clone();
+		clone.systemDefnNames    = (ArrayList<String>) systemDefnNames.clone();
+		clone.rewardStructs      = (ArrayList<RewardStruct>) rewardStructs.clone();
+		clone.rewardStructNames  = (ArrayList<String>) rewardStructNames.clone();
+		clone.observableVarLists = (ArrayList<ObservableVars>) observableVarLists.clone();
+		clone.observableDefns    = (ArrayList<Observable>) observableDefns.clone();
+		clone.varDecls           = (Vector<Declaration>) varDecls.clone();
+		clone.varNames           = (Vector<String>) varNames.clone();
+		clone.varTypes           = (Vector<Type>) varTypes.clone();
+		clone.varModules         = (Vector<Integer>) varModules.clone();
+		clone.observables        = (ArrayList<Observable>) observables.clone();
+		clone.observableNames    = (ArrayList<String>) observableNames.clone();
+		clone.observableTypes    = (ArrayList<Type>) observableTypes.clone();
+		clone.observableVars     = (ArrayList<String>) observableVars.clone();
+
+		// clone other (generated) info
+		if (constantValues != null)
+			clone.constantValues = constantValues.clone();
+		if (undefinedConstantValues != null)
+			clone.undefinedConstantValues = undefinedConstantValues.clone();
+		if (moduleNames != null)
+			clone.moduleNames = moduleNames.clone();
+		if (synchs != null)
+			clone.synchs =  (Vector<String>) synchs.clone();
+
+		return clone;
 	}
 }
 

--- a/prism/src/parser/ast/Observable.java
+++ b/prism/src/parser/ast/Observable.java
@@ -27,6 +27,7 @@
 package parser.ast;
 
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class Observable extends ASTElement
@@ -105,9 +106,9 @@ public class Observable extends ASTElement
 	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
 	@Override
-	public Observable deepCopyASTElements()
+	public Observable deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		definition = definition.clone().deepCopyASTElements();
+		definition = copier.copy(definition);
 
 		return this;
 	}

--- a/prism/src/parser/ast/Observable.java
+++ b/prism/src/parser/ast/Observable.java
@@ -102,13 +102,14 @@ public class Observable extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public Observable deepCopy()
+	@Override
+	public Observable deepCopyASTElements()
 	{
-		Observable ret = new Observable(name, definition.deepCopy());
-		ret.setPosition(this);
-		return ret;
+		definition = definition.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/Observable.java
+++ b/prism/src/parser/ast/Observable.java
@@ -110,6 +110,12 @@ public class Observable extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public Observable clone()
+	{
+		return (Observable) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/ObservableVars.java
+++ b/prism/src/parser/ast/ObservableVars.java
@@ -27,7 +27,6 @@
 package parser.ast;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.stream.Collectors;
 
 import parser.visitor.ASTVisitor;
@@ -126,16 +125,14 @@ public class ObservableVars extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ObservableVars deepCopy()
+	@Override
+	public ObservableVars deepCopyASTElements()
 	{
-		ObservableVars ret = new ObservableVars();
-		for (Expression var : vars) {
-			ret.addVar(var.deepCopy());
-		}
-		ret.setPosition(this);
-		return ret;
+		vars.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/ObservableVars.java
+++ b/prism/src/parser/ast/ObservableVars.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.stream.Collectors;
 
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 /**
@@ -128,9 +129,9 @@ public class ObservableVars extends ASTElement
 	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
 	@Override
-	public ObservableVars deepCopyASTElements()
+	public ObservableVars deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		vars.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		copier.copyAll(vars);
 
 		return this;
 	}

--- a/prism/src/parser/ast/ObservableVars.java
+++ b/prism/src/parser/ast/ObservableVars.java
@@ -41,7 +41,7 @@ public class ObservableVars extends ASTElement
 	/**
 	 * List of variables (stored as AST elements referencing them)
 	 */
-	private List<Expression> vars;
+	private ArrayList<Expression> vars;
 	
 	// Constructor
 	
@@ -136,6 +136,15 @@ public class ObservableVars extends ASTElement
 		}
 		ret.setPosition(this);
 		return ret;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public ObservableVars clone()
+	{
+		ObservableVars clone = (ObservableVars) super.clone();
+		clone.vars = (ArrayList<Expression>) vars.clone();
+		return clone;
 	}
 }
 

--- a/prism/src/parser/ast/PropertiesFile.java
+++ b/prism/src/parser/ast/PropertiesFile.java
@@ -673,6 +673,24 @@ public class PropertiesFile extends ASTElement
 
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public PropertiesFile clone()
+	{
+		PropertiesFile clone = (PropertiesFile) super.clone();
+
+		// clone main components
+		clone.properties = (Vector<Property>) properties.clone();
+
+		// clone other (generated) info
+		if (constantValues != null)
+			clone.constantValues = constantValues.clone();
+		if (undefinedConstantValues != null)
+			clone.undefinedConstantValues = undefinedConstantValues.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/PropertiesFile.java
+++ b/prism/src/parser/ast/PropertiesFile.java
@@ -649,29 +649,20 @@ public class PropertiesFile extends ASTElement
 		return s;
 	}
 
-	/**
-	 * Perform a deep copy.
-	 */
-	public ASTElement deepCopy()
+	@Override
+	public PropertiesFile deepCopyASTElements()
 	{
-		int i, n;
-		PropertiesFile ret = new PropertiesFile(modelInfo);
-		// Copy ASTElement stuff
-		ret.setPosition(this);
-		// Deep copy main components
-		ret.setFormulaList((FormulaList) formulaList.deepCopy());
-		ret.setLabelList((LabelList) labelList.deepCopy());
-		ret.combinedLabelList = (LabelList) combinedLabelList.deepCopy();
-		ret.setConstantList((ConstantList) constantList.deepCopy());
-		n = getNumProperties();
-		for (i = 0; i < n; i++) {
-			ret.addProperty((Property) getPropertyObject(i).deepCopy());
-		}
-		// Copy other (generated) info
-		ret.identUsage = (identUsage == null) ? null : identUsage.deepCopy();
-		ret.constantValues = (constantValues == null) ? null : new Values(constantValues);
+		quotedIdentUsage = new IdentUsage(true);
+		labelList = labelList.clone().deepCopyASTElements();
+		formulaList = formulaList.clone().deepCopyASTElements();
+		constantList = constantList.clone().deepCopyASTElements();
+		combinedLabelList = combinedLabelList.clone().deepCopyASTElements();
+		identUsage = (identUsage == null) ? null : identUsage.clone().deepCopyFields();
 
-		return ret;
+		// deepCopy all elements inside collections
+		properties.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/PropertiesFile.java
+++ b/prism/src/parser/ast/PropertiesFile.java
@@ -26,13 +26,17 @@
 
 package parser.ast;
 
-import java.util.*;
-
-import parser.*;
-import parser.visitor.*;
+import parser.IdentUsage;
+import parser.Values;
+import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
+import parser.visitor.PropertiesSemanticCheck;
 import prism.ModelInfo;
 import prism.PrismLangException;
 import prism.PrismUtils;
+
+import java.util.List;
+import java.util.Vector;
 
 // Class representing parsed properties file/list
 
@@ -650,17 +654,16 @@ public class PropertiesFile extends ASTElement
 	}
 
 	@Override
-	public PropertiesFile deepCopyASTElements()
+	public PropertiesFile deepCopy(DeepCopy copier) throws PrismLangException
 	{
 		quotedIdentUsage = new IdentUsage(true);
-		labelList = labelList.clone().deepCopyASTElements();
-		formulaList = formulaList.clone().deepCopyASTElements();
-		constantList = constantList.clone().deepCopyASTElements();
-		combinedLabelList = combinedLabelList.clone().deepCopyASTElements();
-		identUsage = (identUsage == null) ? null : identUsage.clone().deepCopyFields();
+		labelList = copier.copy(labelList);
+		formulaList = copier.copy(formulaList);
+		constantList = copier.copy(constantList);
+		combinedLabelList = copier.copy(combinedLabelList);
+		identUsage = identUsage.deepCopy();
 
-		// deepCopy all elements inside collections
-		properties.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		copier.copyAll(properties);
 
 		return this;
 	}

--- a/prism/src/parser/ast/Property.java
+++ b/prism/src/parser/ast/Property.java
@@ -303,12 +303,11 @@ public class Property extends ASTElement
 	}
 
 	@Override
-	public Property deepCopy()
+	public Property deepCopyASTElements()
 	{
-		Property prop = new Property(expr.deepCopy(), name, comment);
-		prop.setType(type);
-		prop.setPosition(this);
-		return prop;
+		expr = expr.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/Property.java
+++ b/prism/src/parser/ast/Property.java
@@ -310,6 +310,12 @@ public class Property extends ASTElement
 		prop.setPosition(this);
 		return prop;
 	}
+
+	@Override
+	public Property clone()
+	{
+		return (Property) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/Property.java
+++ b/prism/src/parser/ast/Property.java
@@ -34,6 +34,7 @@ import java.util.regex.Pattern;
 import param.BigRational;
 import parser.Values;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.DefinedConstant;
 import prism.PrismException;
 import prism.PrismLangException;
@@ -303,9 +304,9 @@ public class Property extends ASTElement
 	}
 
 	@Override
-	public Property deepCopyASTElements()
+	public Property deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		expr = expr.clone().deepCopyASTElements();
+		expr = copier.copy(expr);
 
 		return this;
 	}

--- a/prism/src/parser/ast/RenamedModule.java
+++ b/prism/src/parser/ast/RenamedModule.java
@@ -185,20 +185,17 @@ public class RenamedModule extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public RenamedModule deepCopyASTElements()
 	{
-		int i, n;
-		RenamedModule ret = new RenamedModule(name, baseModule);
-		ret.setNameASTElement((ExpressionIdent)nameASTElement.deepCopy());
-		ret.setBaseModuleASTElement((ExpressionIdent)baseModuleASTElement.deepCopy());
-		n = oldNames.size();
-		for (i = 0; i < n; i++) {
-			ret.addRename(oldNames.get(i), newNames.get(i));
-		}
-		ret.setPosition(this);
-		return ret;
+		nameASTElement = nameASTElement.clone().deepCopyASTElements();
+		baseModuleASTElement = baseModuleASTElement.clone().deepCopyASTElements();
+		oldNameASTElements.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		newNameASTElements.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/RenamedModule.java
+++ b/prism/src/parser/ast/RenamedModule.java
@@ -200,6 +200,20 @@ public class RenamedModule extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public RenamedModule clone()
+	{
+		RenamedModule clone = (RenamedModule) super.clone();
+
+		clone.newNameASTElements = (ArrayList<ExpressionIdent>) newNameASTElements.clone();
+		clone.newNames           = (ArrayList<String>) newNames.clone();
+		clone.oldNameASTElements = (ArrayList<ExpressionIdent>) oldNameASTElements.clone();
+		clone.oldNames           = (ArrayList<String>) oldNames.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/RenamedModule.java
+++ b/prism/src/parser/ast/RenamedModule.java
@@ -26,10 +26,11 @@
 
 package parser.ast;
 
-import java.util.ArrayList;
-
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
+
+import java.util.ArrayList;
 
 public class RenamedModule extends ASTElement
 {
@@ -188,12 +189,13 @@ public class RenamedModule extends ASTElement
 	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
 	@Override
-	public RenamedModule deepCopyASTElements()
+	public RenamedModule deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		nameASTElement = nameASTElement.clone().deepCopyASTElements();
-		baseModuleASTElement = baseModuleASTElement.clone().deepCopyASTElements();
-		oldNameASTElements.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
-		newNameASTElements.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		nameASTElement = copier.copy(nameASTElement);
+		baseModuleASTElement = copier.copy(baseModuleASTElement);
+		// Do not reference ASTElements in the old AST
+		oldNameASTElements.clear();
+		newNameASTElements.clear();
 
 		return this;
 	}

--- a/prism/src/parser/ast/RewardStruct.java
+++ b/prism/src/parser/ast/RewardStruct.java
@@ -26,10 +26,11 @@
 
 package parser.ast;
 
-import java.util.Vector;
-
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
+
+import java.util.Vector;
 
 public class RewardStruct extends ASTElement
 {
@@ -149,9 +150,9 @@ public class RewardStruct extends ASTElement
 	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
 	@Override
-	public RewardStruct deepCopyASTElements()
+	public RewardStruct deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		items.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		copier.copyAll(items);
 
 		return this;
 	}

--- a/prism/src/parser/ast/RewardStruct.java
+++ b/prism/src/parser/ast/RewardStruct.java
@@ -146,19 +146,14 @@ public class RewardStruct extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public RewardStruct deepCopyASTElements()
 	{
-		int i, n;
-		RewardStruct ret = new RewardStruct();
-		ret.setName(name);
-		n = getNumItems();
-		for (i = 0; i < n; i++) {
-			ret.addItem((RewardStructItem)getRewardStructItem(i).deepCopy());
-		}
-		ret.setPosition(this);
-		return ret;
+		items.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/RewardStruct.java
+++ b/prism/src/parser/ast/RewardStruct.java
@@ -160,6 +160,17 @@ public class RewardStruct extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public RewardStruct clone()
+	{
+		RewardStruct clone = (RewardStruct) super.clone();
+
+		clone.items = (Vector<RewardStructItem>) items.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/RewardStructItem.java
+++ b/prism/src/parser/ast/RewardStructItem.java
@@ -26,7 +26,8 @@
 
 package parser.ast;
 
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 public class RewardStructItem extends ASTElement
@@ -143,10 +144,10 @@ public class RewardStructItem extends ASTElement
 	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
 	@Override
-	public RewardStructItem deepCopyASTElements()
+	public RewardStructItem deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		states = states.clone().deepCopyASTElements();
-		reward = reward.clone().deepCopyASTElements();
+		states = copier.copy(states);
+		reward = copier.copy(reward);
 
 		return this;
 	}

--- a/prism/src/parser/ast/RewardStructItem.java
+++ b/prism/src/parser/ast/RewardStructItem.java
@@ -140,14 +140,15 @@ public class RewardStructItem extends ASTElement
 	}
 	
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public RewardStructItem deepCopyASTElements()
 	{
-		RewardStructItem ret = new RewardStructItem(synch, states.deepCopy(), reward.deepCopy());
-		ret.setSynchIndex(getSynchIndex());
-		ret.setPosition(this);
-		return ret;
+		states = states.clone().deepCopyASTElements();
+		reward = reward.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/RewardStructItem.java
+++ b/prism/src/parser/ast/RewardStructItem.java
@@ -149,6 +149,12 @@ public class RewardStructItem extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public RewardStructItem clone()
+	{
+		return (RewardStructItem) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemBrackets.java
+++ b/prism/src/parser/ast/SystemBrackets.java
@@ -114,11 +114,11 @@ public class SystemBrackets extends SystemDefn
 	}
 	
 	@Override
-	public SystemDefn deepCopy()
+	public SystemBrackets deepCopyASTElements()
 	{
-		SystemDefn ret = new SystemBrackets(getOperand().deepCopy());
-		ret.setPosition(this);
-		return ret;
+		operand = operand.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/SystemBrackets.java
+++ b/prism/src/parser/ast/SystemBrackets.java
@@ -120,6 +120,12 @@ public class SystemBrackets extends SystemDefn
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public SystemBrackets clone()
+	{
+		return (SystemBrackets) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemBrackets.java
+++ b/prism/src/parser/ast/SystemBrackets.java
@@ -26,10 +26,11 @@
 
 package parser.ast;
 
-import java.util.Vector;
-
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
+
+import java.util.Vector;
 
 // note: although this makes no difference to the meaning
 // of the expression, it means we can keep the user's
@@ -114,9 +115,9 @@ public class SystemBrackets extends SystemDefn
 	}
 	
 	@Override
-	public SystemBrackets deepCopyASTElements()
+	public SystemBrackets deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		operand = operand.clone().deepCopyASTElements();
+		operand = copier.copy(operand);
 
 		return this;
 	}

--- a/prism/src/parser/ast/SystemDefn.java
+++ b/prism/src/parser/ast/SystemDefn.java
@@ -30,12 +30,19 @@ import java.util.Vector;
 
 public abstract class SystemDefn extends ASTElement
 {
-	// Overrided version of deepCopy() from superclass ASTElement (to reduce casting).
+	// Overwritten version of deepCopy() and deepCopyASTElements() from superclass ASTElement (to reduce casting).
+
+	@Override
+	public abstract SystemDefn deepCopyASTElements();
 
 	/**
 	 * Perform a deep copy.
 	 */
-	public abstract SystemDefn deepCopy();
+	@Override
+	public SystemDefn deepCopy()
+	{
+		return (SystemDefn) super.deepCopy();
+	}
 
 	@Override
 	public SystemDefn clone()

--- a/prism/src/parser/ast/SystemDefn.java
+++ b/prism/src/parser/ast/SystemDefn.java
@@ -26,14 +26,17 @@
 
 package parser.ast;
 
+import parser.visitor.DeepCopy;
+import prism.PrismLangException;
+
 import java.util.Vector;
 
 public abstract class SystemDefn extends ASTElement
 {
-	// Overwritten version of deepCopy() and deepCopyASTElements() from superclass ASTElement (to reduce casting).
+	// Overwritten version of deepCopy() and deepCopy(DeepCopy copier) from superclass ASTElement (to reduce casting).
 
 	@Override
-	public abstract SystemDefn deepCopyASTElements();
+	public abstract SystemDefn deepCopy(DeepCopy copier) throws PrismLangException;
 
 	/**
 	 * Perform a deep copy.

--- a/prism/src/parser/ast/SystemDefn.java
+++ b/prism/src/parser/ast/SystemDefn.java
@@ -37,6 +37,12 @@ public abstract class SystemDefn extends ASTElement
 	 */
 	public abstract SystemDefn deepCopy();
 
+	@Override
+	public SystemDefn clone()
+	{
+		return (SystemDefn) super.clone();
+	}
+
 	// Methods required for SystemDefn (all subclasses should implement):
 
 	/**

--- a/prism/src/parser/ast/SystemFullParallel.java
+++ b/prism/src/parser/ast/SystemFullParallel.java
@@ -150,9 +150,9 @@ public class SystemFullParallel extends SystemDefn
 	}
 	
 	@Override
-	public SystemFullParallel deepCopyASTElements()
+	public SystemFullParallel deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		operands.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		copier.copyAll(operands);
 
 		return this;
 	}

--- a/prism/src/parser/ast/SystemFullParallel.java
+++ b/prism/src/parser/ast/SystemFullParallel.java
@@ -161,6 +161,17 @@ public class SystemFullParallel extends SystemDefn
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public SystemFullParallel clone()
+	{
+		SystemFullParallel clone = (SystemFullParallel) super.clone();
+
+		clone.operands = (Vector<SystemDefn>) operands.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemFullParallel.java
+++ b/prism/src/parser/ast/SystemFullParallel.java
@@ -150,16 +150,11 @@ public class SystemFullParallel extends SystemDefn
 	}
 	
 	@Override
-	public SystemDefn deepCopy()
+	public SystemFullParallel deepCopyASTElements()
 	{
-		int i, n;
-		SystemFullParallel ret = new SystemFullParallel();
-		n = getNumOperands();
-		for (i = 0; i < n; i++) {
-			ret.addOperand(getOperand(i).deepCopy());
-		}
-		ret.setPosition(this);
-		return ret;
+		operands.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/SystemHide.java
+++ b/prism/src/parser/ast/SystemHide.java
@@ -165,6 +165,17 @@ public class SystemHide extends SystemDefn
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public SystemHide clone()
+	{
+		SystemHide clone = (SystemHide) super.clone();
+
+		clone.actions = (Vector<String>) actions.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemHide.java
+++ b/prism/src/parser/ast/SystemHide.java
@@ -26,10 +26,11 @@
 
 package parser.ast;
 
-import java.util.Vector;
-
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
+
+import java.util.Vector;
 
 public class SystemHide extends SystemDefn
 {
@@ -154,9 +155,9 @@ public class SystemHide extends SystemDefn
 	}
 	
 	@Override
-	public SystemHide deepCopyASTElements()
+	public SystemHide deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		operand = operand.clone().deepCopyASTElements();
+		operand = copier.copy(operand);
 
 		return this;
 	}

--- a/prism/src/parser/ast/SystemHide.java
+++ b/prism/src/parser/ast/SystemHide.java
@@ -154,16 +154,11 @@ public class SystemHide extends SystemDefn
 	}
 	
 	@Override
-	public SystemDefn deepCopy()
+	public SystemHide deepCopyASTElements()
 	{
-		int i, n;
-		SystemHide ret = new SystemHide(getOperand().deepCopy());
-		n = getNumActions();
-		for (i = 0; i < n; i++) {
-			ret.addAction(getAction(i));
-		}
-		ret.setPosition(this);
-		return ret;
+		operand = operand.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/SystemInterleaved.java
+++ b/prism/src/parser/ast/SystemInterleaved.java
@@ -150,9 +150,9 @@ public class SystemInterleaved extends SystemDefn
 	}
 	
 	@Override
-	public SystemInterleaved deepCopyASTElements()
+	public SystemInterleaved deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		operands.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		copier.copyAll(operands);
 
 		return this;
 	}

--- a/prism/src/parser/ast/SystemInterleaved.java
+++ b/prism/src/parser/ast/SystemInterleaved.java
@@ -161,6 +161,17 @@ public class SystemInterleaved extends SystemDefn
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public SystemInterleaved clone()
+	{
+		SystemInterleaved clone = (SystemInterleaved) super.clone();
+
+		clone.operands = (Vector<SystemDefn>) operands.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemInterleaved.java
+++ b/prism/src/parser/ast/SystemInterleaved.java
@@ -150,16 +150,11 @@ public class SystemInterleaved extends SystemDefn
 	}
 	
 	@Override
-	public SystemDefn deepCopy()
+	public SystemInterleaved deepCopyASTElements()
 	{
-		int i, n;
-		SystemInterleaved ret = new SystemInterleaved();
-		n = getNumOperands();
-		for (i = 0; i < n; i++) {
-			ret.addOperand(getOperand(i).deepCopy());
-		}
-		ret.setPosition(this);
-		return ret;
+		operands.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/SystemModule.java
+++ b/prism/src/parser/ast/SystemModule.java
@@ -114,6 +114,12 @@ public class SystemModule extends SystemDefn
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public SystemModule clone()
+	{
+		return (SystemModule) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemModule.java
+++ b/prism/src/parser/ast/SystemModule.java
@@ -108,11 +108,9 @@ public class SystemModule extends SystemDefn
 	}
 	
 	@Override
-	public SystemDefn deepCopy()
+	public SystemModule deepCopyASTElements()
 	{
-		SystemDefn ret = new SystemModule(name);
-		ret.setPosition(this);
-		return ret;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/SystemModule.java
+++ b/prism/src/parser/ast/SystemModule.java
@@ -26,10 +26,11 @@
 
 package parser.ast;
 
-import java.util.Vector;
-
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
+
+import java.util.Vector;
 
 public class SystemModule extends SystemDefn
 {
@@ -108,7 +109,7 @@ public class SystemModule extends SystemDefn
 	}
 	
 	@Override
-	public SystemModule deepCopyASTElements()
+	public SystemModule deepCopy(DeepCopy copier)
 	{
 		return this;
 	}

--- a/prism/src/parser/ast/SystemParallel.java
+++ b/prism/src/parser/ast/SystemParallel.java
@@ -26,10 +26,11 @@
 
 package parser.ast;
 
-import java.util.Vector;
-
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
+
+import java.util.Vector;
 
 public class SystemParallel extends SystemDefn
 {
@@ -169,10 +170,10 @@ public class SystemParallel extends SystemDefn
 	}
 	
 	@Override
-	public SystemParallel deepCopyASTElements()
+	public SystemParallel deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		operand1 = operand1.clone().deepCopyASTElements();
-		operand2 = operand2.clone().deepCopyASTElements();
+		operand1 = copier.copy(operand1);
+		operand2 = copier.copy(operand2);
 
 		return this;
 	}

--- a/prism/src/parser/ast/SystemParallel.java
+++ b/prism/src/parser/ast/SystemParallel.java
@@ -169,15 +169,12 @@ public class SystemParallel extends SystemDefn
 	}
 	
 	@Override
-	@SuppressWarnings("unchecked")
-	public SystemDefn deepCopy()
+	public SystemParallel deepCopyASTElements()
 	{
-		SystemParallel ret = new SystemParallel();
-		ret.setOperand1(getOperand1().deepCopy());
-		ret.setOperand2(getOperand2().deepCopy());
-		ret.actions = (actions == null) ? null : (Vector<String>)actions.clone();
-		ret.setPosition(this);
-		return ret;
+		operand1 = operand1.clone().deepCopyASTElements();
+		operand2 = operand2.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/SystemParallel.java
+++ b/prism/src/parser/ast/SystemParallel.java
@@ -179,6 +179,17 @@ public class SystemParallel extends SystemDefn
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public SystemParallel clone()
+	{
+		SystemParallel clone = (SystemParallel) super.clone();
+
+		clone.actions = (Vector<String>) actions.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemReference.java
+++ b/prism/src/parser/ast/SystemReference.java
@@ -26,10 +26,11 @@
 
 package parser.ast;
 
-import java.util.Vector;
-
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
+
+import java.util.Vector;
 
 public class SystemReference extends SystemDefn
 {
@@ -113,7 +114,7 @@ public class SystemReference extends SystemDefn
 	}
 	
 	@Override
-	public SystemReference deepCopyASTElements()
+	public SystemReference deepCopy(DeepCopy copier)
 	{
 		return this;
 	}

--- a/prism/src/parser/ast/SystemReference.java
+++ b/prism/src/parser/ast/SystemReference.java
@@ -119,6 +119,12 @@ public class SystemReference extends SystemDefn
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@Override
+	public SystemReference clone()
+	{
+		return (SystemReference) super.clone();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemReference.java
+++ b/prism/src/parser/ast/SystemReference.java
@@ -113,11 +113,9 @@ public class SystemReference extends SystemDefn
 	}
 	
 	@Override
-	public SystemDefn deepCopy()
+	public SystemReference deepCopyASTElements()
 	{
-		SystemDefn ret = new SystemReference(name);
-		ret.setPosition(this);
-		return ret;
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/SystemRename.java
+++ b/prism/src/parser/ast/SystemRename.java
@@ -197,16 +197,11 @@ public class SystemRename extends SystemDefn
 	}
 
 	@Override
-	public SystemDefn deepCopy()
+	public SystemRename deepCopyASTElements()
 	{
-		int i, n;
-		SystemRename ret = new SystemRename(getOperand().deepCopy());
-		n = getNumRenames();
-		for (i = 0; i < n; i++) {
-			ret.addRename(getFrom(i), getTo(i));
-		}
-		ret.setPosition(this);
-		return ret;
+		operand = operand.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/SystemRename.java
+++ b/prism/src/parser/ast/SystemRename.java
@@ -208,6 +208,18 @@ public class SystemRename extends SystemDefn
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public SystemRename clone()
+	{
+		SystemRename clone = (SystemRename) super.clone();
+
+		clone.from = (Vector<String>) from.clone();
+		clone.to   = (Vector<String>) to.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemRename.java
+++ b/prism/src/parser/ast/SystemRename.java
@@ -26,10 +26,11 @@
 
 package parser.ast;
 
-import java.util.Vector;
-
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
+
+import java.util.Vector;
 
 public class SystemRename extends SystemDefn
 {
@@ -197,9 +198,9 @@ public class SystemRename extends SystemDefn
 	}
 
 	@Override
-	public SystemRename deepCopyASTElements()
+	public SystemRename deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		operand = operand.clone().deepCopyASTElements();
+		operand = copier.copy(operand);
 
 		return this;
 	}

--- a/prism/src/parser/ast/Update.java
+++ b/prism/src/parser/ast/Update.java
@@ -36,6 +36,7 @@ import parser.Values;
 import parser.VarList;
 import parser.type.Type;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 /**
@@ -319,9 +320,9 @@ public class Update extends ASTElement implements Iterable<UpdateElement>
 	}
 
 	@Override
-	public Update deepCopyASTElements()
+	public Update deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		elements.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		copier.copyAll(elements);
 
 		return this;
 	}

--- a/prism/src/parser/ast/Update.java
+++ b/prism/src/parser/ast/Update.java
@@ -319,14 +319,11 @@ public class Update extends ASTElement implements Iterable<UpdateElement>
 	}
 
 	@Override
-	public ASTElement deepCopy()
+	public Update deepCopyASTElements()
 	{
-		Update ret = new Update();
-		for (UpdateElement e : this) {
-			ret.addElement(e.deepCopy());
-		}
-		ret.setPosition(this);
-		return ret;
+		elements.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/Update.java
+++ b/prism/src/parser/ast/Update.java
@@ -328,6 +328,17 @@ public class Update extends ASTElement implements Iterable<UpdateElement>
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Update clone()
+	{
+		Update clone = (Update) super.clone();
+
+		clone.elements = (ArrayList<UpdateElement>) elements.clone();
+
+		return clone;
+	}
 	
 	// Other methods:
 	

--- a/prism/src/parser/ast/UpdateElement.java
+++ b/prism/src/parser/ast/UpdateElement.java
@@ -202,12 +202,12 @@ public class UpdateElement extends ASTElement
 	}
 
 	@Override
-	public UpdateElement deepCopy()
+	public UpdateElement deepCopyASTElements()
 	{
-		UpdateElement result = new UpdateElement((ExpressionIdent)ident.deepCopy(), expr.deepCopy());
-		result.type = type;
-		result.index = index;
-		return result;
+		ident = ident.clone().deepCopyASTElements();
+		expr = expr.clone().deepCopyASTElements();
+
+		return this;
 	}
 
 	@Override

--- a/prism/src/parser/ast/UpdateElement.java
+++ b/prism/src/parser/ast/UpdateElement.java
@@ -32,6 +32,7 @@ import parser.Values;
 import parser.VarList;
 import parser.type.Type;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 /**
@@ -202,10 +203,10 @@ public class UpdateElement extends ASTElement
 	}
 
 	@Override
-	public UpdateElement deepCopyASTElements()
+	public UpdateElement deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		ident = ident.clone().deepCopyASTElements();
-		expr = expr.clone().deepCopyASTElements();
+		ident = copier.copy(ident);
+		expr = copier.copy(expr);
 
 		return this;
 	}

--- a/prism/src/parser/ast/UpdateElement.java
+++ b/prism/src/parser/ast/UpdateElement.java
@@ -209,6 +209,12 @@ public class UpdateElement extends ASTElement
 		result.index = index;
 		return result;
 	}
+
+	@Override
+	public UpdateElement clone()
+	{
+		return (UpdateElement) super.clone();
+	}
 	
 	// Other methods:
 	

--- a/prism/src/parser/ast/Updates.java
+++ b/prism/src/parser/ast/Updates.java
@@ -175,22 +175,15 @@ public class Updates extends ASTElement
 	}
 
 	/**
-	 * Perform a deep copy.
+	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
-	public ASTElement deepCopy()
+	@Override
+	public Updates deepCopyASTElements()
 	{
-		int i, n;
-		Expression p;
-		Updates ret = new Updates();
-		n = getNumUpdates();
-		for (i = 0; i < n; i++) {
-			p = getProbability(i);
-			if (p != null)
-				p = p.deepCopy();
-			ret.addUpdate(p, (Update) getUpdate(i).deepCopy());
-		}
-		ret.setPosition(this);
-		return ret;
+		probs.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		updates.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/prism/src/parser/ast/Updates.java
+++ b/prism/src/parser/ast/Updates.java
@@ -26,11 +26,14 @@
 
 package parser.ast;
 
-import java.util.*;
-
-import parser.*;
-import parser.visitor.*;
+import parser.State;
+import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Class to store a list of updates with associated probabilities (or rates).
@@ -178,10 +181,14 @@ public class Updates extends ASTElement
 	 * Copy all internal ASTElements. (Should be called after clone to create deep copy)
 	 */
 	@Override
-	public Updates deepCopyASTElements()
+	public Updates deepCopy(DeepCopy copier) throws PrismLangException
 	{
-		probs.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
-		updates.replaceAll(e -> (e == null) ? null : e.clone().deepCopyASTElements());
+		copier.copyAll(probs);
+		for (int i = 0, n = getNumUpdates(); i < n; i++) {
+			Update upd = Objects.requireNonNull(getUpdate(i));
+			setUpdate(i, copier.copy(upd));
+		}
+		copier.copyAll(updates);
 
 		return this;
 	}

--- a/prism/src/parser/ast/Updates.java
+++ b/prism/src/parser/ast/Updates.java
@@ -192,6 +192,18 @@ public class Updates extends ASTElement
 		ret.setPosition(this);
 		return ret;
 	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Updates clone()
+	{
+		Updates clone = (Updates) super.clone();
+
+		clone.probs   = (ArrayList<Expression>) probs.clone();
+		clone.updates = (ArrayList<Update>) updates.clone();
+
+		return clone;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/visitor/DeepCopy.java
+++ b/prism/src/parser/visitor/DeepCopy.java
@@ -1,0 +1,416 @@
+package parser.visitor;
+
+
+import parser.ast.ASTElement;
+import parser.ast.Command;
+import parser.ast.ConstantList;
+import parser.ast.Declaration;
+import parser.ast.DeclarationArray;
+import parser.ast.DeclarationBool;
+import parser.ast.DeclarationClock;
+import parser.ast.DeclarationInt;
+import parser.ast.DeclarationIntUnbounded;
+import parser.ast.ExpressionBinaryOp;
+import parser.ast.ExpressionConstant;
+import parser.ast.ExpressionExists;
+import parser.ast.ExpressionFilter;
+import parser.ast.ExpressionForAll;
+import parser.ast.ExpressionFormula;
+import parser.ast.ExpressionFunc;
+import parser.ast.ExpressionITE;
+import parser.ast.ExpressionIdent;
+import parser.ast.ExpressionLabel;
+import parser.ast.ExpressionLiteral;
+import parser.ast.ExpressionObs;
+import parser.ast.ExpressionProb;
+import parser.ast.ExpressionProp;
+import parser.ast.ExpressionReward;
+import parser.ast.ExpressionSS;
+import parser.ast.ExpressionStrategy;
+import parser.ast.ExpressionTemporal;
+import parser.ast.ExpressionUnaryOp;
+import parser.ast.ExpressionVar;
+import parser.ast.Filter;
+import parser.ast.ForLoop;
+import parser.ast.FormulaList;
+import parser.ast.LabelList;
+import parser.ast.Module;
+import parser.ast.ModulesFile;
+import parser.ast.Observable;
+import parser.ast.ObservableVars;
+import parser.ast.PropertiesFile;
+import parser.ast.Property;
+import parser.ast.RenamedModule;
+import parser.ast.RewardStruct;
+import parser.ast.RewardStructItem;
+import parser.ast.SystemBrackets;
+import parser.ast.SystemFullParallel;
+import parser.ast.SystemHide;
+import parser.ast.SystemInterleaved;
+import parser.ast.SystemModule;
+import parser.ast.SystemParallel;
+import parser.ast.SystemReference;
+import parser.ast.SystemRename;
+import parser.ast.Update;
+import parser.ast.UpdateElement;
+import parser.ast.Updates;
+import prism.PrismLangException;
+
+import java.util.List;
+import java.util.ListIterator;
+
+/**
+ * DeepCopy is a visitor that copies an AST.
+ * <p>
+ * For copying it provides the methods {@link DeepCopy#copy} and {@link DeepCopy#copyAll} and relies
+ * on {@link ASTElement#deepCopy(DeepCopy)}.
+ * </p>
+ *
+ * @see ASTElement#deepCopy(DeepCopy)
+ */
+public class DeepCopy implements ASTVisitor
+{
+	/**
+	 * Copy an ASTElement or null.
+	 *
+	 * @param element the element to be copied or null
+	 * @return copy of the element or null
+	 * @throws PrismLangException
+	 */
+	@SuppressWarnings("unchecked")
+	public <T extends ASTElement> T copy(T element) throws PrismLangException
+	{
+		return (element == null) ? null : (T) element.accept(this);
+	}
+
+	/**
+	 * Copy all ASTElements (or null) in the collection.
+	 *
+	 * @param list list of elements to be copied
+	 * @return the argument list with all elements copied
+	 * @throws PrismLangException
+	 */
+	public <T extends ASTElement> List<T> copyAll(List<T> list) throws PrismLangException
+	{
+		if (list == null)
+			return null;
+
+		ListIterator<T> iter = list.listIterator();
+		while (iter.hasNext()) {
+			iter.set(copy(iter.next()));
+		}
+		return list;
+	}
+
+	@Override
+	public Object visit(ModulesFile e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(PropertiesFile e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(Property e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(FormulaList e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(LabelList e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ConstantList e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(Declaration e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(DeclarationInt e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(DeclarationBool e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(DeclarationArray e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(DeclarationClock e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(DeclarationIntUnbounded e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(Module e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(Command e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(Updates e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(Update e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(UpdateElement e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(RenamedModule e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(RewardStruct e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(RewardStructItem e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ObservableVars e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(Observable e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(SystemInterleaved e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(SystemFullParallel e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(SystemParallel e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(SystemHide e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(SystemRename e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(SystemModule e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(SystemBrackets e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(SystemReference e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionTemporal e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionITE e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionBinaryOp e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionUnaryOp e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionFunc e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionIdent e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionLiteral e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionConstant e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionFormula e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionVar e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionProb e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionReward e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionSS e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionExists e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionForAll e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionStrategy e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionLabel e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionObs e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionProp e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ExpressionFilter e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(Filter e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+
+	@Override
+	public Object visit(ForLoop e) throws PrismLangException
+	{
+		return e.clone().deepCopy(this);
+	}
+}

--- a/prism/src/prism/ResultsExporter.java
+++ b/prism/src/prism/ResultsExporter.java
@@ -395,7 +395,7 @@ public abstract class ResultsExporter
 			Map<String, Integer> nameCounts = new HashMap<>();
 			// 1. Ensure each property is given a name and count names
 			for (int i=0, size=properties.size(); i<size; i++) {
-				Property property = properties.get(i).deepCopy();
+				Property property = (Property) properties.get(i).deepCopy();
 				String name = property.getName();
 				if (name == null || name.isEmpty()) {
 					// Create copy with new name
@@ -449,7 +449,7 @@ public abstract class ResultsExporter
 				// Ensure property has a name
 				String name = property.getName();
 				if (name == null || name.isEmpty()) {
-					property = property.deepCopy();
+					property = (Property) property.deepCopy();
 					property.setName("Property_1");
 				}
 			}

--- a/prism/unit-tests/parser/ast/ExpressionBinaryOpShortCircuitTest.java
+++ b/prism/unit-tests/parser/ast/ExpressionBinaryOpShortCircuitTest.java
@@ -123,6 +123,12 @@ public class ExpressionBinaryOpShortCircuitTest
 		}
 
 		@Override
+		public ExpressionMock deepCopyASTElements()
+		{
+			return this;
+		}
+
+		@Override
 		public boolean isConstant()
 		{
 			return true;

--- a/prism/unit-tests/parser/ast/ExpressionBinaryOpShortCircuitTest.java
+++ b/prism/unit-tests/parser/ast/ExpressionBinaryOpShortCircuitTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import parser.EvaluateContext;
 import parser.visitor.ASTVisitor;
+import parser.visitor.DeepCopy;
 import prism.PrismLangException;
 
 import java.util.Objects;
@@ -117,15 +118,15 @@ public class ExpressionBinaryOpShortCircuitTest
 		}
 
 		@Override
-		public String toString()
+		public ExpressionMock deepCopy(DeepCopy copier)
 		{
-			return "Evaluated? " + evaluated;
+			return this;
 		}
 
 		@Override
-		public ExpressionMock deepCopyASTElements()
+		public String toString()
 		{
-			return this;
+			return "Evaluated? " + evaluated;
 		}
 
 		@Override


### PR DESCRIPTION
This PR separates deep-copying an AST element in its two logical steps:

1. Creating a shallow copy of the AST node
2. Recursively cloning the fields and child nodes using a visitor called `DeepCopy`

This enables the programmer to create both shallow copies (aka clones in Java terminology) and deep copies. The visitor DeepCopy provides the programmer a hook into the copying process. This can be useful, e.g., to modify the copy on the fly or cache copied elements. It also provides a cleaner interface since traversal and copying logic is better separated. To simplify copying child nodes, `DeepCopy` provides the utility methods `#copy(ASTElement)` and `#copy(List<T>)` which also deal with `null` values. To adapt existing and new subclasses of `ASTElement`, a programmer hast to:

- Override `#clone` such that a) the type of the callee is returned and b) all collection fields are cloned, too. See `Command#clone` and `ConstantList#clone` .
- Override the abstract method `#deepCopy(DeepCopy)` such that it a) returns the type of the callee and b) deep copies of it's child nodes and fields using the utility methods of the provided visitor. See `Command#deepCopy` and `ConstantList#deepCopy` . These methods are shorter and cleaner than the old `#deepCopy` method.

Performance-wise, the impact of this structural change to gain flexibility is negligible.