### PR TITLE
Allow `loadModelGenerator()` to be used with `loadPRISMModel()`

### DIFF
--- a/prism/src/prism/Prism.java
+++ b/prism/src/prism/Prism.java
@@ -1,27 +1,27 @@
 //==============================================================================
-//	
+//
 //	Authors:
 //	* Dave Parker <david.parker@comlab.ox.ac.uk> (University of Oxford, formerly University of Birmingham)
 //	* Andrew Hinton <ug60axh@cs.bham.ac.uk> (University of Birmingham)
-//	
+//
 //------------------------------------------------------------------------------
-//	
+//
 //	This file is part of PRISM.
-//	
+//
 //	PRISM is free software; you can redistribute it and/or modify
 //	it under the terms of the GNU General Public License as published by
 //	the Free Software Foundation; either version 2 of the License, or
 //	(at your option) any later version.
-//	
+//
 //	PRISM is distributed in the hope that it will be useful,
 //	but WITHOUT ANY WARRANTY; without even the implied warranty of
 //	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //	GNU General Public License for more details.
-//	
+//
 //	You should have received a copy of the GNU General Public License
 //	along with PRISM; if not, write to the Free Software Foundation,
 //	Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-//	
+//
 //==============================================================================
 
 package prism;
@@ -162,7 +162,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 	// state space cut-off to trigger MTBDD engine
 	protected static final int MTBDD_STATES_THRESHOLD = 100000000;
-	
+
 	//------------------------------------------------------------------------------
 	// Settings / flags / options
 	//------------------------------------------------------------------------------
@@ -240,11 +240,11 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	public enum ModelBuildType {
 		SYMBOLIC, EXPLICIT
 	}
-	
+
 	public enum PrismEngine {
 		SYMBOLIC, EXPLICIT
 	}
-	
+
 	// Info about currently loaded model, if any
 	// Model source
 	private ModelSource currentModelSource = ModelSource.PRISM_MODEL;
@@ -271,7 +271,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 	// The last strategy that was generated
 	private Strategy<?> strategy = null;
-	
+
 	// Info for explicit files load
 	private File explicitFilesStatesFile = null;
 	private File explicitFilesTransFile = null;
@@ -670,7 +670,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 	/**
 	 * Get the name of this tool.
-	 * ("PRISM" by default, extensions might override) 
+	 * ("PRISM" by default, extensions might override)
 	 */
 	public static String getToolName()
 	{
@@ -679,7 +679,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 	/**
 	 * Get the name of the command-line version of this tool.
-	 * ("prism" by default, extensions might override) 
+	 * ("prism" by default, extensions might override)
 	 */
 	public static String getCommandLineName()
 	{
@@ -687,7 +687,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	}
 
 	/**
-	 * Get current version number, as a string. 
+	 * Get current version number, as a string.
 	 */
 	public static String getVersion()
 	{
@@ -1057,7 +1057,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 				long cuddMaxMem = PrismUtils.convertMemoryStringtoKB(getCUDDMaxMem());
 				JDD.SetCUDDMaxMem(cuddMaxMem);
 			} catch (PrismException e) {
-				// Fail silently if memory string is invalid 
+				// Fail silently if memory string is invalid
 			}
 		}
 		jdd.SanityJDD.enabled = settings.getBoolean(PrismSettings.PRISM_JDD_SANITY_CHECKS);
@@ -1406,7 +1406,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 	/**
 	 * Parse a PRISM properties file, using the currently loaded model
-	 * for context (i.e. definitions of variables, constants, labels, etc.). 
+	 * for context (i.e. definitions of variables, constants, labels, etc.).
 	 * @param file File to read in
 	 */
 	public PropertiesFile parsePropertiesFile(File file) throws FileNotFoundException, PrismLangException
@@ -1417,7 +1417,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	/**
 	 * Parse a PRISM properties file, using a specific ModelInfo object (e.g. ModulesFile)
 	 * for context (i.e. definitions of variables, constants, labels, etc.).
-	 * Usually, just use {@link #parsePropertiesFile(File)}, which uses the currently loaded model. 
+	 * Usually, just use {@link #parsePropertiesFile(File)}, which uses the currently loaded model.
 	 * @param modelInfo Accompanying model info (null if not needed)
 	 * @param file File to read in
 	 */
