### PR TITLE
Fix Initial States and Transitions Strings in GUI

### DIFF
--- a/prism/src/prism/Model.java
+++ b/prism/src/prism/Model.java
@@ -144,7 +144,7 @@ public interface Model<Value>
 	 */
 	default String getNumInitialStatesString()
 	{
-		return Integer.toString(getNumStates());
+		return Integer.toString(getNumInitialStates());
 	}
 
 	/**
@@ -152,6 +152,6 @@ public interface Model<Value>
 	 */
 	default String getNumTransitionsString()
 	{
-		return Integer.toString(getNumStates());
+		return Integer.toString(getNumTransitions());
 	}
 }


### PR DESCRIPTION
The Initial States and Transitions Strings shown in the UI defer from the Log output.

Currently:
<img width="501" height="259" alt="image" src="https://github.com/user-attachments/assets/6898ab88-247f-47f7-8489-97004d8f55f5" />

<img width="1103" height="635" alt="image" src="https://github.com/user-attachments/assets/6cd032e9-4ade-44df-8fe8-784e2f533540" />

Attempted Fix:
<img width="435" height="308" alt="Screenshot 2026-05-28 100448" src="https://github.com/user-attachments/assets/ed113041-52f1-4a9b-89e9-b212c71c31fe" />

