### PR TITLE
Adapt reward export header format

### DIFF
--- a/prism-tests/functionality/export/mdp/robot.prism.header1.srew
+++ b/prism-tests/functionality/export/mdp/robot.prism.header1.srew
@@ -1,4 +1,4 @@
-# Reward structure: "time"
+# Reward structure "time"
 # State rewards
 6 6
 0 1

--- a/prism-tests/functionality/export/mdp/robot.prism.header2.srew
+++ b/prism-tests/functionality/export/mdp/robot.prism.header2.srew
@@ -1,4 +1,4 @@
-# Reward structure: "energy"
+# Reward structure "energy"
 # State rewards
 6 6
 0 2.3

--- a/prism-tests/functionality/export/mdp/robot.prism.header3.srew
+++ b/prism-tests/functionality/export/mdp/robot.prism.header3.srew
@@ -1,3 +1,3 @@
-# Reward structure: "move"
+# Reward structure "move"
 # State rewards
 6 0

--- a/prism-tests/functionality/import/lec31.srew
+++ b/prism-tests/functionality/import/lec31.srew
@@ -1,4 +1,4 @@
-# Reward structure: "r"
+# Reward structure "r"
 # State rewards
 6 1
 0 2

--- a/prism-tests/functionality/import/lec32.srew
+++ b/prism-tests/functionality/import/lec32.srew
@@ -1,4 +1,4 @@
-# Reward structure: "s"
+# Reward structure "s"
 # State rewards
 6 2
 4 1

--- a/prism-tests/functionality/import/lec33.srew
+++ b/prism-tests/functionality/import/lec33.srew
@@ -1,2 +1,3 @@
+# Reward structure
 # State rewards
 6 0

--- a/prism/src/explicit/ProbModelChecker.java
+++ b/prism/src/explicit/ProbModelChecker.java
@@ -1337,13 +1337,12 @@ public class ProbModelChecker extends NonProbModelChecker
 	
 	/**
 	 * Print header to srew file, when not disabled.
-	 * Header format with reward struct name:
+	 * Header format with optional reward struct name:
 	 * <pre>
-	 *   # Reward structure: "$1"
+	 *   # Reward structure &lt;double-quoted-name&gt;
 	 *   # State rewards
 	 * </pre>
-	 * where $1 is the reward struct name.
-	 * If the structure is not named, that header line is omitted.
+	 * where &lt;double-quoted-name&gt; ("<name>") is omitted if the reward structure is not named.
 	 *
 	 * @param r index of the reward structure
 	 * @param out print target
@@ -1355,9 +1354,10 @@ public class ProbModelChecker extends NonProbModelChecker
 			return;
 		}
 		String rewardStructName = rewardGen.getRewardStructName(r);
+		out.print("# Reward structure");
 		if (!"".equals(rewardStructName)) {
-			out.println("# Reward structure: \"" + rewardStructName + "\"");
+			out.print(" \"" + rewardStructName + "\"");
 		}
-		out.println("# State rewards");
+		out.println("\n# State rewards");
 	}
 }

--- a/prism/src/mtbdd/PM_ExportVector.cc
+++ b/prism/src/mtbdd/PM_ExportVector.cc
@@ -71,12 +71,13 @@ jboolean neh    // noexportheaders
 	switch (export_type) {
 	case EXPORT_PLAIN:  // add header to srew file, when not disabled
                         if (!neh) {
+                            export_string("# Reward structure");
                             if (env->GetStringUTFLength(rsn) > 0) {
                                 const char *header = env->GetStringUTFChars(rsn,0);
-                                export_string("# Reward structure: \"%s\"\n", header);
+                                export_string(" \"%s\"", header);
                                 env->ReleaseStringUTFChars(rsn, header);
                             }
-                            export_string("# State rewards\n");
+                            export_string("\n# State rewards\n");
                         }
                         export_string("%" PRId64 " %.0f\n", odd->eoff+odd->toff, DD_GetNumMinterms(ddman, vector, num_vars));
                         break;

--- a/prism/src/prism/ExplicitFilesRewardGenerator.java
+++ b/prism/src/prism/ExplicitFilesRewardGenerator.java
@@ -54,17 +54,13 @@ import parser.State;
  * This abstract class implements the import and storage of state reward structures.
  *
  * It is possible to import the state rewards structure with a header.
- * Header format with reward struct name:
+ * Header format with optional reward struct name:
  * <pre>
- *   # Reward structure: "$1"
+ *   # Reward structure &lt;double-quoted-name&gt;
  *   # State rewards
  * </pre>
- * where $1 is the reward struct name.
- *
- * 	Header format without reward struct name:
- * <pre>
- *   # State rewards
- * </pre>
+ * where &lt;double-quoted-name&gt; ("<name>") is omitted if the reward structure is not named.<br />
+ * We do not enforce the correct format right now.
  */
 public abstract class ExplicitFilesRewardGenerator extends PrismComponent implements RewardGenerator
 {
@@ -78,7 +74,7 @@ public abstract class ExplicitFilesRewardGenerator extends PrismComponent implem
 	// Regex for comments
 	protected static final Pattern COMMENT_PATTERN = Pattern.compile("#.*");
 	// Regex for reward name
-	protected static final Pattern REWARD_NAME_PATTERN = Pattern.compile("# Reward structure: (\"([a-zA-Z0-9]*)\")$");
+	protected static final Pattern REWARD_NAME_PATTERN = Pattern.compile("# Reward structure (\"([a-zA-Z0-9]*)\")$");
 
 	/**
 	 * Constructor
@@ -277,7 +273,8 @@ public abstract class ExplicitFilesRewardGenerator extends PrismComponent implem
 		 * @param rewardStructName reward struct name to be checked
 		 * @throws PrismException if name is null or no identifier
 		 */
-		protected static String checkRewardName(String rewardStructName) throws PrismException
+		protected static String
+		checkRewardName(String rewardStructName) throws PrismException
 		{
 			if (rewardStructName == null)
 				throw new PrismException("Expected identifier but got: null");


### PR DESCRIPTION
The new format is
\# Reward structure <double-quoted-name>
\# State rewards