### PR TITLE
Pass LP results for multi-objective achievability queries

### DIFF
--- a/prism/src/sparse/PS_NondetMultiReachReward.cc
+++ b/prism/src/sparse/PS_NondetMultiReachReward.cc
@@ -669,7 +669,7 @@ JNIEXPORT jdouble __jlongpointer JNICALL Java_sparse_PrismSparse_PS_1NondetMulti
     }
 
     // Modify result based on type
-    if (relops[0] != 0 && relopsReward[0] != 3 && relopsReward[0] != 8) {
+    if ((num_targets == 0 || relops[0] != 0) && (num_rewards == 0 || (relopsReward[0] != 3 && relopsReward[0] != 8))) {
       // for qualitative queries, return 1/0 for existence of solution or not
       PS_PrintToMainLog(env, "LP problem solution %sfound so result is %s\n",  lp_solved ? "" : "not ", lp_solved ? "true" : "false");
       lp_result = lp_solved ? 1.0 : 0.0;

--- a/prism/src/sparse/PS_NondetMultiReachReward1.cc
+++ b/prism/src/sparse/PS_NondetMultiReachReward1.cc
@@ -744,7 +744,7 @@ JNIEXPORT jdouble __jlongpointer JNICALL Java_sparse_PrismSparse_PS_1NondetMulti
     }
 
     // Modify result based on type
-    if (relops[0] != 0 && relopsReward[0] != 3 && relopsReward[0] != 8) {
+    if ((num_targets == 0 || relops[0] != 0) && (num_rewards == 0 || (relopsReward[0] != 3 && relopsReward[0] != 8))) {
       // for qualitative queries, return 1/0 for existence of solution or not
       PS_PrintToMainLog(env, "LP problem solution %sfound so result is %s\n",  lp_solved ? "" : "not ", lp_solved ? "true" : "false");
       lp_result = lp_solved ? 1.0 : 0.0;


### PR DESCRIPTION
Right now, the results of a multi-objective achievability query can be returned as if it were a multi-objective numerical query when using the _-lp_ flag. For this reason, the LP solver can state that the answer is _true_, even though the answer computed by the LP solver was _false_.

For example, on the MDP [model.txt](https://github.com/user-attachments/files/15838739/model.txt), we can evaluate the property: `multi(R{"hire"}>=4 [C], R{"money"}<=1000 [C])` which is unachievable. In this case the output contains the line `LP problem solution not found; result is 0.000000` stating that no solution could be found, but it also reports `Result: true`, which is incorrect. This happens because if there are no probabilistic reachability subgoals, `relops[0]` does not exist. However, this invalid field is checked to determine whether the query is a numerical or achievability query and therefore can mistake an achievability query for a numerical query. With this fix, this field is not longer accessed if there are no probabilistic reachability subgoals, and thus the output contains `LP problem solution not found so result is false` and `Result: false` instead, which is the correct answer.