### PR TITLE
Use bash not sh in launch scripts.

### DIFF
--- a/prism/src/bin/prism.darwin
+++ b/prism/src/bin/prism.darwin
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Startup script for PRISM (Mac OS X)
 

--- a/prism/src/bin/prism.linux
+++ b/prism/src/bin/prism.linux
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Startup script for PRISM (Linux/Solaris)
 

--- a/prism/src/bin/xprism.linux
+++ b/prism/src/bin/xprism.linux
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Startup script for PRISM GUI (Linux/Solaris)
 


### PR DESCRIPTION
prism.darwin and xprism.linux declared #!/bin/sh but used bash-specific syntax (arrays, C-style for loops, [[ ]] tests). prism.linux already used #!/bin/bash. Switch all three to #!/usr/bin/env bash for consistency.