### PR TITLE
Make transition and state reward export header consitent.

### DIFF
--- a/prism-tests/functionality/export/mdp/robot.prism.header1.trew
+++ b/prism-tests/functionality/export/mdp/robot.prism.header1.trew
@@ -1,3 +1,3 @@
-# Reward structure: "time"
+# Reward structure "time"
 # Transition rewards
 6 10 0

--- a/prism-tests/functionality/export/mdp/robot.prism.header2.trew
+++ b/prism-tests/functionality/export/mdp/robot.prism.header2.trew
@@ -1,4 +1,4 @@
-# Reward structure: "energy"
+# Reward structure "energy"
 # Transition rewards
 6 10 2
 2 0 2 3.5

--- a/prism-tests/functionality/export/mdp/robot.prism.header3.trew
+++ b/prism-tests/functionality/export/mdp/robot.prism.header3.trew
@@ -1,4 +1,4 @@
-# Reward structure: "move"
+# Reward structure "move"
 # Transition rewards
 6 10 14
 0 0 1 1

--- a/prism/src/mtbdd/PM_ExportMatrix.cc
+++ b/prism/src/mtbdd/PM_ExportMatrix.cc
@@ -74,7 +74,7 @@ jboolean neh    // noexportheaders
 	if (export_type == EXPORT_PLAIN && !neh) {
 		if (env->GetStringUTFLength(rsn) > 0) {
 			const char *header = env->GetStringUTFChars(rsn,0);
-			export_string("# Reward structure: \"%s\"\n", header);
+			export_string("# Reward structure \"%s\"\n", header);
 			env->ReleaseStringUTFChars(rsn, header);
 		}
 		export_string("# Transition rewards\n");

--- a/prism/src/sparse/PS_ExportMatrix.cc
+++ b/prism/src/sparse/PS_ExportMatrix.cc
@@ -97,7 +97,7 @@ jboolean neh    // noexportheaders
 	if (export_type == EXPORT_PLAIN && !neh) {
 		if (env->GetStringUTFLength(rsn) > 0) {
 			const char *header = env->GetStringUTFChars(rsn,0);
-			export_string("# Reward structure: \"%s\"\n", header);
+			export_string("# Reward structure \"%s\"\n", header);
 			env->ReleaseStringUTFChars(rsn, header);
 		}
 		export_string("# Transition rewards\n");

--- a/prism/src/sparse/PS_ExportSubMDP.cc
+++ b/prism/src/sparse/PS_ExportSubMDP.cc
@@ -88,7 +88,7 @@ jboolean neh    // noexportheaders
 	if (export_type == EXPORT_PLAIN && !neh) {
 		if (env->GetStringUTFLength(rsn) > 0) {
 			const char *header = env->GetStringUTFChars(rsn,0);
-			export_string("# Reward structure: \"%s\"\n", header);
+			export_string("# Reward structure \"%s\"\n", header);
 			env->ReleaseStringUTFChars(rsn, header);
 		}
 		export_string("# Transition rewards\n");


### PR DESCRIPTION
Fix inconsitency of state and transition reward export headers, refered in Issue #227.