### PR TITLE
Add :append option to -mainlog in prism CLI

### DIFF
--- a/prism/src/prism/PrismCL.java
+++ b/prism/src/prism/PrismCL.java
@@ -126,7 +126,6 @@ public class PrismCL implements PrismModelListener
 	private String paramSwitch = null;
 
 	// files/filenames
-	private String mainLogFilename = "stdout";
 	private String settingsFilename = null;
 	private String modelFilename = null;
 	private String importInitDistFilename = null;
@@ -1813,15 +1812,7 @@ public class PrismCL implements PrismModelListener
 				// specify main log (hidden option)
 				else if (sw.equals("mainlog")) {
 					if (i < args.length - 1) {
-						mainLogFilename = args[++i];
-						try {
-							// use temporary storage because an error would go to the old log
-							log = new PrismFileLog(mainLogFilename);
-							mainLog = log;
-							prism.setMainLog(mainLog);
-						} catch (PrismException e) {
-							errorAndExit("Couldn't open log file \"" + mainLogFilename + "\"");
-						}
+						processMainLogSwitch(args[++i]);
 					} else {
 						errorAndExit("No file specified for -" + sw + " switch");
 					}
@@ -2424,6 +2415,35 @@ public class PrismCL implements PrismModelListener
 			else {
 				throw new PrismException("Unknown option \"" + opt + "\" for -exportstrat switch");
 			}
+		}
+	}
+
+	/**
+	 * Process the arguments (file, options) to the -mainlog switch
+	 */
+	private void processMainLogSwitch(String filesOptionsString) throws PrismException
+	{
+		// Split into file/options (on :)
+		String halves[] = splitFilesAndOptions(filesOptionsString);
+		String filename = halves[0];
+		String optionsString = halves[1];
+		// Process options
+		boolean append = false;
+		for (String opt : optionsString.split(",")) {
+			if (opt.equals("")) {
+				// ignore empty
+			} else if (opt.equals("append")) {
+				append = true;
+			} else {
+				throw new PrismException("Unknown option \"" + opt + "\" for -mainlog switch");
+			}
+		}
+		// Open the log
+		try {
+			mainLog = new PrismFileLog(filename, append);
+			prism.setMainLog(mainLog);
+		} catch (PrismException e) {
+			errorAndExit("Couldn't open log file \"" + filename + "\"");
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Extracts `-mainlog` argument processing into `processMainLogSwitch()` in `PrismCL.java`
- Adds support for a `:append` suffix (e.g., `-mainlog out.log:append`) to open the log file in append mode rather than truncating
- Removes the now-redundant `mainLogFilename` field (was effectively a local variable)

## Test plan

- [ ] `./bin/prism <model> <props> -mainlog out.log` — creates/truncates `out.log` as before
- [ ] `./bin/prism <model> <props> -mainlog out.log:append` — appends to `out.log` on repeated runs
- [ ] `-mainlog out.log:unknown` — exits with "Unknown option" error message
- [ ] `-mainlog` with no argument — exits with "No file specified" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)