@@ -1428,9 +1428,9 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 	/**
 	 * Parse a PRISM properties file, using the currently loaded model
-	 * for context (i.e. definitions of variables, constants, labels, etc.). 
+	 * for context (i.e. definitions of variables, constants, labels, etc.).
 	 * You can also choose whether to do "tidy", i.e. post-parse checks and processing
-	 * (this must be done at some point but may want to postpone to allow parsing of files with errors). 
+	 * (this must be done at some point but may want to postpone to allow parsing of files with errors).
 	 * @param file File to read in
 	 * @param tidy Whether or not to do "tidy" (post-parse checks and processing)
 	 */
@@ -1443,8 +1443,8 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	 * Parse a PRISM properties file, using a specific ModelInfo object (e.g. ModulesFile)
 	 * for context (i.e. definitions of variables, constants, labels, etc.).
 	 * You can also choose whether to do "tidy", i.e. post-parse checks and processing
-	 * (this must be done at some point but may want to postpone to allow parsing of files with errors). 
-	 * Usually, just use {@link #parsePropertiesFile(File, boolean)}, which uses the currently loaded model. 
+	 * (this must be done at some point but may want to postpone to allow parsing of files with errors).
+	 * Usually, just use {@link #parsePropertiesFile(File, boolean)}, which uses the currently loaded model.
 	 * @param modelInfo Accompanying model info (null if not needed)
 	 * @param file File to read in
 	 * @param tidy Whether or not to do "tidy" (post-parse checks and processing)
@@ -1481,7 +1481,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 	/**
 	 * Parse a PRISM properties file from a string, using the currently loaded model
-	 * for context (i.e. definitions of variables, constants, labels, etc.). 
+	 * for context (i.e. definitions of variables, constants, labels, etc.).
 	 * @param s String to parse
 	 */
 	public PropertiesFile parsePropertiesString(String s) throws PrismLangException
@@ -1492,7 +1492,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	/**
 	 * Parse a PRISM properties file from a string, using a specific ModelInfo object (e.g. ModulesFile)
 	 * for context (i.e. definitions of variables, constants, labels, etc.).
-	 * Usually, just use {@link #parsePropertiesString(String)}, which uses the currently loaded model. 
+	 * Usually, just use {@link #parsePropertiesString(String)}, which uses the currently loaded model.
 	 * @param modelInfo Accompanying model info (null if not needed)
 	 * @param s String to parse
 	 */
@@ -1590,7 +1590,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 		// Clear built model storage too
 		clearBuiltModel();
 	}
-	
+
 	/**
 	 * Load a (parsed) PRISM model, which will be stored and used for subsequent model checking etc.
 	 * Some model constants can still be undefined at this stage.
@@ -1682,7 +1682,6 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 		currentModelSource = ModelSource.MODEL_GENERATOR;
 		currentModelType = modelGen.getModelType();
 		currentModelInfo = modelGen;
-		currentModulesFile = null;
 		currentModelGenerator = modelGen;
 		// Create a blank reward generator if nor provided by the model generator
 		if (modelGen instanceof RewardGenerator) {
@@ -1856,7 +1855,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 			return PrismEngine.SYMBOLIC;
 		}
 	}
-	
+
 	/**
 	 * Get the ModelGenerator for the currently loaded model.
 	 * This will have either have been loaded directly
@@ -1886,7 +1885,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 				throw new PrismException("There is no currently loaded model generator");
 			case BUILT_MODEL:
 			case EXPLICIT_FILES:
-				// If possible, model building from files creates a ModelGenerator too 
+				// If possible, model building from files creates a ModelGenerator too
 				buildModelIfRequired();
 				break;
 			default:
@@ -1907,7 +1906,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	{
 		return currentDefinedMFConstants;
 	}
-	
+
 	/**
 	 * Get the currently stored built (symbolic) model.
 	 */
@@ -1949,7 +1948,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 			return null;
 		}
 	}
-	
+
 	/**
 	 * Returns true if the current model has been built (for the currently selected engine).
 	 */
