### PR TITLE
Changing all Vectors to ArrayLists

### DIFF
--- a/prism/src/param/SymbolicEngine.java
+++ b/prism/src/param/SymbolicEngine.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Vector;
 
 import parser.State;
 import parser.ast.Command;
@@ -52,7 +51,7 @@ public class SymbolicEngine
 	protected ModelType modelType;
 	protected int numModules;
 	// Synchronising action info
-	protected Vector<String> synchs;
+	protected List<String> synchs;
 	protected int numSynchs;
 	protected int synchModuleCounts[];
 	

--- a/prism/src/parser/Values.java
+++ b/prism/src/parser/Values.java
@@ -28,6 +28,7 @@ package parser;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.List;
 
 import param.BigRational;
 import parser.type.Type;
@@ -44,8 +45,8 @@ import prism.PrismUtils;
  */
 public class Values implements Cloneable //implements Comparable
 {
-	protected ArrayList<String> names;
-	protected ArrayList<Object> values;
+	protected List<String> names;
+	protected List<Object> values;
 	
 	// Constructors
 	
@@ -69,8 +70,8 @@ public class Values implements Cloneable //implements Comparable
 			names = new ArrayList<String>();
 			values = new ArrayList<Object>();
 		} else {
-			names = (ArrayList<String>) v.names.clone();
-			values = (ArrayList<Object>) v.values.clone();
+			names = new ArrayList<String>(v.names);
+			values = new ArrayList<Object>(v.values);
 		}
 	}
 	
@@ -328,8 +329,8 @@ public class Values implements Cloneable //implements Comparable
 		} catch (CloneNotSupportedException e) {
 			throw new InternalError("Object#clone is expected to work for Cloneable objects.", e);
 		}
-		clone.names = (ArrayList<String>) names.clone();
-		clone.values = (ArrayList<Object>) values.clone();
+		clone.names = new ArrayList<String>(names);
+		clone.values = new ArrayList<Object>(values);
 		return clone;
 	}
 

--- a/prism/src/parser/ast/ASTElement.java
+++ b/prism/src/parser/ast/ASTElement.java
@@ -226,9 +226,9 @@ public abstract class ASTElement
 	/**
 	 * Get all formulas (i.e. ExpressionFormula objects), store names in set.
 	 */
