### PR TITLE
Fix for issue 232

### DIFF
--- a/prism-tests/bugfixes/boolean-constant-issue-232.prism
+++ b/prism-tests/bugfixes/boolean-constant-issue-232.prism
@@ -1,0 +1,8 @@
+// A simple model that depends on an undefined boolean constant
+mdp
+
+const bool flag;
+
+module Boolean
+  b : bool init flag;
+endmodule

--- a/prism-tests/bugfixes/boolean-constant-issue-232.prism.args
+++ b/prism-tests/bugfixes/boolean-constant-issue-232.prism.args
@@ -1,0 +1,1 @@
+-const flag=false -exportresults boolean-constant-issue-232.prism.dataframe.csv:dataframe

--- a/prism-tests/bugfixes/boolean-constant-issue-232.prism.dataframe.csv
+++ b/prism-tests/bugfixes/boolean-constant-issue-232.prism.dataframe.csv
@@ -1,0 +1,2 @@
+Property,Result
+Property_1,false

--- a/prism-tests/bugfixes/boolean-constant-issue-232.prism.props
+++ b/prism-tests/bugfixes/boolean-constant-issue-232.prism.props
@@ -1,0 +1,4 @@
+// A simple property to trigger model checking
+// RESULT (flag=true): true
+// RESULT (flag=false): false
+b

--- a/prism/src/prism/DefinedConstant.java
+++ b/prism/src/prism/DefinedConstant.java
@@ -493,7 +493,7 @@ public abstract class DefinedConstant<T>
 	{
 		public DefinedBoolean(String name, boolean low)
 		{
-			super(name, TypeBool.getInstance(), low, null, null, 2);
+			super(name, TypeBool.getInstance(), low, null, null, 1);
 		}
 
 		@Override


### PR DESCRIPTION
Previously, defined boolean constants were initialized with two steps. This causes an increment (without effect) during model checking which results in all properties being checked twice, see issue #232 .