@@ -2014,7 +2013,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 			// Build model
 			l = System.currentTimeMillis();
-			
+
 			switch (getCurrentEngine()) {
 			case SYMBOLIC:
 				switch (currentModelSource) {
@@ -2023,7 +2022,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 					currentModel = mod2mtbdd.translate();
 					currentModelExpl = null;
 					currentModelBuildType = ModelBuildType.SYMBOLIC;
-					break;				
+					break;
 				case MODEL_GENERATOR:
 					ModelGenerator2MTBDD modelGen2mtbdd = new ModelGenerator2MTBDD(this);
 					ModelGenerator<Double> modelGenDbl = (ModelGenerator<Double>) getModelGenerator();
@@ -2081,7 +2080,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 			default:
 				throw new PrismException("Unknown engine " + getCurrentEngine());
 			}
-			
+
 			l = System.currentTimeMillis() - l;
 			mainLog.println("\nTime for model construction: " + l / 1000.0 + " seconds.");
 
@@ -2197,7 +2196,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	/**
 	 * Build a model from a PRISM modelling language description, storing it symbolically,
 	 * as MTBDDs) via explicit-state reachability and model construction.
-	 * It is assumed that all constants in the model file have been defined by now.  
+	 * It is assumed that all constants in the model file have been defined by now.
 	 * @param modulesFile Model to build
 	 */
 	public Model buildModelExplicit(ModulesFile modulesFile) throws PrismException
@@ -2321,7 +2320,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 		if (getCurrentEngine() == PrismEngine.EXPLICIT) {
 			throw new PrismNotSupportedException("Export to Dot file not yet supported by explicit engine");
 		}
-		
+
 		// Export to dot file
 		mainLog.println("\nExporting to dot file \"" + file + "\"...");
 		JDD.ExportDDToDotFileLabelled(currentModel.getTrans(), file.getPath(), currentModel.getDDVarNames());
@@ -2331,7 +2330,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	 * Export the currently loaded model's transition matrix to a file (or to the log)
 	 * @param ordered Ensure that (source) states are in ascending order?
 	 * @param exportType Type of export; one of: <ul>
-	 * <li> {@link #EXPORT_PLAIN} 
+	 * <li> {@link #EXPORT_PLAIN}
 	 * <li> {@link #EXPORT_MATLAB}
 	 * <li> {@link #EXPORT_DOT}
 	 * <li> {@link #EXPORT_MRMC}
@@ -2413,7 +2412,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	 * If there is more than 1 reward structure, then multiple files are generated
 	 * (e.g. "rew.sta" becomes "rew1.sta", "rew2.sta", ...)
 	 * @param exportType Type of export; one of: <ul>
-	 * <li> {@link #EXPORT_PLAIN} 
+	 * <li> {@link #EXPORT_PLAIN}
 	 * <li> {@link #EXPORT_MATLAB}
 	 * <li> {@link #EXPORT_MRMC}
 	 * </ul>
@@ -2426,7 +2425,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 			mainLog.println("\nOmitting state reward export as there are no reward structures");
 			return;
 		}
-		
+
 		// Rows format does not apply to vectors
 		if (exportType == EXPORT_ROWS)
 			exportType = EXPORT_PLAIN;
@@ -2467,17 +2466,17 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 				}
 			}
 		}
-		
+
 		if (files.size() > 1) {
 			mainLog.println("Rewards were exported to multiple files: " + PrismUtils.joinString(files, ","));
 		}
 	}
-	
+
 	/**
 	 * Export the currently loaded model's transition rewards to a file
 	 * @param ordered Ensure that (source) states are in ascending order?
 	 * @param exportType Type of export; one of: <ul>
-	 * <li> {@link #EXPORT_PLAIN} 
+	 * <li> {@link #EXPORT_PLAIN}
 	 * <li> {@link #EXPORT_MATLAB}
 	 * <li> {@link #EXPORT_MRMC}
 	 * <li> {@link #EXPORT_ROWS}
@@ -2491,7 +2490,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 			mainLog.println("\nOmitting transition reward export as there are no reward structures");
 			return;
 		}
-		
+
 		if (getCurrentEngine() == PrismEngine.EXPLICIT) {
 			throw new PrismNotSupportedException("Export of transition rewards not yet supported by explicit engine");
 		}
@@ -2539,7 +2538,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 				// Not implemented yet
 			}
 		}
-		
+
 		if (files.size() > 1) {
 			mainLog.println("Rewards were exported to multiple files: " + PrismUtils.joinString(files, ","));
 		}
@@ -2548,7 +2547,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	/**
 	 * Export the currently loaded model's bottom strongly connected components (BSCCs) to a file
 	 * @param exportType Type of export; one of: <ul>
-	 * <li> {@link #EXPORT_PLAIN} 
+	 * <li> {@link #EXPORT_PLAIN}
 	 * <li> {@link #EXPORT_MATLAB}
 	 * </ul>
 	 * @param file File to export to (if null, print to the log instead)
@@ -2643,7 +2642,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	/**
 	 * Export the (states of the) currently loaded model's maximal end components (MECs) to a file
 	 * @param exportType Type of export; one of: <ul>
-	 * <li> {@link #EXPORT_PLAIN} 
+	 * <li> {@link #EXPORT_PLAIN}
 	 * <li> {@link #EXPORT_MATLAB}
 	 * </ul>
 	 * @param file File to export to (if null, print to the log instead)
@@ -2733,7 +2732,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	/**
 	 * Export the (states of the) currently loaded model's strongly connected components (SCCs) to a file
 	 * @param exportType Type of export; one of: <ul>
-	 * <li> {@link #EXPORT_PLAIN} 
+	 * <li> {@link #EXPORT_PLAIN}
 	 * <li> {@link #EXPORT_MATLAB}
 	 * </ul>
 	 * @param file File to export to (if null, print to the log instead)
@@ -2847,10 +2846,10 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 	/**
 	 * Export the states satisfying labels from the currently loaded model and (optionally) a properties file to a file.
-	 * The PropertiesFile should correspond to the currently loaded model. 
+	 * The PropertiesFile should correspond to the currently loaded model.
 	 * @param propertiesFile The properties file, for further labels (ignored if null)
 	 * @param exportType Type of export; one of: <ul>
-	 * <li> {@link #EXPORT_PLAIN} 
+	 * <li> {@link #EXPORT_PLAIN}
 	 * <li> {@link #EXPORT_MATLAB}
 	 * </ul>
 	 * @param file File to export to (if null, print to the log instead)
@@ -2907,7 +2906,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	/**
 	 * Export the currently loaded model's states to a file
 	 * @param exportType Type of export; one of: <ul>
-	 * <li> {@link #EXPORT_PLAIN} 
+	 * <li> {@link #EXPORT_PLAIN}
 	 * <li> {@link #EXPORT_MATLAB}
 	 * </ul>
 	 * @param file File to export to (if null, print to the log instead)
@@ -2993,7 +2992,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	 * model checking methods which assume you have already parsed the property separately.
 	 * This is just a simplified method for convenience. The property string can in fact be a whole
 	 * properties file, e.g. you can define labels/constants/etc. too, but an exception will be
-	 * thrown if there is more than one property present.    
+	 * thrown if there is more than one property present.
 	 * @param propertyString The property (in fact properties file) to check as a string
 	 */
 	public Result modelCheck(String propertyString) throws PrismException
@@ -3040,7 +3039,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 		// Remove old strategy if present
 		clearStrategy();
-		
+
 		// PTA (and similar) model checking is handled separately
 		if (currentModelType.realTime()) {
 			return modelCheckPTA(propertiesFile, prop.getExpression(), definedPFConstants);
@@ -3148,7 +3147,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 				explicit.StateModelChecker mc = createModelCheckerExplicit(propertiesFile);
 				res = mc.check(currentModelExpl, prop.getExpression());
 			}
-			
+
 			// If model checking generated a strategy, store it
 			if (res.getStrategy() != null) {
 				strategy = res.getStrategy();
@@ -3168,7 +3167,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	 * Perform model checking of a property on the currently loaded PTA PRISM model and return result.
 	 * @param propertiesFile Parent property file of property (for labels/constants/...)
 	 * @param expr The property to check
-	 * @param definedPFConstants Optional values info for properties file (to display in log) 
+	 * @param definedPFConstants Optional values info for properties file (to display in log)
 	 */
 	public Result modelCheckPTA(PropertiesFile propertiesFile, Expression expr, Values definedPFConstants) throws PrismException, PrismLangException
 	{
@@ -3178,7 +3177,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 		// Remove old strategy if present
 		clearStrategy();
-		
+
 		// Digital clocks translation
 		if (settings.getString(PrismSettings.PRISM_PTA_METHOD).equals("Digital clocks") || currentModelType == ModelType.POPTA) {
 			digital = true;
@@ -3291,7 +3290,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	 * Note: All constants in the model/property files must have already been defined.
 	 * @param propertiesFile Parent property file of property (for labels/constants/...)
 	 * @param expr The property to check
-	 * @param definedPFConstants Optional values info for properties file (to display in log) 
+	 * @param definedPFConstants Optional values info for properties file (to display in log)
 	 * @param initialState Initial state (if null, use default, selecting randomly if needed)
 	 * @param maxPathLength The maximum path length for sampling
 	 * @param simMethod Object specifying details of method to use for simulation
@@ -3316,7 +3315,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 		// Remove old strategy if present
 		clearStrategy();
-		
+
 		// Do simulation
 		loadModelIntoSimulator();
 		Result res = getSimulator().modelCheckSingleProperty(propertiesFile, expr, initialState, maxPathLength, simMethod);
@@ -3333,7 +3332,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	 * Note: All constants in the model/property files must have already been defined.
 	 * @param propertiesFile Parent property file of property (for labels/constants/...)
 	 * @param exprs The properties to check
-	 * @param definedPFConstants Optional values info for properties file (to display in log) 
+	 * @param definedPFConstants Optional values info for properties file (to display in log)
 	 * @param initialState Initial state (if null, use default, selecting randomly if needed)
 	 * @param maxPathLength The maximum path length for sampling
 	 * @param simMethod Object specifying details of method to use for simulation
@@ -3367,7 +3366,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 		// Remove old strategy if present
 		clearStrategy();
-		
+
 		// Do simulation
 		loadModelIntoSimulator();
 		Result[] resArray = getSimulator().modelCheckMultipleProperties(propertiesFile, exprs, initialState, maxPathLength, simMethod);
@@ -3406,7 +3405,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 		// Remove old strategy if present
 		clearStrategy();
-		
+
 		// Do simulation
 		loadModelIntoSimulator();
 		getSimulator().modelCheckExperiment(propertiesFile, undefinedConstants, results, expr, initialState, maxPathLength, simMethod);
@@ -3429,7 +3428,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 		// Remove old strategy if present
 		clearStrategy();
-		
+
 		// Set up a dummy parameter (not used)
 		String[] paramNames = new String[] { "dummy" };
 		String[] paramLowerBounds = new String[] { "0" };
@@ -3510,7 +3509,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 		// Remove old strategy if present
 		clearStrategy();
-		
+
 		param.ModelBuilder builder = new ModelBuilder(this, param.ParamMode.PARAMETRIC);
 		FunctionFactory functionFactory = builder.getFunctionFactory(paramNames, paramLowerBounds, paramUpperBounds);
 		ParamModel modelExpl = builder.constructModel(ModulesFileModelGenerator.createForRationalFunctions(currentModulesFile, functionFactory, this));
@@ -3610,7 +3609,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 	/**
 	 * Compute steady-state probabilities for the current model (DTMCs/CTMCs only).
-	 * Output probability distribution to log. 
+	 * Output probability distribution to log.
 	 */
 	public void doSteadyState() throws PrismException
 	{
@@ -3619,7 +3618,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 	/**
 	 * Compute steady-state probabilities for the current model (DTMCs/CTMCs only).
-	 * Output probability distribution to a file (or, if {@code fileOut} is null, to log). 
+	 * Output probability distribution to a file (or, if {@code fileOut} is null, to log).
 	 * The exportType should be EXPORT_PLAIN or EXPORT_MATLAB.
 	 * Optionally (if non-null), read in the initial probability distribution from a file.
 	 */
@@ -3736,7 +3735,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 	/**
 	 * Compute transient probabilities (forwards) for the current model (DTMCs/CTMCs only).
-	 * Output probability distribution to a file (or, if {@code fileOut} is null, to log). 
+	 * Output probability distribution to a file (or, if {@code fileOut} is null, to log).
 	 * For a discrete-time model, {@code time} will be cast to an integer.
 	 * The exportType should be EXPORT_PLAIN or EXPORT_MATLAB.
 	 * Optionally (if non-null), read in the initial probability distribution from a file.
@@ -3833,7 +3832,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	 * Compute transient probabilities (forwards) for the current model (DTMCs/CTMCs only)
 	 * for a range of time points. Each distribution is computed incrementally.
 	 * Output probability distribution to a file (or, if file is null, to log).
-	 * Time points are specified using an UndefinedConstants with a single ranging variable  
+	 * Time points are specified using an UndefinedConstants with a single ranging variable
 	 * (of the appropriate type (int/double) and with arbitrary name).
 	 * The exportType should be EXPORT_PLAIN or EXPORT_MATLAB.
 	 * Optionally (if non-null), read in the initial probability distribution from a file.
@@ -4038,7 +4037,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 			strategy = null;
 		}
 	}
-	
+
 	/**
 	 * Clear up and close down.
 	 */
@@ -4049,7 +4048,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 
 	/**
 	 * Clear up and close down.
-	 * @param check Whether to perform checks on CUDD status when shutting it down. 
+	 * @param check Whether to perform checks on CUDD status when shutting it down.
 	 */
 	public void closeDown(boolean check)
 	{
@@ -4182,7 +4181,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	 * @deprecated
 	 * Load a PRISM model, build it, store for later use and return.
 	 * Reachability and model construction are done symbolically, i.e. using (MT)BDDs.
-	 * It is assumed that all constants in the PRISM model file have been defined by now.  
+	 * It is assumed that all constants in the PRISM model file have been defined by now.
 	 * @param modulesFile Model to build
 	 */
 	@Deprecated
@@ -4225,7 +4224,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	 * @param model The model
 	 * @param ordered Ensure that (source) states are in ascending order?
 	 * @param exportType Type of export; one of: <ul>
-	 * <li> {@link #EXPORT_PLAIN} 
+	 * <li> {@link #EXPORT_PLAIN}
 	 * <li> {@link #EXPORT_MATLAB}
 	 * <li> {@link #EXPORT_DOT}
 	 * <li> {@link #EXPORT_MRMC}
@@ -4246,7 +4245,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	 * @param model The model
 	 * @param ordered Ensure that (source) states are in ascending order?
 	 * @param exportType Type of export; one of: <ul>
-	 * <li> {@link #EXPORT_PLAIN} 
+	 * <li> {@link #EXPORT_PLAIN}
 	 * <li> {@link #EXPORT_MATLAB}
 	 * <li> {@link #EXPORT_DOT}
 	 * <li> {@link #EXPORT_MRMC}
@@ -4267,7 +4266,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	 * Load a (built) model and export its state rewards to a file
 	 * @param model The model
 	 * @param exportType Type of export; one of: <ul>
-	 * <li> {@link #EXPORT_PLAIN} 
+	 * <li> {@link #EXPORT_PLAIN}
 	 * <li> {@link #EXPORT_MATLAB}
 	 * <li> {@link #EXPORT_MRMC}
 	 * </ul>
@@ -4286,7 +4285,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	 * @param model The model
 	 * @param ordered Ensure that (source) states are in ascending order?
 	 * @param exportType Type of export; one of: <ul>
-	 * <li> {@link #EXPORT_PLAIN} 
+	 * <li> {@link #EXPORT_PLAIN}
 	 * <li> {@link #EXPORT_MATLAB}
 	 * <li> {@link #EXPORT_MRMC}
 	 * <li> {@link #EXPORT_ROWS}
@@ -4305,7 +4304,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	 * Load a (built) model and export its bottom strongly connected components (BSCCs) to a file
 	 * @param model The model
 	 * @param exportType Type of export; one of: <ul>
-	 * <li> {@link #EXPORT_PLAIN} 
+	 * <li> {@link #EXPORT_PLAIN}
 	 * <li> {@link #EXPORT_MATLAB}
 	 * </ul>
 	 * @param file File to export to (if null, print to the log instead)
@@ -4320,12 +4319,12 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	/**
 	 * @deprecated
 	 * Load a (built) model and export the states satisfying labels from it and a properties file to a file
-	 * The PropertiesFile should correspond to the model. 
+	 * The PropertiesFile should correspond to the model.
 	 * @param model The model
 	 * @param modulesFile The corresponding (parsed) PRISM model (for the labels)
 	 * @param propertiesFile The properties file (for further labels)
 	 * @param exportType Type of export; one of: <ul>
-	 * <li> {@link #EXPORT_PLAIN} 
+	 * <li> {@link #EXPORT_PLAIN}
 	 * <li> {@link #EXPORT_MATLAB}
 	 * </ul>
 	 * @param file File to export to (if null, print to the log instead)
@@ -4343,7 +4342,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	 * Load a (built) model and export its states to a file
 	 * @param model The model
 	 * @param exportType Type of export; one of: <ul>
-	 * <li> {@link #EXPORT_PLAIN} 
+	 * <li> {@link #EXPORT_PLAIN}
 	 * <li> {@link #EXPORT_MATLAB}
 	 * </ul>
 	 * @param file File to export to (if null, print to the log instead)
@@ -4420,7 +4419,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	/**
 	 * @deprecated
 	 * Load (built) model and compute steady-state probabilities (DTMCs/CTMCs only).
-	 * Output probability distribution to log. 
+	 * Output probability distribution to log.
 	 */
 	@Deprecated
 	public void doSteadyState(Model model) throws PrismException
@@ -4431,7 +4430,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	/**
 	 * @deprecated
 	 * Load (built) model and compute steady-state probabilities (DTMCs/CTMCs only).
-	 * Output probability distribution to a file (or, if file is null, to log). 
+	 * Output probability distribution to a file (or, if file is null, to log).
 	 * The exportType should be EXPORT_PLAIN or EXPORT_MATLAB.
 	 */
 	@Deprecated
@@ -4444,7 +4443,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	/**
 	 * @deprecated
 	 * Load (built) model and compute transient probabilities (DTMCs/CTMCs only).
-	 * Output probability distribution to log. 
+	 * Output probability distribution to log.
 	 */
 	@Deprecated
 	public void doTransient(Model model, double time) throws PrismException
@@ -4455,7 +4454,7 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 	/**
 	 * @deprecated
 	 * Load (built) model and compute transient probabilities (DTMCs/CTMCs only).
-	 * Output probability distribution to a file (or, if file is null, to log). 
+	 * Output probability distribution to a file (or, if file is null, to log).
 	 * The exportType should be EXPORT_PLAIN or EXPORT_MATLAB.
 	 * Optionally (if non-null), read in the initial probability distribution from a file.
 	 */


### PR DESCRIPTION
In the current `master` branch (as well as the 4.8 release), `Prism.loadModelGenerator()` sets `currentModulesFile` to `null`. However, `loadPRISMModel()` sets `currentModelGenerator` to `null`. This means that these two methods cannot be used together with a custom `modulesFile` as follows:

```java
Prism p = /* Initialize Prism as desired */;
ModulesFile myModulesFile = /* Use one of the import functions */;
// Load the modules file into PRISM
p.loadPRISMModel(myModulesFile);
// Create a custom model generator
MyModelGenerator modelGen = new MyModelGenerator();
p.loadModelGenerator(modelGen); // sets the modules file internally to null!
// If we call loadPRISMModel again, we undo loadModelGenerator
p.loadPRISMModel(myModulesFile); // sets the model generator internally to null!
```

`loadModelGenerator()` does not appear to be used, with the exception of `src/prism/TestModelGenerator.java:main()`, which isn't executed in the main `prism` executable (afaik).

----

All this PR does is make it so that `loadModelGenerator()` does not set the internal modules file to `null`, so it can be called after `loadPRISMModel()` which is what v4.5 did. Additionally, it removes some trailing whitespace at the end of lines in `Prism.java`.