### PR TITLE
Implement concat as static function

### DIFF
--- a/prism/src/common/iterable/Reducible.java
+++ b/prism/src/common/iterable/Reducible.java
@@ -27,7 +27,7 @@ import java.util.function.*;
  * <li>Filter all odd numbers
  * <li>Collect the filtered numbers in a new {@code ArrayList}
  * </ol>
- * Please note that {@link Reducible#mapToInt} and {@link Reducible#filter} only wrap the underlying reducible.
+ * Please note that {@link Reducible#mapToInt} and {@link Reducible#filter} only wrap the underlying Reducible.
  * The actual computation happens on-the-fly when {@code collect} is called.
  *
  * <p><em>Transformation operations</em> (known as <a href="package-summary.html#StreamOps">intermediate operations</a> on streams)
@@ -43,7 +43,7 @@ import java.util.function.*;
  * Please note that implementors of the interface may consume no elements if the result of an accumulation can be computed directly.
  *
  * @param <E> the type of elements returned by this Reducible
- * @param <E_CAT> the type of reducibles accepted by  {@link Reducible#concat concat}
+ * @param <E_CAT> the type of Reducibles accepted by  {@link Reducible#concat concat}
  *ø
  * @see java.util.stream.Stream Stream
  */
@@ -194,6 +194,96 @@ public interface Reducible<E, E_CAT>
 	}
 
 	/**
+	 * Concatenate a sequence of Iterables.
+	 * The returned FunctionalIterable iterates over the elements in the order of the argument sequence.
+	 *
+	 * @param iterables the {@link Iterable}s to concatenate
+	 * @return a {@link FunctionalIterable} that iterates over the elements of each Iterable
+	 */
+	static <E> FunctionalIterable<E> concat(Iterable<? extends Iterable<? extends E>> iterables)
+	{
+		return new ChainedIterable.Of(iterables);
+	}
+
+	/**
+	 * Concatenate a sequence of Iterators.
+	 * The returned FunctionalIterator iterates over the elements in the order of the argument sequence.
+	 *
+	 * @param iterators the {@link Iterator}s to concatenate
+	 * @return a {@link FunctionalIterator} that iterates over the elements of each Iterator
+	 */
+	static <E> FunctionalIterator<E> concat(Iterator<? extends Iterator<? extends E>> iterators)
+	{
+		return new ChainedIterator.Of(iterators);
+	}
+
+	/**
+	 * Primitive specialisation of {@code concat} for {@code double}.
+	 *
+	 * @param iterables the {@link PrimitiveIterable.OfDouble}s to concatenate
+	 * @return a {@link FunctionalPrimitiveIterable.OfDouble} that iterates over the elements of each Iterable
+	 */
+	static FunctionalPrimitiveIterable.OfDouble concatDouble(Iterable<? extends PrimitiveIterable.OfDouble> iterables)
+	{
+		return new ChainedIterable.OfDouble(iterables);
+	}
+
+	/**
+	 * Primitive specialisation of {@code concat} for {@code double}.
+	 *
+	 * @param iterators the {@link PrimitiveIterator.OfDouble}s to concatenate
+	 * @return a {@link FunctionalPrimitiveIterator.OfDouble} that iterates over the elements of each Iterator
+	 */
+	static FunctionalPrimitiveIterator.OfDouble concatDouble(Iterator<? extends PrimitiveIterator.OfDouble> iterators)
+	{
+		return new ChainedIterator.OfDouble(iterators);
+	}
+
+	/**
+	 * Primitive specialisation of {@code concat} for {@code int}.
+	 *
+	 * @param iterables the {@link PrimitiveIterable.OfInt}s to concatenate
+	 * @return a {@link FunctionalPrimitiveIterable.OfInt} that iterates over the elements of each Iterable
+	 */
+	static FunctionalPrimitiveIterable.OfInt concatInt(Iterable<? extends PrimitiveIterable.OfInt> iterables)
+	{
+		return new ChainedIterable.OfInt(iterables);
+	}
+
+	/**
+	 * Primitive specialisation of {@code concat} for {@code int}.
+	 *
+	 * @param iterators the {@link PrimitiveIterator.OfInt}s to concatenate
+	 * @return a {@link FunctionalPrimitiveIterator.OfInt} that iterates over the elements of each Iterator
+	 */
+	static FunctionalPrimitiveIterator.OfInt concatInt(Iterator<? extends PrimitiveIterator.OfInt> iterators)
+	{
+		return new ChainedIterator.OfInt(iterators);
+	}
+
+	/**
+	 * Primitive specialisation of {@code concat} for {@code long}.
+	 *
+	 * @param iterables the {@link PrimitiveIterable.OfLong}s to concatenate
+	 * @return a {@link FunctionalPrimitiveIterable.OfLong} that iterates over the elements of each Iterable
+	 */
+	static FunctionalPrimitiveIterable.OfLong concatLong(Iterable<? extends PrimitiveIterable.OfLong> iterables)
+	{
+		return new ChainedIterable.OfLong(iterables);
+	}
+
+	/**
+	 * Primitive specialisation of {@code concat} for {@code long}.
+	 *
+	 * @param iterators the {@link PrimitiveIterator.OfLong}s to concatenate
+	 * @return a {@link FunctionalPrimitiveIterator.OfLong} that iterates over the elements of each Iterator
+	 */
+	static FunctionalPrimitiveIterator.OfLong concatLong(Iterator<? extends PrimitiveIterator.OfLong> iterators)
+	{
+		return new ChainedIterator.OfLong(iterators);
+	}
+
+	/**
 	 * Convert an Iterable&lt;Double&gt; to a FunctionalPrimitiveIterable.OfDouble by unboxing each element.
 	 * If the argument's Iterator yields {@code null}, a {@link NullPointerException} is thrown when iterating.
 	 * Answer the Iterable if it already implements of FunctionalPrimitiveIterable.OfDouble.
@@ -314,7 +404,7 @@ public interface Reducible<E, E_CAT>
 
 	/**
 	 * Concatenate the receiver and the argument.
-	 * The returned reducible first iterates over the elements of the receiver and then over the elements the argument.
+	 * The returned Reducible first iterates over the elements of the receiver and then over the elements the argument.
 	 *
 	 * @param reducible the {@link Reducible} to append
 	 * @return a {@link Reducible} that iterates over the elements of the receiver and the argument
@@ -401,7 +491,7 @@ public interface Reducible<E, E_CAT>
 	// Accumulations Methods (Consuming)
 
 	/**
-	 * Consume this reducible, i.e., iterate over all its elements.
+	 * Consume this Reducible, i.e., iterate over all its elements.
 	 */
 	default Reducible<E,E_CAT> consume()
 	{

--- a/prism/unit-tests/common/iterable/ReducibleStaticTest.java
+++ b/prism/unit-tests/common/iterable/ReducibleStaticTest.java
@@ -223,6 +223,278 @@ class ReducibleStaticTest
 	}
 
 	@ParameterizedTest
+	@MethodSource("getIterables")
+	void testConcatIterable(Iterable<?> iterable)
+	{
+		ArrayList<Object> expected = new ArrayList<>();
+		iterable.forEach(expected::add);
+		iterable.forEach(expected::add);
+		FunctionalIterable<Object> actual = Reducible.concat(List.of(iterable, iterable));
+		assertIterableEquals(expected, actual);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterables")
+	void testConcatIterator(Iterable<?> iterable)
+	{
+		ArrayList<Object> expected = new ArrayList<>();
+		iterable.forEach(expected::add);
+		iterable.forEach(expected::add);
+		FunctionalIterator<Object> actual = Reducible.concat(List.of(iterable.iterator(), iterable.iterator()).iterator());
+		assertIteratorEquals(expected.iterator(), actual);
+	}
+
+	@Test
+	void testConcatIterable_Empty()
+	{
+		EmptyIterable<Object> expected = EmptyIterable.of();
+		Iterable<Object> actual = Reducible.concat(EmptyIterable.of());
+		assertIterableEquals(expected, actual);
+	}
+
+	@Test
+	void testConcatIterator_Empty()
+	{
+		EmptyIterator<Object> expected = EmptyIterator.of();
+		Iterator<Object> actual = Reducible.concat(EmptyIterator.of());
+		assertIteratorEquals(expected, actual);
+	}
+
+	@Test
+	void testConcatIterable_Null()
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concat((Iterable<Iterable<?>>) null));
+	}
+
+	@Test
+	void testConcatIterator_Null()
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concat((Iterator<Iterator<?>>) null));
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesNull")
+	void testConcatIterable_NullValues(Iterable<Iterable<?>> iterable)
+	{
+		FunctionalIterable<Object> result = Reducible.concat(iterable);
+		assertThrows(NullPointerException.class, result::consume);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesNull")
+	void testConcatIterator_NullValues(Iterable<Iterator<?>> iterable)
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concat(iterable.iterator()));
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesDouble")
+	void testConcatDoubleIterable(Iterable<Double> iterable)
+	{
+		ArrayList<Double> expectedBoxed = new ArrayList<>();
+		iterable.forEach(expectedBoxed::add);
+		iterable.forEach(expectedBoxed::add);
+		FunctionalPrimitiveIterable.OfDouble expected = Reducible.unboxDouble(expectedBoxed);
+		FunctionalPrimitiveIterable.OfDouble unboxed = Reducible.unboxDouble(iterable);
+		FunctionalPrimitiveIterable.OfDouble actual = Reducible.concatDouble(List.of(unboxed, unboxed));
+		assertIterableEquals(expected, actual);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesDouble")
+	void testConcatDoubleIterator(Iterable<Double> iterable)
+	{
+		ArrayList<Double> expectedBoxed = new ArrayList<>();
+		iterable.forEach(expectedBoxed::add);
+		iterable.forEach(expectedBoxed::add);
+		FunctionalPrimitiveIterable.OfDouble expected = Reducible.unboxDouble(expectedBoxed);
+		FunctionalPrimitiveIterable.OfDouble unboxed = Reducible.unboxDouble(iterable);
+		FunctionalPrimitiveIterator.OfDouble actual = Reducible.concatDouble(List.of(unboxed.iterator(), unboxed.iterator()).iterator());
+		assertIteratorEquals(expected.iterator(), actual);
+	}
+
+	@Test
+	void testConcatDoubleIterable_Empty()
+	{
+		EmptyIterable.OfDouble expected = EmptyIterable.ofDouble();
+		FunctionalPrimitiveIterable.OfDouble actual = Reducible.concatDouble(EmptyIterable.of());
+		assertIterableEquals(expected, actual);
+	}
+
+	@Test
+	void testConcatDoubleIterator_Empty()
+	{
+		EmptyIterator.OfDouble expected = EmptyIterator.ofDouble();
+		FunctionalPrimitiveIterator.OfDouble actual = Reducible.concatDouble(EmptyIterator.of());
+		assertIteratorEquals(expected, actual);
+	}
+
+	@Test
+	void testConcatDoubleIterable_Null()
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concatDouble((Iterable<PrimitiveIterable.OfDouble>) null));
+	}
+
+	@Test
+	void testConcatDoubleIterator_Null()
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concat((Iterator<PrimitiveIterator.OfDouble>) null));
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesNull")
+	void testConcatDoubleIterable_NullValues(Iterable<PrimitiveIterable.OfDouble> iterable)
+	{
+		FunctionalPrimitiveIterable.OfDouble result = Reducible.concatDouble(iterable);
+		assertThrows(NullPointerException.class, result::consume);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesNull")
+	void testConcatDoubleIterator_NullValues(Iterable<PrimitiveIterator.OfDouble> iterable)
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concatDouble(iterable.iterator()));
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesInt")
+	void testConcatIntIterable(Iterable<Integer> iterable)
+	{
+		ArrayList<Integer> expectedBoxed = new ArrayList<>();
+		iterable.forEach(expectedBoxed::add);
+		iterable.forEach(expectedBoxed::add);
+		FunctionalPrimitiveIterable.OfInt expected = Reducible.unboxInt(expectedBoxed);
+		FunctionalPrimitiveIterable.OfInt unboxed = Reducible.unboxInt(iterable);
+		FunctionalPrimitiveIterable.OfInt actual = Reducible.concatInt(List.of(unboxed, unboxed));
+		assertIterableEquals(expected, actual);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesInt")
+	void testConcatIntIterator(Iterable<Integer> iterable)
+	{
+		ArrayList<Integer> expectedBoxed = new ArrayList<>();
+		iterable.forEach(expectedBoxed::add);
+		iterable.forEach(expectedBoxed::add);
+		FunctionalPrimitiveIterable.OfInt expected = Reducible.unboxInt(expectedBoxed);
+		FunctionalPrimitiveIterable.OfInt unboxed = Reducible.unboxInt(iterable);
+		FunctionalPrimitiveIterator.OfInt actual = Reducible.concatInt(List.of(unboxed.iterator(), unboxed.iterator()).iterator());
+		assertIteratorEquals(expected.iterator(), actual);
+	}
+
+	@Test
+	void testConcatIntIterable_Empty()
+	{
+		EmptyIterable.OfInt expected = EmptyIterable.ofInt();
+		FunctionalPrimitiveIterable.OfInt actual = Reducible.concatInt(EmptyIterable.of());
+		assertIterableEquals(expected, actual);
+	}
+
+	@Test
+	void testConcatIntIterator_Empty()
+	{
+		EmptyIterator.OfInt expected = EmptyIterator.ofInt();
+		FunctionalPrimitiveIterator.OfInt actual = Reducible.concatInt(EmptyIterator.of());
+		assertIteratorEquals(expected, actual);
+	}
+
+	@Test
+	void testConcatIntIterable_Null()
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concatInt((Iterable<PrimitiveIterable.OfInt>) null));
+	}
+
+	@Test
+	void testConcatIntIterator_Null()
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concat((Iterator<PrimitiveIterator.OfInt>) null));
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesNull")
+	void testConcatIntIterable_NullValues(Iterable<PrimitiveIterable.OfInt> iterable)
+	{
+		FunctionalPrimitiveIterable.OfInt result = Reducible.concatInt(iterable);
+		assertThrows(NullPointerException.class, result::consume);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesNull")
+	void testConcatIntIterator_NullValues(Iterable<PrimitiveIterator.OfInt> iterable)
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concatInt(iterable.iterator()));
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesLong")
+	void testConcatLongIterable(Iterable<Long> iterable)
+	{
+		ArrayList<Long> expectedBoxed = new ArrayList<>();
+		iterable.forEach(expectedBoxed::add);
+		iterable.forEach(expectedBoxed::add);
+		FunctionalPrimitiveIterable.OfLong expected = Reducible.unboxLong(expectedBoxed);
+		FunctionalPrimitiveIterable.OfLong unboxed = Reducible.unboxLong(iterable);
+		FunctionalPrimitiveIterable.OfLong actual = Reducible.concatLong(List.of(unboxed, unboxed));
+		assertIterableEquals(expected, actual);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesLong")
+	void testConcatLongIterator(Iterable<Long> iterable)
+	{
+		ArrayList<Long> expectedBoxed = new ArrayList<>();
+		iterable.forEach(expectedBoxed::add);
+		iterable.forEach(expectedBoxed::add);
+		FunctionalPrimitiveIterable.OfLong expected = Reducible.unboxLong(expectedBoxed);
+		FunctionalPrimitiveIterable.OfLong unboxed = Reducible.unboxLong(iterable);
+		FunctionalPrimitiveIterator.OfLong actual = Reducible.concatLong(List.of(unboxed.iterator(), unboxed.iterator()).iterator());
+		assertIteratorEquals(expected.iterator(), actual);
+	}
+
+	@Test
+	void testConcatLongIterable_Empty()
+	{
+		EmptyIterable.OfLong expected = EmptyIterable.ofLong();
+		FunctionalPrimitiveIterable.OfLong actual = Reducible.concatLong(EmptyIterable.of());
+		assertIterableEquals(expected, actual);
+	}
+
+	@Test
+	void testConcatLongIterator_Empty()
+	{
+		EmptyIterator.OfLong expected = EmptyIterator.ofLong();
+		FunctionalPrimitiveIterator.OfLong actual = Reducible.concatLong(EmptyIterator.of());
+		assertIteratorEquals(expected, actual);
+	}
+
+	@Test
+	void testConcatLongIterable_Null()
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concatLong((Iterable<PrimitiveIterable.OfLong>) null));
+	}
+
+	@Test
+	void testConcatLongIterator_Null()
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concat((Iterator<PrimitiveIterator.OfLong>) null));
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesNull")
+	void testConcatLongIterable_NullValues(Iterable<PrimitiveIterable.OfLong> iterable)
+	{
+		FunctionalPrimitiveIterable.OfLong result = Reducible.concatLong(iterable);
+		assertThrows(NullPointerException.class, result::consume);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesNull")
+	void testConcatLongIterator_NullValues(Iterable<PrimitiveIterator.OfLong> iterable)
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concatLong(iterable.iterator()));
+	}
+
+	@ParameterizedTest
 	@MethodSource("getIterablesDouble")
 	@DisplayName("unboxDouble() yields same sequence as the underlying iterable.")
 	void testUnboxDoubleIterable(Iterable<Double> iterable)


### PR DESCRIPTION
To make code more readable, this PR adds static functions for concatenation to `Reducible`. Then

    new ChainedIterable.Of<>(iterables)

becomes

    Reducible.concat(iterables)

or even

    concat(iterables)

if concat is statically imported.