### PR TITLE
Remove old references to pepa.zip

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -9,7 +9,7 @@
 	<classpathentry kind="lib" path="prism/lib/jfreechart.jar"/>
 	<classpathentry kind="lib" path="prism/lib/jhoafparser.jar"/>
 	<classpathentry kind="lib" path="prism/lib/colt.jar"/>
-	<classpathentry kind="lib" path="prism/lib/pepa.zip"/>
+	<classpathentry kind="lib" path="prism/lib/pepa.jar"/>
 	<classpathentry kind="lib" path="prism/lib/lpsolve55j.jar"/>
 	<classpathentry kind="lib" path="prism/lib/jas.jar"/>
 	<classpathentry kind="lib" path="prism/lib/log4j-api.jar"/>

--- a/prism/.classpath
+++ b/prism/.classpath
@@ -9,7 +9,7 @@
 	<classpathentry kind="lib" path="lib/jfreechart.jar" sourcepath="/jfreechart/source"/>
 	<classpathentry kind="lib" path="lib/jhoafparser.jar"/>
 	<classpathentry kind="lib" path="lib/colt.jar" sourcepath="/Users/dxp/colt/src"/>
-	<classpathentry kind="lib" path="lib/pepa.zip"/>
+	<classpathentry kind="lib" path="lib/pepa.jar"/>
 	<classpathentry kind="lib" path="lib/lpsolve55j.jar"/>
 	<classpathentry kind="lib" path="lib/jas.jar"/>
 	<classpathentry kind="lib" path="lib/log4j-core.jar"/>

--- a/prism/src/bin/prism.bat.win
+++ b/prism/src/bin/prism.bat.win
@@ -16,9 +16,8 @@ rem Set up CLASSPATH:
 rem  - PRISM jar file (for binary versions) (gets priority)
 rem  - classes directory (most PRISM classes)
 rem  - top-level directory (for images, dtds)
-rem  - lib/pepa.zip (PEPA stuff)
 rem  - lib/*.jar (all other jars)
-set CP=%PRISM_DIR%\lib\prism.jar;%PRISM_DIR%\classes;%PRISM_DIR%;%PRISM_DIR%\lib\pepa.zip;%PRISM_DIR%\lib\*
+set CP=%PRISM_DIR%\lib\prism.jar;%PRISM_DIR%\classes;%PRISM_DIR%;%PRISM_DIR%\lib\*
 
 rem Run PRISM through Java
 java -Xss4M -Djava.library.path="%PRISM_DIR%\lib" -classpath "%CP%" prism.PrismCL %*

--- a/prism/src/bin/prism.cygwin
+++ b/prism/src/bin/prism.cygwin
@@ -85,9 +85,8 @@ done
 #  - PRISM jar file (for binary versions) (gets priority)
 #  - classes directory (most PRISM classes)
 #  - top-level directory (for images, dtds)
-#  - lib/pepa.zip (PEPA stuff)
 #  - lib/*.jar (all other jars)
-PRISM_CLASSPATH="$PRISM_DIR"/lib/prism.jar:"$PRISM_DIR"/classes:"$PRISM_DIR":"$PRISM_DIR"/lib/pepa.zip:"$PRISM_DIR"/lib/*
+PRISM_CLASSPATH="$PRISM_DIR"/lib/prism.jar:"$PRISM_DIR"/classes:"$PRISM_DIR":"$PRISM_DIR"/lib/*
 
 # Set up pointers to libraries
 PRISM_LIB_PATH="$PRISM_DIR"/lib

--- a/prism/src/bin/prism.darwin
+++ b/prism/src/bin/prism.darwin
@@ -94,9 +94,8 @@ done
 #  - PRISM jar file (for binary versions) (gets priority)
 #  - classes directory (most PRISM classes)
 #  - top-level directory (for images, dtds)
-#  - lib/pepa.zip (PEPA stuff)
 #  - lib/*.jar (all other jars)
-PRISM_CLASSPATH="$PRISM_DIR"/lib/prism.jar:"$PRISM_DIR"/classes:"$PRISM_DIR":"$PRISM_DIR"/lib/pepa.zip:"$PRISM_DIR"/lib/*
+PRISM_CLASSPATH="$PRISM_DIR"/lib/prism.jar:"$PRISM_DIR"/classes:"$PRISM_DIR":"$PRISM_DIR"/lib/*
 
 # Set up pointers to libraries
 PRISM_LIB_PATH="$PRISM_DIR"/lib

--- a/prism/src/bin/prism.linux
+++ b/prism/src/bin/prism.linux
@@ -85,9 +85,8 @@ done
 #  - PRISM jar file (for binary versions) (gets priority)
 #  - classes directory (most PRISM classes)
 #  - top-level directory (for images, dtds)
-#  - lib/pepa.zip (PEPA stuff)
 #  - lib/*.jar (all other jars)
-PRISM_CLASSPATH="$PRISM_DIR"/lib/prism.jar:"$PRISM_DIR"/classes:"$PRISM_DIR":"$PRISM_DIR"/lib/pepa.zip:"$PRISM_DIR"/lib/*
+PRISM_CLASSPATH="$PRISM_DIR"/lib/prism.jar:"$PRISM_DIR"/classes:"$PRISM_DIR":"$PRISM_DIR"/lib/*
 
 # Set up pointers to libraries
 PRISM_LIB_PATH="$PRISM_DIR"/lib

--- a/prism/src/bin/xprism.bat.win
+++ b/prism/src/bin/xprism.bat.win
@@ -16,9 +16,8 @@ rem Set up CLASSPATH:
 rem  - PRISM jar file (for binary versions) (gets priority)
 rem  - classes directory (most PRISM classes)
 rem  - top-level directory (for images, dtds)
-rem  - lib/pepa.zip (PEPA stuff)
 rem  - lib/*.jar (all other jars)
-set CP=%PRISM_DIR%\lib\prism.jar;%PRISM_DIR%\classes;%PRISM_DIR%;%PRISM_DIR%\lib\pepa.zip;%PRISM_DIR%\lib\*
+set CP=%PRISM_DIR%\lib\prism.jar;%PRISM_DIR%\classes;%PRISM_DIR%;%PRISM_DIR%\lib\*
 
 rem Run PRISM through Java
 start "PRISM" javaw -Xmx1g -Xss4M -Djava.library.path="%PRISM_DIR%\lib" -classpath "%CP%" userinterface/GUIPrism %*

--- a/prism/src/manifest.txt
+++ b/prism/src/manifest.txt
@@ -1,2 +1,1 @@
 Main-Class: userinterface.GUIPrism
-Class-Path: pepa.zip

--- a/prism/src/pepa/compiler/Main.java
+++ b/prism/src/pepa/compiler/Main.java
@@ -58,7 +58,7 @@ public class Main {
 
             return PRISM_result;
 	} catch (ClassNotFoundException cnfe) {
-	    throw new InternalError("Could not load the PEPA compiler class from pepa.zip");
+	    throw new InternalError("Could not load the PEPA compiler class from pepa.jar");
 	} catch (SecurityException se) {
 	    throw new InternalError("Could not secure the PEPA compiler class");
 	} catch (IllegalAccessException iae) {


### PR DESCRIPTION
This was converted to a .jar and treated like other libs in c7e2f9db6.