### PR TITLE
Always use .dylib, not .jnilib, for shared libraries on macOS

### DIFF
--- a/prism/Makefile
+++ b/prism/Makefile
@@ -409,12 +409,7 @@ make_dirs:
 	  LIBMATH="$(LIBMATH)" \
 	  CLASSPATHSEP="$(CLASSPATHSEP)") \
 	  || exit 1; \
-	done; \
-	if [ "$(OSTYPE)" = "darwin" ]; then \
-	  echo Creating shared library symlinks...; \
-	  (cd $(PRISM_LIB_DIR) && \
-	  for lib in `ls *$(LIBSUFFIX)`; do ln -fs $$lib `echo $$lib | sed s/$(LIBSUFFIX)/.jnilib/`; done;); \
-	fi
+	done
 # On Windows, convert the generated JNI headers using dos2unix
 # and any scripts to be run from Cywgin, in case extracted with CRLF endings.
 	@if [ "$(OSTYPE)" = "cygwin" ]; then \

--- a/prism/ext/lp_solve_5.5_java/Makefile
+++ b/prism/ext/lp_solve_5.5_java/Makefile
@@ -29,7 +29,7 @@ lpsolve55java:
 	@(if [ "$(OSTYPE)" = "darwin" ]; then \
 	  echo "Rebuild lpsolve55 Java wrapper for MacOS"; \
 	  (cd lib/mac; ARCH=$(ARCH) JAVA_JNI_H_DIR="$(JAVA_JNI_H_DIR)" JAVA_JNI_MD_H_DIR="$(JAVA_JNI_MD_H_DIR)" sh -x build-osx); \
-	  cp lib/lpsolve55j.jar lib/mac/liblpsolve55j.jnilib ../../$(PRISM_LIB_DIR)/ ; \
+	  cp lib/lpsolve55j.jar lib/mac/liblpsolve55j.dylib ../../$(PRISM_LIB_DIR)/ ; \
 	fi)
 	@(if [ "$(OSTYPE)" = "cygwin" ]; then \
 	  if [ "$(ARCH)" = "x86_64" ]; then \

--- a/prism/ext/lp_solve_5.5_java/lib/mac/build-osx
+++ b/prism/ext/lp_solve_5.5_java/lib/mac/build-osx
@@ -32,4 +32,4 @@ if [ "$ARCH" = "arm64" ]; then
 fi
 
 g++ $CFLAGS $INCL -c $SRC_DIR/lpsolve5j.cpp
-g++ $CFLAGS -dynamiclib lpsolve5j.o -compatibility_version 5.5.0 -current_version 5.5.0 -o liblpsolve55j.jnilib -lc -llpsolve55 -L$LPSOLVE_LIB_DIR
+g++ $CFLAGS -dynamiclib lpsolve5j.o -compatibility_version 5.5.0 -current_version 5.5.0 -o liblpsolve55j.dylib -lc -llpsolve55 -L$LPSOLVE_LIB_DIR


### PR DESCRIPTION
* Don't create symlinks on build (but "make clean" still removes them).
* Fix lp_solve_5.5_java builtd to generate a .dylib.