-	public Vector<String> getAllFormulas() throws PrismLangException
+	public List<String> getAllFormulas() throws PrismLangException
 	{
-		Vector<String> v = new Vector<String>();
+		List<String> v = new ArrayList<>();
 		GetAllFormulas visitor = new GetAllFormulas(v);
 		accept(visitor);
 		return v;
@@ -256,9 +256,9 @@ public abstract class ASTElement
 	/**
 	 * Get all constants (i.e. ExpressionConstant objects), store names in set.
 	 */
-	public Vector<String> getAllConstants()
+	public List<String> getAllConstants()
 	{
-		Vector<String> v = new Vector<String>();
+		List<String> v = new ArrayList<>();
 		GetAllConstants visitor = new GetAllConstants(v);
 		try {
 			accept(visitor);
@@ -277,9 +277,9 @@ public abstract class ASTElement
 	* ConstantList must be non-null so that we can determine which constants are undefined;
 	* LabelList and PropertiesFile passed in as null are ignored.
 	 */
-	public Vector<String> getAllUndefinedConstantsRecursively(ConstantList constantList, LabelList labelList, PropertiesFile propertiesFile)
+	public List<String> getAllUndefinedConstantsRecursively(ConstantList constantList, LabelList labelList, PropertiesFile propertiesFile)
 	{
-		Vector<String> v = new Vector<String>();
+		List<String> v = new ArrayList<>();
 		GetAllUndefinedConstantsRecursively visitor = new GetAllUndefinedConstantsRecursively(v, constantList, labelList, propertiesFile);
 		try {
 			accept(visitor);
@@ -320,9 +320,9 @@ public abstract class ASTElement
 	/**
 	 * Get all variables (i.e. ExpressionVar objects), store names in set.
 	 */
-	public Vector<String> getAllVars() throws PrismLangException
+	public List<String> getAllVars() throws PrismLangException
 	{
-		Vector<String> v = new Vector<String>();
+		List<String> v = new ArrayList<>();
 		GetAllVars visitor = new GetAllVars(v);
 		accept(visitor);
 		return v;
@@ -341,9 +341,9 @@ public abstract class ASTElement
 	 * Get all labels (i.e. ExpressionLabel objects), store names in set.
 	 * Special labels "deadlock", "init" *are* included in the list.
 	 */
-	public Vector<String> getAllLabels() throws PrismLangException
+	public List<String> getAllLabels() throws PrismLangException
 	{
-		Vector<String> v = new Vector<String>();
+		List<String> v = new ArrayList<>();
 		GetAllLabels visitor = new GetAllLabels(v);
 		accept(visitor);
 		return v;
@@ -372,9 +372,9 @@ public abstract class ASTElement
 	/**
 	 * Get all references to properties (by name) (i.e. ExpressionProp objects), store names in set.
 	 */
-	public Vector<String> getAllPropRefs() throws PrismLangException
+	public List<String> getAllPropRefs() throws PrismLangException
 	{
-		Vector<String> v = new Vector<String>();
+		List<String> v = new ArrayList<>();
 		GetAllPropRefs visitor = new GetAllPropRefs(v);
 		accept(visitor);
 		return v;
@@ -383,9 +383,9 @@ public abstract class ASTElement
 	/**
 	 * Get all references to properties (by name) (i.e. ExpressionProp objects) recursively, store names in set.
 	 */
-	public Vector<String> getAllPropRefsRecursively(PropertiesFile propertiesFile) throws PrismLangException
+	public List<String> getAllPropRefsRecursively(PropertiesFile propertiesFile) throws PrismLangException
 	{
-		Vector<String> v = new Vector<String>();
+		List<String> v = new ArrayList<>();
 		GetAllPropRefsRecursively visitor = new GetAllPropRefsRecursively(v, propertiesFile);
 		accept(visitor);
 		return v;

--- a/prism/src/parser/ast/ConstantList.java
+++ b/prism/src/parser/ast/ConstantList.java
@@ -26,16 +26,20 @@
 
 package parser.ast;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Vector;
-
 import param.BigRational;
-import parser.*;
-import parser.visitor.*;
+import parser.Values;
+import parser.type.Type;
+import parser.type.TypeBool;
+import parser.type.TypeDouble;
+import parser.type.TypeInt;
+import parser.visitor.ASTVisitor;
 import prism.PrismLangException;
 import prism.PrismUtils;
-import parser.type.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Class to store list of (defined and undefined) constants
@@ -43,12 +47,12 @@ import parser.type.*;
 public class ConstantList extends ASTElement
 {
 	// Name/expression/type triples to define constants
-	private Vector<String> names = new Vector<String>();
-	private Vector<Expression> constants = new Vector<Expression>(); // these can be null, i.e. undefined
-	private Vector<Type> types = new Vector<Type>();
+	private final List<String> names = new ArrayList<>();
+	private final List<Expression> constants = new ArrayList<>(); // these can be null, i.e. undefined
+	private final List<Type> types = new ArrayList<>();
 	// We also store an ExpressionIdent to match each name.
 	// This is to just to provide positional info.
-	private Vector<ExpressionIdent> nameIdents = new Vector<ExpressionIdent>();
+	private final List<ExpressionIdent> nameIdents = new ArrayList<>();
 	
 	/** Constructor */
 	public ConstantList()
@@ -76,15 +80,15 @@ public class ConstantList extends ASTElement
 	
 	public void addConstant(ExpressionIdent n, Expression c, Type t)
 	{
-		names.addElement(n.getName());
-		constants.addElement(c);
-		types.addElement(t);
-		nameIdents.addElement(n);
+		names.add(n.getName());
+		constants.add(c);
+		types.add(t);
+		nameIdents.add(n);
 	}
 	
 	public void setConstant(int i, Expression c)
 	{
-		constants.setElementAt(c, i);
+		constants.set(i, c);
 	}
 	
 	// Get methods
@@ -96,22 +100,22 @@ public class ConstantList extends ASTElement
 
 	public String getConstantName(int i)
 	{
-		return names.elementAt(i);
+		return names.get(i);
 	}
 	
 	public Expression getConstant(int i)
 	{
-		return constants.elementAt(i);
+		return constants.get(i);
 	}
 	
 	public Type getConstantType(int i)
 	{
-		return types.elementAt(i);
+		return types.get(i);
 	}
 	
 	public ExpressionIdent getConstantNameIdent(int i)
 	{
-		return nameIdents.elementAt(i);
+		return nameIdents.get(i);
 	}
 
 	/**
@@ -164,9 +168,9 @@ public class ConstantList extends ASTElement
 		for (int i = 0; i < n; i++) {
 			Expression e = getConstant(i);
 			if (e != null) {
-				Vector<String> v = e.getAllConstants();
+				List<String> v = e.getAllConstants();
 				for (int j = 0; j < v.size(); j++) {
-					int k = getConstantIndex(v.elementAt(j));
+					int k = getConstantIndex(v.get(j));
 					if (k != -1) {
 						matrix[i][k] = true;
 					}
@@ -204,18 +208,17 @@ public class ConstantList extends ASTElement
 	/**
 	 * Get a list of the undefined constants in the list.
 	 */
-	public Vector<String> getUndefinedConstants()
+	public List<String> getUndefinedConstants()
 	{
 		int i, n;
 		Expression e;
-		Vector<String> v;
-		
-		v = new Vector<String>();
+		List<String> v = new ArrayList<>();
+
 		n = constants.size();
 		for (i = 0; i < n; i++) {
 			e = getConstant(i);
 			if (e == null) {
-				v.addElement(getConstantName(i));
+				v.add(getConstantName(i));
 			}
 		}
 		

--- a/prism/src/parser/ast/FormulaList.java
+++ b/prism/src/parser/ast/FormulaList.java
@@ -26,39 +26,40 @@
 
 package parser.ast;
 
-import java.util.Vector;
-
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
 import prism.PrismLangException;
 import prism.PrismUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 // class to store list of formulas
 
 public class FormulaList extends ASTElement
 {
 	// Name/expression pairs to define formulas
-	private Vector<String> names;
-	private Vector<Expression> formulas;
+	private List<String> names;
+	private List<Expression> formulas;
 	// We also store an ExpressionIdent to match each name.
 	// This is to just to provide positional info.
-	private Vector<ExpressionIdent> nameIdents;
+	private List<ExpressionIdent> nameIdents;
 
 	// Constructor
 
 	public FormulaList()
 	{
-		names = new Vector<String>();
-		formulas = new Vector<Expression>();
-		nameIdents = new Vector<ExpressionIdent>();
+		names = new ArrayList<>();
+		formulas = new ArrayList<>();
+		nameIdents = new ArrayList<>();
 	}
 
 	// Set methods
 
 	public void addFormula(ExpressionIdent n, Expression f)
 	{
-		names.addElement(n.getName());
-		formulas.addElement(f);
-		nameIdents.addElement(n);
+		names.add(n.getName());
+		formulas.add(f);
+		nameIdents.add(n);
 	}
 
 	public void setFormulaName(int i, ExpressionIdent n)
@@ -81,17 +82,17 @@ public class FormulaList extends ASTElement
 
 	public String getFormulaName(int i)
 	{
-		return names.elementAt(i);
+		return names.get(i);
 	}
 
 	public Expression getFormula(int i)
 	{
-		return formulas.elementAt(i);
+		return formulas.get(i);
 	}
 
 	public ExpressionIdent getFormulaNameIdent(int i)
 	{
-		return nameIdents.elementAt(i);
+		return nameIdents.get(i);
 	}
 
 	/**
@@ -112,9 +113,9 @@ public class FormulaList extends ASTElement
 		int n = size();
 		boolean matrix[][] = new boolean[n][n];
 		for (int i = 0; i < n; i++) {
-			Vector<String> v = getFormula(i).getAllFormulas();
+			List<String> v = getFormula(i).getAllFormulas();
 			for (int j = 0; j < v.size(); j++) {
-				int k = getFormulaIndex((String) v.elementAt(j));
+				int k = getFormulaIndex(v.get(j));
 				if (k != -1) {
 					matrix[i][k] = true;
 				}

--- a/prism/src/parser/ast/LabelList.java
+++ b/prism/src/parser/ast/LabelList.java
@@ -28,7 +28,6 @@ package parser.ast;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 
 import parser.visitor.ASTVisitor;
 import prism.PrismLangException;
@@ -39,18 +38,18 @@ public class LabelList extends ASTElement
 {
 	// Name/expression pairs to define labels
 	private List<String> names;
-	private Vector<Expression> labels;
+	private List<Expression> labels;
 	// We also store an ExpressionIdent to match each name.
 	// This is to just to provide positional info.
-	private Vector<ExpressionIdent> nameIdents;
+	private List<ExpressionIdent> nameIdents;
 	
 	// Constructor
 	
 	public LabelList()
 	{
-		names = new ArrayList<String>();
-		labels = new Vector<Expression>();
-		nameIdents = new Vector<ExpressionIdent>();
+		names = new ArrayList<>();
+		labels = new ArrayList<>();
+		nameIdents = new ArrayList<>();
 	}
 	
 	// Set methods
@@ -58,7 +57,7 @@ public class LabelList extends ASTElement
 	public void addLabel(ExpressionIdent n, Expression l)
 	{
 		names.add(n.getName());
-		labels.addElement(l);
+		labels.add(l);
 		nameIdents.add(n);
 	}
 	
@@ -92,12 +91,12 @@ public class LabelList extends ASTElement
 	
 	public Expression getLabel(int i)
 	{
-		return labels.elementAt(i);
+		return labels.get(i);
 	}
 	
 	public ExpressionIdent getLabelNameIdent(int i)
 	{
-		return nameIdents.elementAt(i);
+		return nameIdents.get(i);
 	}
 
 	/**

--- a/prism/src/parser/ast/Module.java
+++ b/prism/src/parser/ast/Module.java
@@ -26,10 +26,11 @@
 
 package parser.ast;
 
-import java.util.*;
-
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
 import prism.PrismLangException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class Module extends ASTElement
 {
@@ -47,15 +48,15 @@ public class Module extends ASTElement
 	// Base module (if was constructed through renaming; null if not)
 	private String baseModule;
 	// Alphabet (if defined explicitly rather than deduced from syntax)
-	private Vector<String> alphabet;
+	private List<String> alphabet;
 
 	// Constructor
 	
 	public Module(String n)
 	{
 		name = n;
-		decls = new ArrayList<Declaration>();
-		commands = new ArrayList<Command>();
+		decls = new ArrayList<>();
+		commands = new ArrayList<>();
 		invariant = null;
 		parent = null;
 		baseModule = null;
@@ -122,7 +123,7 @@ public class Module extends ASTElement
 	 */
 	public void setAlphabet(List<String> alphabet)
 	{
-		this.alphabet = (alphabet == null) ? null : new Vector<String>(alphabet); 
+		this.alphabet = (alphabet == null) ? null : new ArrayList<>(alphabet);
 	}
 	
 	// Get methods
@@ -209,7 +210,7 @@ public class Module extends ASTElement
 	 * module ensures that a is in the alphabet, regardless of whether the guard is true.
 	 * The alphabet for a module can also be overridden using {@link #setAlphabet(List)}
 	 */
-	public Vector<String> getAllSynchs()
+	public List<String> getAllSynchs()
 	{
 		// If overridden, use this
 		if (alphabet != null) {
@@ -218,7 +219,7 @@ public class Module extends ASTElement
 		// Otherwise, deduce syntactically
 		int i, n;
 		String s;
-		Vector<String> allSynchs = new Vector<String>();
+		List<String> allSynchs = new ArrayList<>();
 		n = getNumCommands();
 		for (i = 0; i < n; i++) {
 			s = getCommand(i).getSynch();

--- a/prism/src/parser/ast/ModulesFile.java
+++ b/prism/src/parser/ast/ModulesFile.java
@@ -29,7 +29,6 @@ package parser.ast;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Vector;
 
 import param.BigRational;
 import parser.IdentUsage;
@@ -61,11 +60,11 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 	private FormulaList formulaList;
 	private LabelList labelList;
 	private ConstantList constantList;
-	private Vector<Declaration> globals; // Global variables
-	private Vector<Object> modules; // Modules (includes renamed modules)
-	private ArrayList<SystemDefn> systemDefns; // System definitions (system...endsystem constructs)
-	private ArrayList<String> systemDefnNames; // System definition names (system...endsystem constructs)
-	private ArrayList<RewardStruct> rewardStructs; // Rewards structures
+	private List<Declaration> globals; // Global variables
+	private List<Object> modules; // Modules (includes renamed modules)
+	private List<SystemDefn> systemDefns; // System definitions (system...endsystem constructs)
+	private List<String> systemDefnNames; // System definition names (system...endsystem constructs)
+	private List<RewardStruct> rewardStructs; // Rewards structures
 	private List<String> rewardStructNames; // Names of reward structures
 	private Expression initStates; // Initial states specification
 	private List<ObservableVars> observableVarLists; // Observable variables lists
@@ -77,12 +76,12 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 	// List of all module names
 	private String[] moduleNames;
 	// List of synchronising actions
-	private Vector<String> synchs;
+	private List<String> synchs;
 	// Lists of variable info (declaration, name, type, module index)
-	private Vector<Declaration> varDecls;
-	private Vector<String> varNames;
-	private Vector<Type> varTypes;
-	private Vector<Integer> varModules;
+	private List<Declaration> varDecls;
+	private List<String> varNames;
+	private List<Type> varTypes;
+	private List<Integer> varModules;
 	// Lists of observable info
 	private List<Observable> observables;
 	private List<String> observableNames;
@@ -102,8 +101,8 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 		labelList = new LabelList();
 		constantList = new ConstantList();
 		modelTypeInFile = modelType = null; // Unspecified
-		globals = new Vector<Declaration>();
-		modules = new Vector<Object>();
+		globals = new ArrayList<>();
+		modules = new ArrayList<>();
 		systemDefns = new ArrayList<SystemDefn>();
 		systemDefnNames = new ArrayList<String>();
 		rewardStructs = new ArrayList<RewardStruct>();
@@ -113,10 +112,10 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 		observableDefns = new ArrayList<>();
 		identUsage = new IdentUsage();
 		quotedIdentUsage = new IdentUsage(true);
-		varDecls = new Vector<Declaration>();
-		varNames = new Vector<String>();
-		varTypes = new Vector<Type>();
-		varModules = new Vector<Integer>();
+		varDecls = new ArrayList<>();
+		varNames = new ArrayList<>();
+		varTypes = new ArrayList<>();
+		varModules = new ArrayList<>();
 		observables = new ArrayList<>();
 		observableNames = new ArrayList<>();
 		observableTypes = new ArrayList<>();
@@ -372,7 +371,7 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 
 	public Declaration getGlobal(int i)
 	{
-		return globals.elementAt(i);
+		return globals.get(i);
 	}
 	
 	public int getNumModules()
@@ -385,7 +384,7 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 	// these will have been replaced with Modules after tidyUp()
 	public Module getModule(int i)
 	{
-		Object o = modules.elementAt(i);
+		Object o = modules.get(i);
 		return (o instanceof Module) ? (Module) o : null;
 	}
 
@@ -705,7 +704,7 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 	/**
 	 * Get the list of action names.
 	 */
-	public Vector<String> getSynchs()
+	public List<String> getSynchs()
 	{
 		return synchs;
 	}
@@ -769,12 +768,12 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 		return varTypes.get(i);
 	}
 
-	public Vector<String> getVarNames()
+	public List<String> getVarNames()
 	{
 		return varNames;
 	}
 
-	public Vector<Type> getVarTypes()
+	public List<Type> getVarTypes()
 	{
 		return varTypes;
 	}
@@ -968,7 +967,7 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 		// Go through modules and find ones which are defined by renaming
 		n = modules.size();
 		for (i = 0; i < n; i++) {
-			o = modules.elementAt(i);
+			o = modules.get(i);
 			if (o instanceof Module)
 				continue;
 			module = (RenamedModule) o;
@@ -1046,12 +1045,12 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 
 	private void getSynchNames() throws PrismLangException
 	{
-		Vector<String> v;
+		List<String> v;
 		String s;
 		int i, j, n, m;
 
-		// create vector to store names
-		synchs = new Vector<String>();
+		// create list to store names
+		synchs = new ArrayList<>();
 
 		// go thru modules and extract names which appear in their commands
 		n = modules.size();
@@ -1059,7 +1058,7 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 			v = getModule(i).getAllSynchs();
 			m = v.size();
 			for (j = 0; j < m; j++) {
-				s = v.elementAt(j);
+				s = v.get(j);
 				if (!synchs.contains(s)) {
 					synchs.add(s);
 				}
@@ -1180,10 +1179,10 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 		boolean matrix[][] = new boolean[n][n];
 		for (int i = 0; i < n; i++) {
 			SystemDefn sys = systemDefns.get(i);
-			Vector<String> v = new Vector<String>();
+			List<String> v = new ArrayList<>();
 			sys.getReferences(v);
 			for (int j = 0; j < v.size(); j++) {
-				int k = getSystemDefnIndex(v.elementAt(j));
+				int k = getSystemDefnIndex(v.get(j));
 				if (k != -1) {
 					matrix[i][k] = true;
 				}
@@ -1288,7 +1287,7 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 	 * Get  a list of constants in the model that are undefined
 	 * ("const int x;" rather than "const int x = 1;") 
 	 */
-	public Vector<String> getUndefinedConstants()
+	public List<String> getUndefinedConstants()
 	{
 		return constantList.getUndefinedConstants();
 	}
@@ -1463,10 +1462,10 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 		int i, n;
 
 		// Recompute lists of all variables and types
-		varDecls = new Vector<Declaration>();
-		varNames = new Vector<String>();
-		varTypes = new Vector<Type>();
-		varModules = new Vector<Integer>();
+		varDecls = new ArrayList<>();
+		varNames = new ArrayList<>();
+		varTypes = new ArrayList<>();
+		varModules = new ArrayList<>();
 		// Globals
 		for (Declaration decl : globals) {
 			varDecls.add(decl);
@@ -1616,9 +1615,9 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 		}
 
 		for (i = 0; i < modules.size() - 1; i++) {
-			s += modules.elementAt(i) + "\n\n";
+			s += modules.get(i) + "\n\n";
 		}
-		s += modules.elementAt(modules.size() - 1) + "\n";
+		s += modules.get(modules.size() - 1) + "\n";
 
 		for (i = 0; i < systemDefns.size(); i++) {
 			s += "\nsystem ";
@@ -1683,15 +1682,15 @@ public class ModulesFile extends ASTElement implements ModelInfo, RewardGenerato
 		ret.identUsage = (identUsage == null) ? null : identUsage.deepCopy();
 		ret.quotedIdentUsage = (quotedIdentUsage == null) ? null : quotedIdentUsage.deepCopy();
 		ret.moduleNames = (moduleNames == null) ? null : moduleNames.clone();
-		ret.synchs = (synchs == null) ? null : (Vector<String>)synchs.clone();
+		ret.synchs = (synchs == null) ? null : new ArrayList<>(synchs);
 		if (varDecls != null) {
-			ret.varDecls = new Vector<Declaration>();
+			ret.varDecls = new ArrayList<>();
 			for (Declaration d : varDecls)
 				ret.varDecls.add((Declaration) d.deepCopy());
 		}
-		ret.varNames = (varNames == null) ? null : (Vector<String>)varNames.clone();
-		ret.varTypes = (varTypes == null) ? null : (Vector<Type>)varTypes.clone();
-		ret.varModules = (varModules == null) ? null : (Vector<Integer>)varModules.clone();
+		ret.varNames = (varNames == null) ? null : new ArrayList<>(varNames);
+		ret.varTypes = (varTypes == null) ? null : new ArrayList<>(varTypes);
+		ret.varModules = (varModules == null) ? null : new ArrayList<>(varModules);
 		for (Observable obs : observables)
 			ret.observables.add(obs.deepCopy());
 		ret.observableNames = (observableNames == null) ? null : new ArrayList<>(observableNames);

--- a/prism/src/parser/ast/PropertiesFile.java
+++ b/prism/src/parser/ast/PropertiesFile.java
@@ -26,13 +26,16 @@
 
 package parser.ast;
 
-import java.util.*;
-
-import parser.*;
-import parser.visitor.*;
+import parser.IdentUsage;
+import parser.Values;
+import parser.visitor.ASTVisitor;
+import parser.visitor.PropertiesSemanticCheck;
 import prism.ModelInfo;
 import prism.PrismLangException;
 import prism.PrismUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 // Class representing parsed properties file/list
 
@@ -47,7 +50,7 @@ public class PropertiesFile extends ASTElement
 	private LabelList labelList;
 	private LabelList combinedLabelList; // Labels from both model/here
 	private ConstantList constantList;
-	private Vector<Property> properties; // Properties
+	private List<Property> properties; // Properties
 
 	// Info about all identifiers used
 	private IdentUsage identUsage;
@@ -67,7 +70,7 @@ public class PropertiesFile extends ASTElement
 		labelList = new LabelList();
 		combinedLabelList = new LabelList();
 		constantList = new ConstantList();
-		properties = new Vector<Property>();
+		properties = new ArrayList<>();
 		identUsage = new IdentUsage();
 		quotedIdentUsage = new IdentUsage(true);
 		undefinedConstantValues = null;
@@ -116,7 +119,7 @@ public class PropertiesFile extends ASTElement
 
 	public void addProperty(Expression p, String c)
 	{
-		properties.addElement(new Property(p, null, c));
+		properties.add(new Property(p, null, c));
 	}
 
 	public void setPropertyObject(int i, Property prop)
@@ -426,9 +429,9 @@ public class PropertiesFile extends ASTElement
 		boolean matrix[][] = new boolean[n][n];
 		for (int i = 0; i < n; i++) {
 			Expression e = properties.get(i).getExpression();
-			Vector<String> v = e.getAllPropRefs();
+			List<String> v = e.getAllPropRefs();
 			for (int j = 0; j < v.size(); j++) {
-				int k = getPropertyIndexByName(v.elementAt(j));
+				int k = getPropertyIndexByName(v.get(j));
 				if (k != -1) {
 					matrix[i][k] = true;
 				}
@@ -456,7 +459,7 @@ public class PropertiesFile extends ASTElement
 	 * Get a list of all undefined constants in the properties files
 	 * ("const int x;" rather than "const int x = 1;") 
 	 */
-	public Vector<String> getUndefinedConstants()
+	public List<String> getUndefinedConstants()
 	{
 		return constantList.getUndefinedConstants();
 	}
@@ -466,12 +469,12 @@ public class PropertiesFile extends ASTElement
 	 * (including those that appear in definitions of other needed constants)
 	 * (undefined constants are those of form "const int x;" rather than "const int x = 1;")
 	 */
-	public Vector<String> getUndefinedConstantsUsedInLabels()
+	public List<String> getUndefinedConstantsUsedInLabels()
 	{
 		int i, n;
 		Expression expr;
-		Vector<String> consts, tmp;
-		consts = new Vector<String>();
+		List<String> consts, tmp;
+		consts = new ArrayList<>();
 		n = labelList.size();
 		for (i = 0; i < n; i++) {
 			expr = labelList.getLabel(i);
@@ -490,7 +493,7 @@ public class PropertiesFile extends ASTElement
 	 * (including those that appear in definitions of other needed constants and labels/properties)
 	 * (undefined constants are those of form "const int x;" rather than "const int x = 1;") 
 	 */
-	public Vector<String> getUndefinedConstantsUsedInProperty(Property prop)
+	public List<String> getUndefinedConstantsUsedInProperty(Property prop)
 	{
 		return prop.getExpression().getAllUndefinedConstantsRecursively(constantList, combinedLabelList, this);
 	}
@@ -500,10 +503,10 @@ public class PropertiesFile extends ASTElement
 	 * (including those that appear in definitions of other needed constants and labels/properties)
 	 * (undefined constants are those of form "const int x;" rather than "const int x = 1;") 
 	 */
-	public Vector<String> getUndefinedConstantsUsedInProperties(List<Property> props)
+	public List<String> getUndefinedConstantsUsedInProperties(List<Property> props)
 	{
-		Vector<String> consts, tmp;
-		consts = new Vector<String>();
+		List<String> consts, tmp;
+		consts = new ArrayList<>();
 		for (Property prop : props) {
 			tmp = prop.getExpression().getAllUndefinedConstantsRecursively(constantList, combinedLabelList, this);
 			for (String s : tmp) {

--- a/prism/src/parser/ast/RewardStruct.java
+++ b/prism/src/parser/ast/RewardStruct.java
@@ -26,15 +26,16 @@
 
 package parser.ast;
 
-import java.util.Vector;
-
-import parser.visitor.*;
+import parser.visitor.ASTVisitor;
 import prism.PrismLangException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class RewardStruct extends ASTElement
 {
 	private String name;		// name (optional)
-	private Vector<RewardStructItem> items;		// list of items
+	private final List<RewardStructItem> items;		// list of items
 	private int numStateItems;	// how may of the items are state rewards
 	private int numTransItems;	// how may of the items are transition rewards
 	
@@ -43,7 +44,7 @@ public class RewardStruct extends ASTElement
 	public RewardStruct()
 	{
 		name = "";
-		items = new Vector<RewardStructItem>();
+		items = new ArrayList<>();
 		numStateItems = 0;
 		numTransItems = 0;
 	}
@@ -97,7 +98,7 @@ public class RewardStruct extends ASTElement
 	
 	public RewardStructItem getRewardStructItem(int i)
 	{
-		return items.elementAt(i);
+		return items.get(i);
 	}
 	
 	public String getSynch(int i)

--- a/prism/src/parser/ast/SystemBrackets.java
+++ b/prism/src/parser/ast/SystemBrackets.java
@@ -26,10 +26,10 @@
 
 package parser.ast;
 
-import java.util.Vector;
-
 import parser.visitor.*;
 import prism.PrismLangException;
+
+import java.util.List;
 
 // note: although this makes no difference to the meaning
 // of the expression, it means we can keep the user's
@@ -69,32 +69,32 @@ public class SystemBrackets extends SystemDefn
 	
 	@Override
 	@SuppressWarnings("deprecation")
-	public void getModules(Vector<String> v)
+	public void getModules(List<String> v)
 	{
 		operand.getModules(v);
 	}
 
 	@Override
-	public void getModules(Vector<String> v, ModulesFile modulesFile)
+	public void getModules(List<String> v, ModulesFile modulesFile)
 	{
 		operand.getModules(v, modulesFile);
 	}
 
 	@Override
 	@SuppressWarnings("deprecation")
-	public void getSynchs(Vector<String> v)
+	public void getSynchs(List<String> v)
 	{
 		operand.getSynchs(v);
 	}
 	
 	@Override
-	public void getSynchs(Vector<String> v, ModulesFile modulesFile)
+	public void getSynchs(List<String> v, ModulesFile modulesFile)
 	{
 		operand.getSynchs(v, modulesFile);
 	}
 	
 	@Override
-	public void getReferences(Vector<String> v)
+	public void getReferences(List<String> v)
 	{
 		operand.getReferences(v);
 	}

--- a/prism/src/parser/ast/SystemDefn.java
+++ b/prism/src/parser/ast/SystemDefn.java
@@ -26,7 +26,7 @@
 
 package parser.ast;
 
-import java.util.Vector;
+import java.util.List;
 
 public abstract class SystemDefn extends ASTElement
 {
@@ -42,33 +42,33 @@ public abstract class SystemDefn extends ASTElement
 	/**
 	 * Get list of all modules appearing (recursively).
 	 * Duplicates are not removed and will appear multiple times in the list.
-	 * @deprecated Use {@link SystemDefn#getModules(Vector, ModulesFile)} instead.
+	 * @deprecated Use {@link SystemDefn#getModules(List, ModulesFile)} instead.
 	 */
 	@Deprecated
-	public abstract void getModules(Vector<String> v);
+	public abstract void getModules(List<String> v);
 
 	/**
 	 * Get list of all modules appearing (recursively, including descent into references).
 	 * Duplicates are not removed and will appear multiple times in the list.
 	 */
-	public abstract void getModules(Vector<String> v, ModulesFile modulesFile);
+	public abstract void getModules(List<String> v, ModulesFile modulesFile);
 
 	/**
 	 * Get list of all synchronising actions _introduced_ (recursively).
-	 * @deprecated Use {@link SystemDefn#getSynchs(Vector, ModulesFile)} instead.
+	 * @deprecated Use {@link SystemDefn#getSynchs(List, ModulesFile)} instead.
 	 */
 	@Deprecated
-	public abstract void getSynchs(Vector<String> v);
+	public abstract void getSynchs(List<String> v);
 
 	/**
 	 * Get list of all synchronising actions _introduced_ (recursively, including descent into references).
 	 */
-	public abstract void getSynchs(Vector<String> v, ModulesFile modulesFile);
+	public abstract void getSynchs(List<String> v, ModulesFile modulesFile);
 
 	/**
 	 * Get list of all references to other SystemDefns (recursively, but not following references).
 	 */
-	public abstract void getReferences(Vector<String> v);
+	public abstract void getReferences(List<String> v);
 }
 
 //------------------------------------------------------------------------------

--- a/prism/src/parser/ast/SystemFullParallel.java
+++ b/prism/src/parser/ast/SystemFullParallel.java
@@ -26,33 +26,34 @@
 
 package parser.ast;
 
-import java.util.Vector;
-
 import parser.visitor.*;
 import prism.PrismLangException;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class SystemFullParallel extends SystemDefn
 {
-	// Vector of operands
-	private Vector<SystemDefn> operands;
+	// List of operands
+	private List<SystemDefn> operands;
 	
 	// Constructor
 	
 	public SystemFullParallel()
 	{
-		operands = new Vector<SystemDefn>();
+		operands = new ArrayList<>();
 	}
 	
 	// Set methods
 	
 	public void addOperand(SystemDefn s)
 	{
-		operands.addElement(s);
+		operands.add(s);
 	}
 		
 	public void setOperand(int i, SystemDefn s)
 	{
-		operands.setElementAt(s, i);
+		operands.set(i, s);
 	}
 			
 	// Get methods
@@ -64,14 +65,14 @@ public class SystemFullParallel extends SystemDefn
 	
 	public SystemDefn getOperand(int i)
 	{
-		return operands.elementAt(i);
+		return operands.get(i);
 	}
 		
 	// Methods required for SystemDefn (all subclasses should implement):
 	
 	@Override
 	@SuppressWarnings("deprecation")
-	public void getModules(Vector<String> v)
+	public void getModules(List<String> v)
 	{
 		int i, n;
 		
@@ -82,7 +83,7 @@ public class SystemFullParallel extends SystemDefn
 	}
 
 	@Override
-	public void getModules(Vector<String> v, ModulesFile modulesFile)
+	public void getModules(List<String> v, ModulesFile modulesFile)
 	{
 		int i, n;
 		
@@ -94,7 +95,7 @@ public class SystemFullParallel extends SystemDefn
 
 	@Override
 	@SuppressWarnings("deprecation")
-	public void getSynchs(Vector<String> v)
+	public void getSynchs(List<String> v)
 	{
 		int i, n;
 		
@@ -105,7 +106,7 @@ public class SystemFullParallel extends SystemDefn
 	}
 	
 	@Override
-	public void getSynchs(Vector<String> v, ModulesFile modulesFile)
+	public void getSynchs(List<String> v, ModulesFile modulesFile)
 	{
 		int i, n;
 		
@@ -116,7 +117,7 @@ public class SystemFullParallel extends SystemDefn
 	}
 	
 	@Override
-	public void getReferences(Vector<String> v)
+	public void getReferences(List<String> v)
 	{
 		int n = getNumOperands();
 		for (int i = 0; i < n; i++) {

--- a/prism/src/parser/ast/SystemHide.java
+++ b/prism/src/parser/ast/SystemHide.java
@@ -26,29 +26,30 @@
 
 package parser.ast;
 
-import java.util.Vector;
-
 import parser.visitor.*;
 import prism.PrismLangException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class SystemHide extends SystemDefn
 {
 	// Operand
 	private SystemDefn operand;
 	// Actions to be hidden
-	private Vector<String> actions;
+	private List<String> actions;
 	
 	// Constructors
 	
 	public SystemHide()
 	{
-		actions = new Vector<String>();
+		actions = new ArrayList<>();
 	}
 	
 	public SystemHide(SystemDefn s)
 	{
+		this();
 		operand = s;
-		actions = new Vector<String>();
 	}
 	
 	// Set methods
@@ -60,12 +61,12 @@ public class SystemHide extends SystemDefn
 	
 	public void addAction(String s)
 	{
-		actions.addElement(s);
+		actions.add(s);
 	}
 		
 	public void setAction(int i, String s)
 	{
-		actions.setElementAt(s, i);
+		actions.set(i, s);
 	}
 	
 	// Get methods
@@ -82,7 +83,7 @@ public class SystemHide extends SystemDefn
 	
 	public String getAction(int i)
 	{
-		return actions.elementAt(i);
+		return actions.get(i);
 	}
 		
 	public boolean containsAction(String s)
@@ -94,34 +95,34 @@ public class SystemHide extends SystemDefn
 	
 	@Override
 	@SuppressWarnings("deprecation")
-	public void getModules(Vector<String> v)
+	public void getModules(List<String> v)
 	{
 		operand.getModules(v);
 	}
 	
 	@Override
-	public void getModules(Vector<String> v, ModulesFile modulesFile)
+	public void getModules(List<String> v, ModulesFile modulesFile)
 	{
 		operand.getModules(v, modulesFile);
 	}
 	
 	@Override
 	@SuppressWarnings("deprecation")
-	public void getSynchs(Vector<String> v)
+	public void getSynchs(List<String> v)
 	{
 		// recurse
 		operand.getSynchs(v);
 	}
 	
 	@Override
-	public void getSynchs(Vector<String> v, ModulesFile modulesFile)
+	public void getSynchs(List<String> v, ModulesFile modulesFile)
 	{
 		// recurse
 		operand.getSynchs(v, modulesFile);
 	}
 	
 	@Override
-	public void getReferences(Vector<String> v)
+	public void getReferences(List<String> v)
 	{
 		operand.getReferences(v);
 	}

--- a/prism/src/parser/ast/SystemInterleaved.java
+++ b/prism/src/parser/ast/SystemInterleaved.java
@@ -26,33 +26,34 @@
 
 package parser.ast;
 
-import java.util.Vector;
-
 import parser.visitor.*;
 import prism.PrismLangException;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class SystemInterleaved extends SystemDefn
 {
-	// Vector of operands
-	private Vector<SystemDefn> operands;
+	// List of operands
+	private List<SystemDefn> operands;
 	
 	// Constructor
 	
 	public SystemInterleaved()
 	{
-		operands = new Vector<SystemDefn>();
+		operands = new ArrayList<>();
 	}
 	
 	// Set methods
 	
 	public void addOperand(SystemDefn s)
 	{
-		operands.addElement(s);
+		operands.add(s);
 	}
 		
 	public void setOperand(int i, SystemDefn s)
 	{
-		operands.setElementAt(s, i);
+		operands.set(i, s);
 	}
 			
 	// Get methods
@@ -64,14 +65,14 @@ public class SystemInterleaved extends SystemDefn
 	
 	public SystemDefn getOperand(int i)
 	{
-		return operands.elementAt(i);
+		return operands.get(i);
 	}
 		
 	// Methods required for SystemDefn (all subclasses should implement):
 	
 	@Override
 	@SuppressWarnings("deprecation")
-	public void getModules(Vector<String> v)
+	public void getModules(List<String> v)
 	{
 		int i, n;
 		
@@ -82,7 +83,7 @@ public class SystemInterleaved extends SystemDefn
 	}
 
 	@Override
-	public void getModules(Vector<String> v, ModulesFile modulesFile)
+	public void getModules(List<String> v, ModulesFile modulesFile)
 	{
 		int i, n;
 		
@@ -94,7 +95,7 @@ public class SystemInterleaved extends SystemDefn
 
 	@Override
 	@SuppressWarnings("deprecation")
-	public void getSynchs(Vector<String> v)
+	public void getSynchs(List<String> v)
 	{
 		int i, n;
 		
@@ -105,7 +106,7 @@ public class SystemInterleaved extends SystemDefn
 	}
 	
 	@Override
-	public void getSynchs(Vector<String> v, ModulesFile modulesFile)
+	public void getSynchs(List<String> v, ModulesFile modulesFile)
 	{
 		int i, n;
 		
@@ -116,7 +117,7 @@ public class SystemInterleaved extends SystemDefn
 	}
 	
 	@Override
-	public void getReferences(Vector<String> v)
+	public void getReferences(List<String> v)
 	{
 		int n = getNumOperands();
 		for (int i = 0; i < n; i++) {

--- a/prism/src/parser/ast/SystemModule.java
+++ b/prism/src/parser/ast/SystemModule.java
@@ -26,10 +26,10 @@
 
 package parser.ast;
 
-import java.util.Vector;
-
 import parser.visitor.*;
 import prism.PrismLangException;
+
+import java.util.List;
 
 public class SystemModule extends SystemDefn
 {
@@ -64,31 +64,31 @@ public class SystemModule extends SystemDefn
 	// Methods required for SystemDefn (all subclasses should implement):
 	
 	@Override
-	public void getModules(Vector<String> v)
+	public void getModules(List<String> v)
 	{
-		v.addElement(name);
+		v.add(name);
 	}
 	
 	@Override
-	public void getModules(Vector<String> v, ModulesFile modulesFile)
+	public void getModules(List<String> v, ModulesFile modulesFile)
 	{
-		v.addElement(name);
+		v.add(name);
 	}
 	
 	@Override
-	public void getSynchs(Vector<String> v)
-	{
-		// do nothing
-	}
-	
-	@Override
-	public void getSynchs(Vector<String> v, ModulesFile modulesFile)
+	public void getSynchs(List<String> v)
 	{
 		// do nothing
 	}
 	
 	@Override
-	public void getReferences(Vector<String> v)
+	public void getSynchs(List<String> v, ModulesFile modulesFile)
+	{
+		// do nothing
+	}
+	
+	@Override
+	public void getReferences(List<String> v)
 	{
 		// do nothing
 	}

--- a/prism/src/parser/ast/SystemParallel.java
+++ b/prism/src/parser/ast/SystemParallel.java
@@ -26,31 +26,32 @@
 
 package parser.ast;
 
-import java.util.Vector;
-
 import parser.visitor.*;
 import prism.PrismLangException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class SystemParallel extends SystemDefn
 {
 	// Pair of operands
 	private SystemDefn operand1;
 	private SystemDefn operand2;
-	// Vector of synchronising actions
-	private Vector<String> actions;
+	// List of synchronising actions
+	private List<String> actions;
 	
 	// Constructors
 	
 	public SystemParallel()
 	{
-		actions = new Vector<String>();
+		actions = new ArrayList<>();
 	}
 	
 	public SystemParallel(SystemDefn s1, SystemDefn s2)
 	{
+		this();
 		operand1 = s1;
 		operand2 = s2;
-		actions = new Vector<String>();
 	}
 	
 	// Set methods
@@ -67,12 +68,12 @@ public class SystemParallel extends SystemDefn
 	
 	public void addAction(String s)
 	{
-		actions.addElement(s);
+		actions.add(s);
 	}
 		
 	public void setAction(int i, String s)
 	{
-		actions.setElementAt(s, i);
+		actions.set(i, s);
 	}
 			
 	// Get methods
@@ -94,7 +95,7 @@ public class SystemParallel extends SystemDefn
 	
 	public String getAction(int i)
 	{
-		return actions.elementAt(i);
+		return actions.get(i);
 	}
 		
 	public boolean containsAction(String s)
@@ -106,14 +107,14 @@ public class SystemParallel extends SystemDefn
 	
 	@Override
 	@SuppressWarnings("deprecation")
-	public void getModules(Vector<String> v)
+	public void getModules(List<String> v)
 	{
 		operand1.getModules(v);
 		operand2.getModules(v);
 	}
 
 	@Override
-	public void getModules(Vector<String> v, ModulesFile modulesFile)
+	public void getModules(List<String> v, ModulesFile modulesFile)
 	{
 		operand1.getModules(v, modulesFile);
 		operand2.getModules(v, modulesFile);
@@ -121,21 +122,21 @@ public class SystemParallel extends SystemDefn
 
 	@Override
 	@SuppressWarnings("deprecation")
-	public void getSynchs(Vector<String> v)
+	public void getSynchs(List<String> v)
 	{
 		operand1.getSynchs(v);
 		operand2.getSynchs(v);
 	}
 	
 	@Override
-	public void getSynchs(Vector<String> v, ModulesFile modulesFile)
+	public void getSynchs(List<String> v, ModulesFile modulesFile)
 	{
 		operand1.getSynchs(v, modulesFile);
 		operand2.getSynchs(v, modulesFile);
 	}
 	
 	@Override
-	public void getReferences(Vector<String> v)
+	public void getReferences(List<String> v)
 	{
 		operand1.getReferences(v);
 		operand2.getReferences(v);
@@ -175,7 +176,7 @@ public class SystemParallel extends SystemDefn
 		SystemParallel ret = new SystemParallel();
 		ret.setOperand1(getOperand1().deepCopy());
 		ret.setOperand2(getOperand2().deepCopy());
-		ret.actions = (actions == null) ? null : (Vector<String>)actions.clone();
+		ret.actions = (actions == null) ? null : new ArrayList<>(actions);
 		ret.setPosition(this);
 		return ret;
 	}

--- a/prism/src/parser/ast/SystemReference.java
+++ b/prism/src/parser/ast/SystemReference.java
@@ -26,10 +26,10 @@
 
 package parser.ast;
 
-import java.util.Vector;
-
 import parser.visitor.*;
 import prism.PrismLangException;
+
+import java.util.List;
 
 public class SystemReference extends SystemDefn
 {
@@ -60,13 +60,13 @@ public class SystemReference extends SystemDefn
 	// Methods required for SystemDefn (all subclasses should implement):
 	
 	@Override
-	public void getModules(Vector<String> v)
+	public void getModules(List<String> v)
 	{
-		v.addElement(name);
+		v.add(name);
 	}
 	
 	@Override
-	public void getModules(Vector<String> v, ModulesFile modulesFile)
+	public void getModules(List<String> v, ModulesFile modulesFile)
 	{
 		// Recurse into referenced SystemDefn
 		SystemDefn ref = modulesFile.getSystemDefnByName(name);
@@ -76,13 +76,13 @@ public class SystemReference extends SystemDefn
 	}
 	
 	@Override
-	public void getSynchs(Vector<String> v)
+	public void getSynchs(List<String> v)
 	{
 		// do nothing
 	}
 	
 	@Override
-	public void getSynchs(Vector<String> v, ModulesFile modulesFile)
+	public void getSynchs(List<String> v, ModulesFile modulesFile)
 	{
 		// Recurse into referenced SystemDefn
 		SystemDefn ref = modulesFile.getSystemDefnByName(name);
@@ -92,7 +92,7 @@ public class SystemReference extends SystemDefn
 	}
 	
 	@Override
-	public void getReferences(Vector<String> v)
+	public void getReferences(List<String> v)
 	{
 		if (!v.contains(name))
 			v.add(name);

--- a/prism/src/parser/ast/SystemRename.java
+++ b/prism/src/parser/ast/SystemRename.java
@@ -26,32 +26,32 @@
 
 package parser.ast;
 
-import java.util.Vector;
-
 import parser.visitor.*;
 import prism.PrismLangException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class SystemRename extends SystemDefn
 {
 	// Operand
 	private SystemDefn operand;
-	// Vectors for pairs of actions to be renamed
-	private Vector<String> from;
-	private Vector<String> to;
+	// lists for pairs of actions to be renamed
+	private final List<String> from;
+	private final List<String> to;
 
 	// Constructors
 
 	public SystemRename()
 	{
-		from = new Vector<String>();
-		to = new Vector<String>();
+		from = new ArrayList<>();
+		to = new ArrayList<>();
 	}
 
 	public SystemRename(SystemDefn s)
 	{
+		this();
 		operand = s;
-		from = new Vector<String>();
-		to = new Vector<String>();
 	}
 
 	// Set methods
@@ -63,14 +63,14 @@ public class SystemRename extends SystemDefn
 
 	public void addRename(String s1, String s2)
 	{
-		from.addElement(s1);
-		to.addElement(s2);
+		from.add(s1);
+		to.add(s2);
 	}
 
 	public void setRename(int i, String s1, String s2)
 	{
-		from.setElementAt(s1, i);
-		to.setElementAt(s2, i);
+		from.set(i, s1);
+		to.set(i, s2);
 	}
 
 	// Get methods
@@ -87,12 +87,12 @@ public class SystemRename extends SystemDefn
 
 	public String getFrom(int i)
 	{
-		return from.elementAt(i);
+		return from.get(i);
 	}
 
 	public String getTo(int i)
 	{
-		return to.elementAt(i);
+		return to.get(i);
 	}
 
 	public String getNewName(String s)
@@ -103,7 +103,7 @@ public class SystemRename extends SystemDefn
 		if (i == -1) {
 			return s;
 		} else {
-			return (String) to.elementAt(i);
+			return to.get(i);
 		}
 	}
 
@@ -111,32 +111,32 @@ public class SystemRename extends SystemDefn
 
 	@Override
 	@SuppressWarnings("deprecation")
-	public void getModules(Vector<String> v)
+	public void getModules(List<String> v)
 	{
 		operand.getModules(v);
 	}
 
 	@Override
-	public void getModules(Vector<String> v, ModulesFile modulesFile)
+	public void getModules(List<String> v, ModulesFile modulesFile)
 	{
 		operand.getModules(v, modulesFile);
 	}
 
 	@Override
 	@SuppressWarnings("deprecation")
-	public void getSynchs(Vector<String> v)
+	public void getSynchs(List<String> v)
 	{
 		int i, n;
 		String s;
 
 		// add action names in renames
-		// (only look in 'to' vector because we're only
+		// (only look in 'to' list because we're only
 		//  interested in actions _introduced_)
 		n = getNumRenames();
 		for (i = 0; i < n; i++) {
 			s = getTo(i);
 			if (!(v.contains(s)))
-				v.addElement(s);
+				v.add(s);
 		}
 
 		// recurse
@@ -144,19 +144,19 @@ public class SystemRename extends SystemDefn
 	}
 
 	@Override
-	public void getSynchs(Vector<String> v, ModulesFile modulesFile)
+	public void getSynchs(List<String> v, ModulesFile modulesFile)
 	{
 		int i, n;
 		String s;
 
 		// add action names in renames
-		// (only look in 'to' vector because we're only
+		// (only look in 'to' list because we're only
 		//  interested in actions _introduced_)
 		n = getNumRenames();
 		for (i = 0; i < n; i++) {
 			s = getTo(i);
 			if (!(v.contains(s)))
-				v.addElement(s);
+				v.add(s);
 		}
 
 		// recurse
@@ -164,7 +164,7 @@ public class SystemRename extends SystemDefn
 	}
 
 	@Override
-	public void getReferences(Vector<String> v)
+	public void getReferences(List<String> v)
 	{
 		operand.getReferences(v);
 	}

--- a/prism/src/parser/visitor/GetAllConstants.java
+++ b/prism/src/parser/visitor/GetAllConstants.java
@@ -26,19 +26,19 @@
 
 package parser.visitor;
 
-import java.util.Vector;
-
-import parser.ast.*;
+import parser.ast.ExpressionConstant;
 import prism.PrismLangException;
+
+import java.util.List;
 
 /**
  * Get all constants (i.e. ExpressionConstant objects), store names in set.
  */
 public class GetAllConstants extends ASTTraverse
 {
-	private Vector<String> v;
+	private List<String> v;
 	
-	public GetAllConstants(Vector<String> v)
+	public GetAllConstants(List<String> v)
 	{
 		this.v = v;
 	}
@@ -46,7 +46,7 @@ public class GetAllConstants extends ASTTraverse
 	public void visitPost(ExpressionConstant e) throws PrismLangException
 	{
 		if (!v.contains(e.getName())) {
-			v.addElement(e.getName());
+			v.add(e.getName());
 		}
 	}
 }

--- a/prism/src/parser/visitor/GetAllFormulas.java
+++ b/prism/src/parser/visitor/GetAllFormulas.java
@@ -26,19 +26,19 @@
 
 package parser.visitor;
 
-import java.util.Vector;
-
-import parser.ast.*;
+import parser.ast.ExpressionFormula;
 import prism.PrismLangException;
+
+import java.util.List;
 
 /**
  * Get all formulas (i.e. ExpressionFormula objects), store names in set.
  */
 public class GetAllFormulas extends ASTTraverse
 {
-	private Vector<String> v;
+	private List<String> v;
 	
-	public GetAllFormulas(Vector<String> v)
+	public GetAllFormulas(List<String> v)
 	{
 		this.v = v;
 	}
@@ -46,7 +46,7 @@ public class GetAllFormulas extends ASTTraverse
 	public void visitPost(ExpressionFormula e) throws PrismLangException
 	{
 		if (!v.contains(e.getName())) {
-			v.addElement(e.getName());
+			v.add(e.getName());
 		}
 	}
 }

--- a/prism/src/parser/visitor/GetAllLabels.java
+++ b/prism/src/parser/visitor/GetAllLabels.java
@@ -26,19 +26,19 @@
 
 package parser.visitor;
 
-import java.util.Vector;
-
-import parser.ast.*;
+import parser.ast.ExpressionLabel;
 import prism.PrismLangException;
+
+import java.util.List;
 
 /**
  * Get all variables (i.e. ExpressionVar objects), store names in set.
  */
 public class GetAllLabels extends ASTTraverse
 {
-	private Vector<String> v;
+	private List<String> v;
 	
-	public GetAllLabels(Vector<String> v)
+	public GetAllLabels(List<String> v)
 	{
 		this.v = v;
 	}
@@ -46,7 +46,7 @@ public class GetAllLabels extends ASTTraverse
 	public void visitPost(ExpressionLabel e) throws PrismLangException
 	{
 		if (!v.contains(e.getName())) {
-			v.addElement(e.getName());
+			v.add(e.getName());
 		}
 	}
 }

--- a/prism/src/parser/visitor/GetAllPropRefs.java
+++ b/prism/src/parser/visitor/GetAllPropRefs.java
@@ -26,19 +26,19 @@
 
 package parser.visitor;
 
-import java.util.Vector;
-
-import parser.ast.*;
+import parser.ast.ExpressionProp;
 import prism.PrismLangException;
+
+import java.util.List;
 
 /**
  * Get all references to properties (by name) (i.e. ExpressionProp objects), store names in set.
  */
 public class GetAllPropRefs extends ASTTraverse
 {
-	private Vector<String> v;
+	private List<String> v;
 	
-	public GetAllPropRefs(Vector<String> v)
+	public GetAllPropRefs(List<String> v)
 	{
 		this.v = v;
 	}
@@ -46,7 +46,7 @@ public class GetAllPropRefs extends ASTTraverse
 	public void visitPost(ExpressionProp e) throws PrismLangException
 	{
 		if (!v.contains(e.getName())) {
-			v.addElement(e.getName());
+			v.add(e.getName());
 		}
 	}
 }

--- a/prism/src/parser/visitor/GetAllPropRefsRecursively.java
+++ b/prism/src/parser/visitor/GetAllPropRefsRecursively.java
@@ -27,6 +27,7 @@
 
 package parser.visitor;
 
+import java.util.List;
 import java.util.Vector;
 
 import parser.ast.ExpressionLabel;
@@ -40,10 +41,10 @@ import prism.PrismLangException;
  */
 public class GetAllPropRefsRecursively extends ASTTraverse
 {
-	private Vector<String> v;
+	private List<String> v;
 	private PropertiesFile pf;
 
-	public GetAllPropRefsRecursively(Vector<String> v, PropertiesFile pf)
+	public GetAllPropRefsRecursively(List<String> v, PropertiesFile pf)
 	{
 		this.v = v;
 		this.pf = pf;
@@ -52,7 +53,7 @@ public class GetAllPropRefsRecursively extends ASTTraverse
 	public void visitPost(ExpressionProp e) throws PrismLangException
 	{
 		if (!v.contains(e.getName())) {
-			v.addElement(e.getName());
+			v.add(e.getName());
 		}
 	}
 
@@ -67,7 +68,7 @@ public class GetAllPropRefsRecursively extends ASTTraverse
 		}
 		if (prop != null) {
 			// If so, add the name
-			v.addElement(e.getName());
+			v.add(e.getName());
 		}
 	}
 }

--- a/prism/src/parser/visitor/GetAllUndefinedConstantsRecursively.java
+++ b/prism/src/parser/visitor/GetAllUndefinedConstantsRecursively.java
@@ -26,10 +26,17 @@
 
 package parser.visitor;
 
-import java.util.Vector;
-
-import parser.ast.*;
+import parser.ast.ConstantList;
+import parser.ast.Expression;
+import parser.ast.ExpressionConstant;
+import parser.ast.ExpressionLabel;
+import parser.ast.ExpressionProp;
+import parser.ast.LabelList;
+import parser.ast.PropertiesFile;
+import parser.ast.Property;
 import prism.PrismLangException;
+
+import java.util.List;
 
 /**
  * Get all undefined constants used (i.e. in ExpressionConstant objects) recursively and return as a list.
@@ -41,12 +48,12 @@ import prism.PrismLangException;
  */
 public class GetAllUndefinedConstantsRecursively extends ASTTraverse
 {
-	private Vector<String> v;
+	private List<String> v;
 	private ConstantList constantList;
 	private LabelList labelList;
 	private PropertiesFile propertiesFile;
 
-	public GetAllUndefinedConstantsRecursively(Vector<String> v, ConstantList constantList, LabelList labelList, PropertiesFile propertiesFile)
+	public GetAllUndefinedConstantsRecursively(List<String> v, ConstantList constantList, LabelList labelList, PropertiesFile propertiesFile)
 	{
 		this.v = v;
 		this.constantList = constantList;
@@ -65,7 +72,7 @@ public class GetAllUndefinedConstantsRecursively extends ASTTraverse
 		// If constant is undefined, add to the list
 		if (expr == null) {
 			if (!v.contains(e.getName())) {
-				v.addElement(e.getName());
+				v.add(e.getName());
 			}
 		}
 		// If not, check constant definition recursively for more undefined constants

--- a/prism/src/parser/visitor/GetAllVars.java
+++ b/prism/src/parser/visitor/GetAllVars.java
@@ -26,19 +26,19 @@
 
 package parser.visitor;
 
-import java.util.Vector;
-
-import parser.ast.*;
+import parser.ast.ExpressionVar;
 import prism.PrismLangException;
+
+import java.util.List;
 
 /**
  * Get all variables (i.e. ExpressionVar objects), store names in set.
  */
 public class GetAllVars extends ASTTraverse
 {
-	private Vector<String> v;
+	private List<String> v;
 	
-	public GetAllVars(Vector<String> v)
+	public GetAllVars(List<String> v)
 	{
 		this.v = v;
 	}
@@ -46,7 +46,7 @@ public class GetAllVars extends ASTTraverse
 	public void visitPost(ExpressionVar e) throws PrismLangException
 	{
 		if (!v.contains(e.getName())) {
-			v.addElement(e.getName());
+			v.add(e.getName());
 		}
 	}
 }

--- a/prism/src/prism/Modules2MTBDD.java
+++ b/prism/src/prism/Modules2MTBDD.java
@@ -26,6 +26,8 @@
 
 package prism;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Vector;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -63,7 +65,7 @@ public class Modules2MTBDD
 	private Values constantValues;	// values of constants
 	// synch info
 	private int numSynchs;			// number of synchronisations
-	private Vector<String> synchs;			// synchronisations
+	private List<String> synchs;			// synchronisations
 	// rewards
 	private int numRewardStructs;		// number of reward structs
 	private String[] rewardStructNames;	// reward struct names
@@ -322,7 +324,7 @@ public class Modules2MTBDD
 			modelWasBuilt = true;
 
 			// We also store a copy of the list of action label names
-			model.setSynchs((Vector<String>)synchs.clone());
+			model.setSynchs(new ArrayList<>(synchs));
 		
 			// For MDPs, we also store the DDs used to construct the part
 			// of the transition matrix that corresponds to each action
@@ -487,7 +489,7 @@ public class Modules2MTBDD
 			if (modelType == ModelType.MDP) {
 				// allocate vars
 				for (i = 0; i < numSynchs; i++) {
-					ddSynchVars[i] = modelVariables.allocateVariable(synchs.elementAt(i)+".a");
+					ddSynchVars[i] = modelVariables.allocateVariable(synchs.get(i)+".a");
 				}
 			}
 		
@@ -564,7 +566,7 @@ public class Modules2MTBDD
 			// allocate synchronizing action variables
 			if (modelType == ModelType.MDP) {
 				for (i = 0; i < numSynchs; i++) {
-					ddSynchVars[i] = modelVariables.allocateVariable(synchs.elementAt(i)+".a");
+					ddSynchVars[i] = modelVariables.allocateVariable(synchs.get(i)+".a");
 				}
 			}
 
@@ -1017,7 +1019,7 @@ public class Modules2MTBDD
 		sysDDs.ind = translateModule(m, module, "", 0);
 		// build mtbdd for each synchronising action
 		for (i = 0; i < numSynchs; i++) {
-			synch = synchs.elementAt(i);
+			synch = synchs.get(i);
 			sysDDs.synchs[i] = translateModule(m, module, synch, synchMin[i]);
 		}
 		// store identity matrix
@@ -1139,7 +1141,7 @@ public class Modules2MTBDD
 		// go thru all synchronising actions and decide if we will synchronise on each one
 		synchBool = new boolean[numSynchs];
 		for (i = 0; i < numSynchs; i++) {
-			synchBool[i] = sys.containsAction(synchs.elementAt(i));
+			synchBool[i] = sys.containsAction(synchs.get(i));
 		}
 		
 		// construct mtbdds for first operand
@@ -1198,7 +1200,7 @@ public class Modules2MTBDD
 		// store this in new array - old one may still be used elsewhere
 		newSynchMin = new int[numSynchs];
 		for (i = 0; i < numSynchs; i++) {
-			if (sys.containsAction(synchs.elementAt(i))) {
+			if (sys.containsAction(synchs.get(i))) {
 				newSynchMin[i] = 0;
 			}
 			else {
@@ -1221,7 +1223,7 @@ public class Modules2MTBDD
 			// if the action is in the set to be hidden, hide it...
 			// note that it doesn't matter if an action is included more than once in the set
 			// (although this would be picked up during the syntax check anyway)
-			if (sys.containsAction(synchs.elementAt(i))) {
+			if (sys.containsAction(synchs.get(i))) {
 				
 				// move these transitions into the independent bit
 				sysDDs.ind = combineComponentDDs(sysDDs.ind, sysDDs1.synchs[i]);
@@ -1267,7 +1269,7 @@ public class Modules2MTBDD
 		for (i = 0; i < numSynchs; i++) {
 			// find out what this action is renamed to
 			// (this may be itself, i.e. it's not renamed)
-			s = sys.getNewName(synchs.elementAt(i));
+			s = sys.getNewName(synchs.get(i));
 			j = synchs.indexOf(s);
 			if (j == -1) {
 				throw new PrismLangException("Invalid action name \"" + s + "\" in renaming", sys);
@@ -1299,7 +1301,7 @@ public class Modules2MTBDD
 			// find out what this action is renamed to
 			// (this may be itself, i.e. it's not renamed)
 			// then add it to result
-			s = sys.getNewName(synchs.elementAt(i));
+			s = sys.getNewName(synchs.get(i));
 			j = synchs.indexOf(s);
 			if (j == -1) {
 				throw new PrismLangException("Invalid action name \"" + s + "\" in renaming", sys);

--- a/prism/src/prism/UndefinedConstants.java
+++ b/prism/src/prism/UndefinedConstants.java
@@ -189,11 +189,11 @@ public class UndefinedConstants
 	 */
 	public void initialise()
 	{
-		Vector<String> mfv, pfv;
+		List<String> mfv, pfv;
 		// determine which constants are undefined
-		mfv = (modulesFile == null) ? new Vector<String>() : modulesFile.getUndefinedConstants();
+		mfv = (modulesFile == null) ? new ArrayList<>() : modulesFile.getUndefinedConstants();
 		if (propertiesFile == null) {
-			pfv = new Vector<String>();
+			pfv = new ArrayList<>();
 		} else {
 			if (props == null) {
 				if (justLabels) {
@@ -214,10 +214,10 @@ public class UndefinedConstants
 	/**
 	 * Create a new copy of a list of constant names, sorted by their occurrence in a PropertiesFile. 
 	 */
-	private Vector<String> orderConstantsByPropertiesFile(Vector<String> oldList, PropertiesFile propertiesFile)
+	private List<String> orderConstantsByPropertiesFile(List<String> oldList, PropertiesFile propertiesFile)
 	{
-		Vector<String> newList = new Vector<String>();
-		Vector<String> pfList = propertiesFile.getUndefinedConstants();
+		List<String> newList = new ArrayList<>();
+		List<String> pfList = propertiesFile.getUndefinedConstants();
 		for (String s : pfList) {
 			if (oldList.contains(s))
 				newList.add(s);
@@ -228,7 +228,7 @@ public class UndefinedConstants
 	/**
 	 * Set up data structures (as required by constructor methods)
 	 */
-	private void setUpDataStructures(Vector<String> mfv, Vector<String> pfv)
+	private void setUpDataStructures(List<String> mfv, List<String> pfv)
 	{
 		int i;
 		String s;
@@ -238,13 +238,13 @@ public class UndefinedConstants
 		// create storage for info about constant definitions
 		mfConsts = new ArrayList<DefinedConstant>(mfNumConsts);
 		for (i = 0; i < mfNumConsts; i++) {
-			s = (String) mfv.elementAt(i);
+			s = mfv.get(i);
 			Type type = modulesFile.getConstantList().getConstantType(modulesFile.getConstantList().getConstantIndex(s));
 			mfConsts.add(new DefinedConstant.Undefined(s, type));
 		}
 		pfConsts = new ArrayList<DefinedConstant>(pfNumConsts);
 		for (i = 0; i < pfNumConsts; i++) {
-			s = (String) pfv.elementAt(i);
+			s = pfv.get(i);
 			Type type = propertiesFile.getConstantList().getConstantType(propertiesFile.getConstantList().getConstantIndex(s));
 			pfConsts.add(new DefinedConstant.Undefined(s, type));
 		}

--- a/prism/src/simulator/Updater.java
+++ b/prism/src/simulator/Updater.java
@@ -32,7 +32,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 
 import parser.State;
 import parser.VarList;
@@ -63,7 +62,7 @@ public class Updater extends PrismComponent
 	protected int numModules;
 	protected VarList varList;
 	// Synchronising action info
-	protected Vector<String> synchs;
+	protected List<String> synchs;
 	protected int numSynchs;
 	protected int synchModuleCounts[];
 	// Model info/stats

--- a/prism/src/userinterface/properties/GUIProperty.java
+++ b/prism/src/userinterface/properties/GUIProperty.java
@@ -29,6 +29,7 @@
 
 package userinterface.properties;
 
+import java.util.List;
 import java.util.Vector;
 
 import javax.swing.ImageIcon;
@@ -106,7 +107,7 @@ public class GUIProperty
 	private String method; // Method used (verification, simulation)
 	private String constantsString; // Constant values used
 	private String name;
-	private Vector<String> referencedNames;
+	private List<String> referencedNames;
 	
 	private GUIPropertiesList propList; // to be able to get named properties
 
@@ -194,7 +195,7 @@ public class GUIProperty
 	 * <p/>
 	 * If the property is not valid, returns {@code null}.
 	 */
-	public Vector<String> getReferencedNames()
+	public List<String> getReferencedNames()
 	{
 		return this.referencedNames;
 	}

--- a/prism/src/userinterface/simulator/GUISimulator.java
+++ b/prism/src/userinterface/simulator/GUISimulator.java
@@ -44,7 +44,6 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -437,7 +436,7 @@ public class GUISimulator extends GUIPlugin implements MouseListener, ListSelect
 			tableScroll.setViewportView(pathTable);
 
 			displayPathLoops = true;
-			
+
 			// Create a new path in the simulator and add labels/properties
 			getPrism().loadModelIntoSimulator();
 			getPrism().loadStrategyIntoSimulator();
@@ -896,8 +895,8 @@ public class GUISimulator extends GUIPlugin implements MouseListener, ListSelect
 
 	/**
 	 * Re-populate lists of labels and path formulas.
-	 * Labels are taken from current model and passed in properties file. 
-	 * Path formulas are taken from the passed in properties file. 
+	 * Labels are taken from current model and passed in properties file.
+	 * Path formulas are taken from the passed in properties file.
 	 */
 	private void repopulateFormulae(PropertiesFile propertiesFile)
 	{
@@ -934,7 +933,7 @@ public class GUISimulator extends GUIPlugin implements MouseListener, ListSelect
 				GUIProperty gp = gpl.getProperty(i);
 
 				// obtain constants in property
-				Vector<String> propertyConstants = gp.getProperty().getAllConstants();
+				List<String> propertyConstants = gp.getProperty().getAllConstants();
 				boolean allConstantsDefined = true;
 				for (String propertyConstant : propertyConstants) {
 					if (!parsedModel.isDefinedConstant(propertyConstant) &&
@@ -2300,7 +2299,7 @@ public class GUISimulator extends GUIPlugin implements MouseListener, ListSelect
 	enum UpdateTableModelColumn {
 		STRAT, ACTION, PROB, UPDATE
 	};
-	
+
 	class UpdateTableModel extends AbstractTableModel
 	{
 		private List<UpdateTableModelColumn> visibleColumns = new ArrayList<>();
@@ -2437,7 +2436,7 @@ public class GUISimulator extends GUIPlugin implements MouseListener, ListSelect
 			}
 			visibleColumns.add(UpdateTableModelColumn.UPDATE);
 		}
-		
+
 		public void restartUpdatesTable()
 		{
 			fireTableStructureChanged();


### PR DESCRIPTION
The `Vector` class is synchronized which might have a negative influence on performance. Since no synchronization is needed this PR substitutes all `Vectors` with `ArrayLists`.