### PR TITLE
Rewards (and labels) attach-able to explicit.Model

### DIFF
--- a/prism/src/explicit/DTMCSparse.java
+++ b/prism/src/explicit/DTMCSparse.java
@@ -72,21 +72,7 @@ public class DTMCSparse extends DTMCExplicit<Double>
 	public DTMCSparse(final DTMC<Double> dtmc)
 	{
 		initialise(dtmc.getNumStates());
-		if (dtmc instanceof ActionListOwner) {
-			actionList.copyFrom(((ActionListOwner) dtmc).getActionList());
-		}
-		for (Integer state : dtmc.getDeadlockStates()) {
-			deadlocks.add(state);
-		}
-		for (Integer state : dtmc.getInitialStates()) {
-			initialStates.add(state);
-		}
-		constantValues = dtmc.getConstantValues();
-		varList = dtmc.getVarList();
-		statesList = dtmc.getStatesList();
-		for (String label : dtmc.getLabels()) {
-			labels.put(label, dtmc.getLabelStates(label));
-		}
+		copyFrom(dtmc);
 
 		// Copy transition function
 		final int numTransitions = dtmc.getNumTransitions();

--- a/prism/src/explicit/LTLModelChecker.java
+++ b/prism/src/explicit/LTLModelChecker.java
@@ -40,7 +40,6 @@ import java.util.Stack;
 import java.util.Vector;
 
 import common.Interval;
-import explicit.rewards.MDPRewards;
 import parser.State;
 import parser.VarList;
 import parser.ast.Declaration;

--- a/prism/src/explicit/LTLModelChecker.java
+++ b/prism/src/explicit/LTLModelChecker.java
@@ -40,6 +40,7 @@ import java.util.Stack;
 import java.util.Vector;
 
 import common.Interval;
+import explicit.rewards.MDPRewards;
 import parser.State;
 import parser.VarList;
 import parser.ast.Declaration;
@@ -754,11 +755,13 @@ public class LTLModelChecker extends PrismComponent
 		// generate acceptance for the product model by lifting
 		product.setAcceptance(liftAcceptance(product, da.getAcceptance()));
 
-		// lift the labels
+		// lift any labels
 		for (String label : model.getLabels()) {
 			BitSet liftedLabel = product.liftFromModel(model.getLabelStates(label));
 			prodModel.addLabel(label, liftedLabel);
 		}
+		// lift any rewards
+		((ModelSimple<Value>) prodModel).copyRewardsMapped(model, rews -> rews.liftFromModel(product));
 
 		return product;
 	}

--- a/prism/src/explicit/MDPSparse.java
+++ b/prism/src/explicit/MDPSparse.java
@@ -98,14 +98,7 @@ public class MDPSparse extends MDPExplicit<Double>
 	public MDPSparse(final MDP<Double> mdp, boolean sort)
 	{
 		initialise(mdp.getNumStates());
-		if (mdp instanceof ActionListOwner) {
-			actionList.copyFrom(((ActionListOwner) mdp).getActionList());
-		}
-		setStatesList(mdp.getStatesList());
-		setConstantValues(mdp.getConstantValues());
-		for (String label : mdp.getLabels()) {
-			addLabel(label, mdp.getLabelStates(label));
-		}
+		copyFrom(mdp);
 
 		// Copy stats
 		numDistrs = mdp.getNumChoices();
@@ -122,13 +115,6 @@ public class MDPSparse extends MDPExplicit<Double>
 		final TreeMap<Integer, Double> sorted = sort ? new TreeMap<Integer, Double>() : null;
 		int rowIndex = 0, choiceIndex = 0;
 		for (int state = 0; state < numStates; state++) {
-			if (mdp.isInitialState(state)) {
-				addInitialState(state);
-			}
-			if (mdp.isDeadlockState(state)) {
-				deadlocks.add(state);
-			}
-
 			rowStarts[state] = rowIndex;
 			if (actions != null) {
 				for (int choice = 0, numChoices = mdp.getNumChoices(state); choice < numChoices; choice++) {

--- a/prism/src/explicit/Model.java
+++ b/prism/src/explicit/Model.java
@@ -40,9 +40,7 @@ import java.util.function.IntPredicate;
 import common.IterableStateSet;
 import common.IteratorTools;
 import explicit.rewards.Rewards;
-import io.DotExporter;
-import io.ModelExportOptions;
-import io.PrismExplicitExporter;
+import io.*;
 import parser.State;
 import parser.Values;
 import parser.VarList;
@@ -425,6 +423,31 @@ public interface Model<Value> extends prism.Model<Value>
 	 * States in 'except' (If non-null) are excluded from the check.
 	 */
 	void checkForDeadlocks(BitSet except) throws PrismException;
+
+	/**
+	 * Export to the specified model format.
+	 */
+	default void export(PrismLog out, ModelExportFormat exportFormat) throws PrismException
+	{
+		export(out, new ModelExportOptions(exportFormat));
+	}
+
+	/**
+	 * Export using the specified export options.
+	 */
+	default void export(PrismLog out, ModelExportOptions exportOptions) throws PrismException
+	{
+		// Create a model checker with {@code out} as the log and export to that
+		StateModelChecker mcExport = StateModelChecker.createModelChecker(getModelType());
+		mcExport.setLog(out);
+		// If {@code out} is backed by a real file (as opposed to stdout/the main log),
+		// pass that file through too, since some (e.g. binary) export formats need it
+		File file = null;
+		if (out instanceof PrismFileLog && !((PrismFileLog) out).isStdout()) {
+			file = new File(((PrismFileLog) out).getFileName());
+		}
+		mcExport.exportModel(this, ModelExportTask.fromOptions(file, exportOptions));
+	}
 
 	// Export methods (explicit files)
 

--- a/prism/src/explicit/Model.java
+++ b/prism/src/explicit/Model.java
@@ -39,6 +39,7 @@ import java.util.function.IntPredicate;
 
 import common.IterableStateSet;
 import common.IteratorTools;
+import explicit.rewards.Rewards;
 import io.DotExporter;
 import io.ModelExportOptions;
 import io.PrismExplicitExporter;
@@ -153,7 +154,43 @@ public interface Model<Value> extends prism.Model<Value>
 		}
 		return labels;
 	}
-	
+
+	/**
+	 * Get an attached reward structure, by its (optional) name.
+	 * Returns null if it does not exist.
+	 */
+	Rewards<Value> getRewardsByName(String name);
+
+	/**
+	 * Get an attached reward structure, by its (optional) position.
+	 * By convention, positions are assumed to be indexed from 0.
+	 * Returns null if it does not exist.
+	 */
+	Rewards<Value> getRewardsByPosition(int r);
+
+	/**
+	 * Get the number of reward structures that are attached to the model.
+	 */
+	int getNumRewards();
+
+	/**
+	 * Get the {@code i}th stored reward structure.
+	 */
+	Rewards<Value> getRewards(int i);
+
+	/**
+	 * Get the name of the {@code i}th stored reward structure.
+	 * This is optionally stored and "" if absent.
+	 */
+	String getRewardName(int i);
+
+	/**
+	 * Get the position of the {@code i}th stored reward structure.
+	 * This is optionally stored, and refers to the order within its original source,
+	 * e.g., a properties file. By convention, positions are 0-indexed. Null if absent.
+	 */
+	Integer getRewardPosition(int i);
+
 	@Override
 	default int getNumTransitions()
 	{

--- a/prism/src/explicit/ModelExplicit.java
+++ b/prism/src/explicit/ModelExplicit.java
@@ -376,7 +376,7 @@ public abstract class ModelExplicit<Value> implements Model<Value>, ActionListOw
 			}
 		}
 		if (nameMatch != -1 && positionMatch != -1 && nameMatch != positionMatch) {
-			throw new RuntimeException("Reward structure name \"" + name + "\" and position " + position + " refer to different existing reward structures");
+			throw new IllegalArgumentException("Reward structure name \"" + name + "\" and position " + position + " refer to different existing reward structures");
 		}
 		return nameMatch != -1 ? nameMatch : positionMatch;
 	}

--- a/prism/src/explicit/ModelExplicit.java
+++ b/prism/src/explicit/ModelExplicit.java
@@ -27,13 +27,7 @@
 package explicit;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.BitSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.function.Function;
 
 import explicit.rewards.Rewards;
@@ -98,7 +92,7 @@ public abstract class ModelExplicit<Value> implements Model<Value>, ActionListOw
 	 * (Optionally) some labels (atomic propositions) associated with the model,
 	 * represented as a String->BitSet mapping from their names to the states that satisfy them.
 	 */
-	protected Map<String, BitSet> labels = new TreeMap<String, BitSet>();
+	protected Map<String, BitSet> labels = new LinkedHashMap<>();
 
 	/**
 	 * (Optionally) some attached reward structures.
@@ -198,7 +192,7 @@ public abstract class ModelExplicit<Value> implements Model<Value>, ActionListOw
 		statesList = null;
 		constantValues = null;
 		varList = null;
-		labels = new TreeMap<String, BitSet>();
+		labels = new LinkedHashMap<>();
 		rewards = new ArrayList<>();
 	}
 

--- a/prism/src/explicit/ModelExplicit.java
+++ b/prism/src/explicit/ModelExplicit.java
@@ -34,7 +34,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.Function;
 
+import explicit.rewards.Rewards;
 import io.ExplicitModelImporter;
 import io.PrismExplicitImporter;
 import parser.State;
@@ -99,6 +101,23 @@ public abstract class ModelExplicit<Value> implements Model<Value>, ActionListOw
 	protected Map<String, BitSet> labels = new TreeMap<String, BitSet>();
 
 	/**
+	 * (Optionally) some attached reward structures.
+	 * Each can have a name (set to "" if it is unnamed).
+	 * Each can have a position, referring to the order within its original source,
+	 * e.g., a properties file (null if undefined).
+	 * By convention, positions are assumed to be indexed from 0.
+	 * Both names and positions must be unique if defined.
+	 */
+	protected List<IndexedRewards<Value>> rewards = new ArrayList<>();
+
+	static protected class IndexedRewards<Value>
+	{
+		String name = "";
+		Integer position = null;
+		Rewards<Value> rews;
+	}
+
+	/**
 	 * (Optionally) the stored predecessor relation. Becomes inaccurate after the model is changed!
 	 */
 	protected PredecessorRelation predecessorRelation = null;
@@ -117,6 +136,7 @@ public abstract class ModelExplicit<Value> implements Model<Value>, ActionListOw
 	 * Copy data from another Model (used by superclass copy constructors).
 	 * Assumes that this has already been initialise()ed.
 	 */
+	@SuppressWarnings("unchecked")
 	public void copyFrom(Model<?> model)
 	{
 		setEvaluator((Evaluator<Value>) model.getEvaluator());
@@ -134,6 +154,7 @@ public abstract class ModelExplicit<Value> implements Model<Value>, ActionListOw
 		statesList = model.getStatesList();
 		constantValues = model.getConstantValues();
 		labels = model.getLabelToStatesMap();
+		copyRewards((Model<Value>) model);
 		varList = model.getVarList();
 	}
 
@@ -162,6 +183,7 @@ public abstract class ModelExplicit<Value> implements Model<Value>, ActionListOw
 		statesList = null;
 		constantValues = model.getConstantValues();
 		labels.clear();
+		rewards.clear();
 		varList = model.getVarList();
 	}
 
@@ -177,6 +199,7 @@ public abstract class ModelExplicit<Value> implements Model<Value>, ActionListOw
 		constantValues = null;
 		varList = null;
 		labels = new TreeMap<String, BitSet>();
+		rewards = new ArrayList<>();
 	}
 
 	/**
@@ -311,6 +334,87 @@ public abstract class ModelExplicit<Value> implements Model<Value>, ActionListOw
 
 		addLabel(label, labelStates);
 		return label;
+	}
+
+	/**
+	 * Attach a reward structure with optional name and position.
+	 * If a reward structure already exists with the same (non-empty) name or the same
+	 * (non-null) position, it is overwritten. If both name and position are provided,
+	 * and they do not identify the same existing reward structure (or lack thereof),
+	 * this is an error.
+	 * @param name Name of reward structure ("" for unnamed; null also accepted)
+	 * @param position Position of reward structure (0-indexed; null if not stored)
+	 * @param rews The rewards
+	 * @return The index of the attached reward
+	 */
+	public int addRewards(String name, Integer position, Rewards<Value> rews)
+	{
+		String rewName = name == null ? "" : name;
+		int i = findRewardsIndex(rewName, position);
+		if (i == -1) {
+			i = rewards.size();
+			rewards.add(new IndexedRewards<>());
+		}
+		IndexedRewards<Value> ir = rewards.get(i);
+		ir.name = rewName;
+		ir.position = position;
+		ir.rews = rews;
+		return i;
+	}
+
+	/**
+	 * Find the index of a stored reward structure matching a (non-empty) name
+	 * or a (non-null) position, if any. Returns -1 if there is no match.
+	 * If both name and position are provided, but match different existing reward
+	 * structures, this is an error (they should either both be absent or agree).
+	 */
+	private int findRewardsIndex(String name, Integer position)
+	{
+		int nameMatch = -1;
+		int positionMatch = -1;
+		for (int i = 0; i < rewards.size(); i++) {
+			IndexedRewards<Value> ir = rewards.get(i);
+			if (!name.isEmpty() && name.equals(ir.name)) {
+				nameMatch = i;
+			}
+			if (position != null && position.equals(ir.position)) {
+				positionMatch = i;
+			}
+		}
+		if (nameMatch != -1 && positionMatch != -1 && nameMatch != positionMatch) {
+			throw new RuntimeException("Reward structure name \"" + name + "\" and position " + position + " refer to different existing reward structures");
+		}
+		return nameMatch != -1 ? nameMatch : positionMatch;
+	}
+
+	/**
+	 * Attach a reward structure with optional name.
+	 * @param name Name of reward structure ("" for unnamed; null also accepted)
+	 * @param rews The rewards
+	 * @return The index of the attached reward
+	 */
+	public int addRewards(String name, Rewards<Value> rews)
+	{
+		return addRewards(name, null, rews);
+	}
+
+	/**
+	 * Copy the rewards from an existing model.
+	 */
+	public void copyRewards(Model<Value> model)
+	{
+		copyRewardsMapped(model, rews -> rews);
+	}
+
+	/**
+	 * Copy the rewards from an existing model after first applying a function to them.
+	 */
+	public void copyRewardsMapped(Model<Value> model, Function<Rewards<Value>, Rewards<Value>> map)
+	{
+		int numRewards = model.getNumRewards();
+		for (int i = 0; i < numRewards; i++) {
+			addRewards(model.getRewardName(i), model.getRewardPosition(i), map.apply(model.getRewards(i)));
+		}
 	}
 
 	// Accessors (for Model interface)
@@ -448,6 +552,55 @@ public abstract class ModelExplicit<Value> implements Model<Value>, ActionListOw
 	public Map<String, BitSet> getLabelToStatesMap()
 	{
 		return labels;
+	}
+
+	@Override
+	public Rewards<Value> getRewardsByName(String name)
+	{
+		if (name == null || name.isEmpty()) {
+			return null;
+		}
+		for (IndexedRewards<Value> ir : rewards) {
+			if (name.equals(ir.name)) {
+				return ir.rews;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public Rewards<Value> getRewardsByPosition(int r)
+	{
+		for (IndexedRewards<Value> ir : rewards) {
+			if (ir.position != null && ir.position == r) {
+				return ir.rews;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public int getNumRewards()
+	{
+		return rewards.size();
+	}
+
+	@Override
+	public Rewards<Value> getRewards(int i)
+	{
+		return rewards.get(i).rews;
+	}
+
+	@Override
+	public String getRewardName(int i)
+	{
+		return rewards.get(i).name;
+	}
+
+	@Override
+	public Integer getRewardPosition(int i)
+	{
+		return rewards.get(i).position;
 	}
 
 	@Override

--- a/prism/src/explicit/ModelSimple.java
+++ b/prism/src/explicit/ModelSimple.java
@@ -31,6 +31,7 @@ import java.util.BitSet;
 import java.util.List;
 import java.util.function.Function;
 
+import explicit.rewards.Rewards;
 import io.ExplicitModelImporter;
 import io.PrismExplicitImporter;
 import parser.State;
@@ -98,6 +99,33 @@ public interface ModelSimple<Value> extends Model<Value>
 	 * @param states The states that satisfy the label 
 	 */
 	public void addLabel(String name, BitSet states);
+
+	/**
+	 * Attach a reward structure with optional name and position.
+	 * @param name Name of reward structure ("" for unnamed; null also accepted)
+	 * @param position Position of reward structure (0-indexed; null if not stored)
+	 * @param rews The rewards
+	 * @return The index of the attached reward
+	 */
+	public int addRewards(String name, Integer position, Rewards<Value> rews);
+
+	/**
+	 * Attach a reward structure with optional name.
+	 * @param name Name of reward structure ("" for unnamed; null also accepted)
+	 * @param rews The rewards
+	 * @return The index of the attached reward
+	 */
+	public int addRewards(String name, Rewards<Value> rews);
+
+	/**
+	 * Copy the rewards from an existing model.
+	 */
+	public void copyRewards(Model<Value> model);
+
+	/**
+	 * Copy the rewards from an existing model after first applying a function to them.
+	 */
+	public void copyRewardsMapped(Model<Value> model, Function<Rewards<Value>, Rewards<Value>> map);
 
 	// Static helper methods
 

--- a/prism/src/explicit/ProbModelChecker.java
+++ b/prism/src/explicit/ProbModelChecker.java
@@ -954,6 +954,7 @@ public class ProbModelChecker extends NonProbModelChecker
 	/**
 	 * Model check an R operator expression and return the values for all states.
 	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	protected StateValues checkExpressionReward(Model<?> model, ExpressionReward expr, boolean forAll, Coalition coalition, BitSet statesOfInterest) throws PrismException
 	{
 		// Get info from R operator
@@ -977,6 +978,20 @@ public class ProbModelChecker extends NonProbModelChecker
 			// at position 0, but the model has some attached rewards, just use the first one
 			if (rewards == null && model.getNumRewards() > 0 && (rewardGen == null || rewardGen.getNumRewardStructs() == 0)) {
 				rewards = model.getRewards(0);
+			}
+		}
+		if (rewards != null) {
+			// Rewards resolved directly from the model (rather than freshly built below) may
+			// still carry raw transition rewards that solution methods can't consume directly
+			// (e.g., imported/attached Markov chain transition rewards) - convert to expected
+			// state rewards where needed (skipped for instantaneous-reward properties, which
+			// don't use transition rewards and mustn't have them folded into the state reward).
+			// The conversion (and the legality checks it also performs) is cached, since this
+			// is invoked repeatedly for the same underlying rewards object, e.g., once per
+			// property checked against the same model.
+			if (!Expression.usesInstantaneousReward(expr.getExpression())) {
+				Model rawModel = model;
+				rewards = ConstructRewards.getExpectedRewards((Rewards) rewards, rawModel, rawModel.getEvaluator(), true, false);
 			}
 		}
 		// Failing that, build rewards via reward generator

--- a/prism/src/explicit/ProbModelChecker.java
+++ b/prism/src/explicit/ProbModelChecker.java
@@ -972,6 +972,12 @@ public class ProbModelChecker extends NonProbModelChecker
 		} else if (rsi instanceof Expression) {
 			int i = ((Expression) rsi).evaluateInt(constantValues);
 			rewards = model.getRewardsByPosition(i - 1);
+			// If the model has attached rewards but none carries positional metadata
+			// matching i, and there is no reward generator to fall back on, just use
+			// the i-th attached reward (list order), as is done below for position 0
+			if (rewards == null && i >= 1 && i <= model.getNumRewards() && (rewardGen == null || rewardGen.getNumRewardStructs() == 0)) {
+				rewards = model.getRewards(i - 1);
+			}
 		} else {
 			rewards = model.getRewardsByPosition(0);
 			// If neither the model nor the reward generator can provide a reward structure

--- a/prism/src/explicit/ProbModelChecker.java
+++ b/prism/src/explicit/ProbModelChecker.java
@@ -960,10 +960,31 @@ public class ProbModelChecker extends NonProbModelChecker
 		OpRelOpBound opInfo = expr.getRelopBoundInfo(constantValues);
 		MinMax minMax = opInfo.getMinMax(model.getModelType(), forAll);
 
-		// Build rewards
-		int r = expr.getRewardStructIndexByIndexObject(rewardGen, constantValues);
-		mainLog.println("Building reward structure...");
-		Rewards<?> rewards = Expression.usesInstantaneousReward(expr.getExpression()) ? constructRewards(model, r) : constructExpectedRewards(model, r);
+		// First look at rewards attached directly to model:
+		// resolve by name, or by position (reward structure indices are 1-based at this point,
+		// i.e. as written by the user, so convert to a 0-based position), or, if neither is
+		// specified, the one at position 0.
+		Object rsi = expr.getRewardStructIndex();
+		Rewards<?> rewards;
+		if (rsi instanceof String) {
+			rewards = model.getRewardsByName((String) rsi);
+		} else if (rsi instanceof Expression) {
+			int i = ((Expression) rsi).evaluateInt(constantValues);
+			rewards = model.getRewardsByPosition(i - 1);
+		} else {
+			rewards = model.getRewardsByPosition(0);
+			// If neither the model nor the reward generator can provide a reward structure
+			// at position 0, but the model has some attached rewards, just use the first one
+			if (rewards == null && model.getNumRewards() > 0 && (rewardGen == null || rewardGen.getNumRewardStructs() == 0)) {
+				rewards = model.getRewards(0);
+			}
+		}
+		// Failing that, build rewards via reward generator
+		if (rewards == null) {
+			int r = expr.getRewardStructIndexByIndexObject(rewardGen, constantValues);
+			mainLog.println("Building reward structure...");
+			rewards = Expression.usesInstantaneousReward(expr.getExpression()) ? constructRewards(model, r) : constructExpectedRewards(model, r);
+		}
 
 		// Compute rewards
 		StateValues rews = checkRewardFormula(model, rewards, expr.getExpression(), minMax, statesOfInterest);

--- a/prism/src/explicit/StateModelChecker.java
+++ b/prism/src/explicit/StateModelChecker.java
@@ -80,22 +80,7 @@ import parser.type.TypeBool;
 import parser.type.TypeDouble;
 import parser.visitor.ASTTraverseModify;
 import parser.visitor.ReplaceLabels;
-import prism.Accuracy;
-import prism.Evaluator;
-import prism.Filter;
-import prism.ModelInfo;
-import prism.ModelType;
-import prism.Pair;
-import prism.Prism;
-import prism.PrismComponent;
-import prism.PrismException;
-import prism.PrismFileLog;
-import prism.PrismLangException;
-import prism.PrismLog;
-import prism.PrismNotSupportedException;
-import prism.PrismSettings;
-import prism.Result;
-import prism.RewardGenerator;
+import prism.*;
 
 /**
  * Super class for explicit-state model checkers.
@@ -1474,6 +1459,25 @@ public class StateModelChecker extends PrismComponent
 	}
 
 	/**
+	 * Get a {@link ModelInfo} object for the provided model,
+	 * containing info about model type, variables and labels.
+	 * If this is already stored locally in {@link #modelInfo}, use that.
+	 * If not construct one from data attached to the model.
+	 */
+	protected <Value> ModelInfo getModelInfo(Model<Value> model) throws PrismException
+	{
+		if (modelInfo != null) {
+			return modelInfo;
+		}
+		BasicModelInfo modelInfo = new BasicModelInfo(model.getModelType());
+		if (model.getVarList() != null) {
+			modelInfo.setVarList(model.getVarList());
+		}
+		model.getLabels().forEach(label -> modelInfo.getLabelNameList().add(label));
+		return modelInfo;
+	}
+
+	/**
 	 * Construct rewards for the reward structure with index r of the reward generator and a model.
 	 * Ensures non-negative rewards.
 	 * <br>
@@ -1594,9 +1598,9 @@ public class StateModelChecker extends PrismComponent
 	 * (always present) stored model info, plus any additional labels attached directly
 	 * to the model that are not already included.
 	 */
-	protected List<String> getAllLabelNames(Model<?> model)
+	protected List<String> getAllLabelNames(Model<?> model) throws PrismException
 	{
-		List<String> labelNames = new ArrayList<>(modelInfo.getLabelNames());
+		List<String> labelNames = new ArrayList<>(getModelInfo(model).getLabelNames());
 		for (String name : model.getLabels()) {
 			if (!labelNames.contains(name)) {
 				labelNames.add(name);
@@ -1646,7 +1650,7 @@ public class StateModelChecker extends PrismComponent
 			default:
 				throw new PrismNotSupportedException("Export " + exportOptions.getFormat().description() + " not supported by explicit engine");
 		}
-		exporter.setModelInfo(modelInfo);
+		exporter.setModelInfo(getModelInfo(model));
 		File file = exportTask.getFile();
 		// Disallow stdout export for binary formats
 		if (exportOptions.getFormat().isBinary() && !exportOptions.getBinaryAsText() && file == null) {

--- a/prism/src/explicit/StateModelChecker.java
+++ b/prism/src/explicit/StateModelChecker.java
@@ -85,6 +85,7 @@ import prism.Evaluator;
 import prism.Filter;
 import prism.ModelInfo;
 import prism.ModelType;
+import prism.Pair;
 import prism.Prism;
 import prism.PrismComponent;
 import prism.PrismException;
@@ -1519,6 +1520,92 @@ public class StateModelChecker extends PrismComponent
 	}
 
 	/**
+	 * Get the {@code r}th reward structure for a model. If the (stored) reward generator is
+	 * present, {@code r} is the (0-indexed) position within that list of rewards. But, if
+	 * rewards matching that reward structure's name or position are attached directly to
+	 * {@code model}, those are given preference over extracting one from the reward generator.
+	 * <br>
+	 * If there is no reward generator, the {@code r}th reward structure attached to the
+	 * model, if present, is returned (irrespective of any position/name info stored).
+	 * <br>
+	 * If {@code allowNegativeRewards} is false, rewards constructed from the reward generator
+	 * are checked to ensure that they are non-negative.
+	 */
+	protected <Value> Rewards<Value> getRewards(Model<Value> model, int r, boolean allowNegativeRewards) throws PrismException
+	{
+		if (rewardGen != null) {
+			Rewards<Value> byPosition = model.getRewardsByPosition(r);
+			Rewards<Value> byName = model.getRewardsByName(rewardGen.getRewardStructName(r));
+			if (byPosition != null && byName != null && byPosition != byName) {
+				throw new PrismException("Reward structure at position " + r + " and name \"" + rewardGen.getRewardStructName(r) + "\" refer to different reward structures attached to the model");
+			}
+			Rewards<Value> rews = byPosition != null ? byPosition : byName;
+			return rews != null ? rews : constructRewards(model, r, allowNegativeRewards);
+		}
+		return model.getRewards(r);
+	}
+
+	/**
+	 * Get the name of the reward structure with index r for a model (see {@link #getRewards}
+	 * for what r denotes). Names come from the stored reward generator, if present; if not,
+	 * from the model's own attached reward structures.
+	 */
+	protected String getRewardStructName(Model<?> model, int r)
+	{
+		return rewardGen != null ? rewardGen.getRewardStructName(r) : model.getRewardName(r);
+	}
+
+	/**
+	 * Get values and names for all the reward structures relevant/available for a model.
+	 * If a RewardGenerator is available, these rewards are added to the list.
+	 * If any additional, named rewards are attached to the model, these are also added.
+	 * If no RewardGenerator is present, any rewards attached to the models are used,
+	 * with their names if present, but with any positional info ignored.
+	 */
+	protected <Value> Pair<List<Rewards<Value>>, List<String>> getAllRewards(Model<Value> model) throws PrismException
+	{
+		List<Rewards<Value>> rewards = new ArrayList<>();
+		List<String> rewardNames = new ArrayList<>();
+		if (rewardGen != null) {
+			int numFromGen = rewardGen.getNumRewardStructs();
+			for (int r = 0; r < numFromGen; r++) {
+				rewardNames.add(rewardGen.getRewardStructName(r));
+				rewards.add(getRewards(model, r, true));
+			}
+			for (int i = 0; i < model.getNumRewards(); i++) {
+				String name = model.getRewardName(i);
+				if (name != null && !name.isEmpty() && !rewardNames.contains(name)) {
+					rewardNames.add(name);
+					rewards.add(model.getRewards(i));
+				}
+			}
+		} else {
+			int numRewards = model.getNumRewards();
+			for (int i = 0; i < numRewards; i++) {
+				rewardNames.add(model.getRewardName(i));
+				rewards.add(model.getRewards(i));
+			}
+		}
+		return new Pair<>(rewards, rewardNames);
+	}
+
+	/**
+	 * Get the names of all the labels relevant/available for a model: those from the
+	 * (always present) stored model info, plus any additional labels attached directly
+	 * to the model that are not already included.
+	 */
+	protected List<String> getAllLabelNames(Model<?> model)
+	{
+		List<String> labelNames = new ArrayList<>(modelInfo.getLabelNames());
+		for (String name : model.getLabels()) {
+			if (!labelNames.contains(name)) {
+				labelNames.add(name);
+			}
+		}
+		return labelNames;
+	}
+
+	/**
 	 * Load all labels from a PRISM labels (.lab) file and store them in BitSet objects.
 	 * Return a map from label name Strings to BitSets.
 	 * This is for all labels in the file, including "init", "deadlock".
@@ -1571,12 +1658,9 @@ public class StateModelChecker extends PrismComponent
 		}
 		// Add rewards to exporter if requested
 		if (exportOptions.getShowRewards()) {
-			List<Rewards<Value>> rewards = new ArrayList<>();
-			for (int r = 0; r < rewardGen.getNumRewardStructs(); r++) {
-				rewards.add(constructRewards(model, r, true));
-			}
-			exporter.addRewards(rewards, rewardGen.getRewardStructNames());
-			exporter.setRewardEvaluator((Evaluator<Value>) rewardGen.getRewardEvaluator());
+			Pair<List<Rewards<Value>>, List<String>> allRewards = getAllRewards(model);
+			exporter.setRewardEvaluator(rewardGen != null ? (Evaluator<Value>) rewardGen.getRewardEvaluator() : model.getEvaluator());
+			exporter.addRewards(allRewards.first, allRewards.second);
 		}
 		// Add labels to exporter if requested
 		if (exportOptions.getShowLabels()) {
@@ -1587,7 +1671,7 @@ public class StateModelChecker extends PrismComponent
 			if (exportTask.deadlockLabelIncluded()) {
 				labelNames.add("deadlock");
 			}
-			labelNames.addAll(modelInfo.getLabelNames());
+			labelNames.addAll(getAllLabelNames(model));
 			// If labels from a properties file were requested (and one is attached), add those too
 			if (exportTask.extraLabelsUsed() && propertiesFile != null) {
 				for (String name : propertiesFile.getCombinedLabelList().getLabelNames()) {
@@ -1636,10 +1720,10 @@ public class StateModelChecker extends PrismComponent
 
 		// Construct rewards before opening the output file:
 		// the rewards may be read lazily from an import file which could be the same as the export target.
-		Rewards<Value> modelRewards = constructRewards(model, r, true);
+		Rewards<Value> modelRewards = getRewards(model, r, true);
 		try (PrismLog out = getPrismLogForFile(file)) {
 			PrismExplicitExporter<Value> exporter = new PrismExplicitExporter<>(exportOptions);
-			exporter.exportStateRewards(model, modelRewards, rewardGen.getRewardStructName(r), out);
+			exporter.exportStateRewards(model, modelRewards, getRewardStructName(model, r), out);
 		}
 		ModelExportZipper.zipIfRequested(file, exportOptions);
 	}
@@ -1659,10 +1743,10 @@ public class StateModelChecker extends PrismComponent
 
 		// Construct rewards before opening the output file:
 		// the rewards may be read lazily from an import file which could be the same as the export target.
-		Rewards<Value> modelRewards = constructRewards(model, r, true);
+		Rewards<Value> modelRewards = getRewards(model, r, true);
 		try (PrismLog out = getPrismLogForFile(file)) {
 			PrismExplicitExporter<Value> exporter = new PrismExplicitExporter<>(exportOptions);
-			exporter.exportTransRewards(model, modelRewards, rewardGen.getRewardStructName(r), out);
+			exporter.exportTransRewards(model, modelRewards, getRewardStructName(model, r), out);
 		}
 		ModelExportZipper.zipIfRequested(file, exportOptions);
 	}

--- a/prism/src/explicit/SubNondetModel.java
+++ b/prism/src/explicit/SubNondetModel.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 
 import common.IterableStateSet;
+import explicit.rewards.Rewards;
 import io.ModelExportOptions;
 import parser.State;
 import parser.Values;
@@ -223,6 +224,42 @@ public class SubNondetModel<Value> implements NondetModel<Value>, ActionListOwne
 
 	@Override
 	public boolean hasLabel(String name)
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Rewards<Value> getRewardsByName(String name)
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Rewards<Value> getRewardsByPosition(int r)
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int getNumRewards()
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Rewards<Value> getRewards(int i)
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getRewardName(int i)
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Integer getRewardPosition(int i)
 	{
 		throw new UnsupportedOperationException();
 	}

--- a/prism/src/explicit/modelviews/DTMCAlteredDistributions.java
+++ b/prism/src/explicit/modelviews/DTMCAlteredDistributions.java
@@ -42,6 +42,7 @@ import parser.State;
 import parser.Values;
 import parser.VarList;
 import explicit.DTMC;
+import explicit.rewards.Rewards;
 
 /**
  * A view of a DTMC where for selected states the transitions are changed.
@@ -144,6 +145,42 @@ public class DTMCAlteredDistributions<Value> extends DTMCView<Value>
 	public BitSet getLabelStates(final String name)
 	{
 		return model.getLabelStates(name);
+	}
+
+	@Override
+	public Rewards<Value> getRewardsByName(String name)
+	{
+		return model.getRewardsByName(name);
+	}
+
+	@Override
+	public Rewards<Value> getRewardsByPosition(int r)
+	{
+		return model.getRewardsByPosition(r);
+	}
+
+	@Override
+	public int getNumRewards()
+	{
+		return model.getNumRewards();
+	}
+
+	@Override
+	public Rewards<Value> getRewards(int i)
+	{
+		return model.getRewards(i);
+	}
+
+	@Override
+	public String getRewardName(int i)
+	{
+		return model.getRewardName(i);
+	}
+
+	@Override
+	public Integer getRewardPosition(int i)
+	{
+		return model.getRewardPosition(i);
 	}
 
 	@Override

--- a/prism/src/explicit/modelviews/MDPAdditionalChoices.java
+++ b/prism/src/explicit/modelviews/MDPAdditionalChoices.java
@@ -39,6 +39,7 @@ import java.util.function.IntPredicate;
 
 import common.iterable.SingletonIterator;
 import explicit.MDP;
+import explicit.rewards.Rewards;
 import parser.State;
 import parser.Values;
 import parser.VarList;
@@ -143,6 +144,42 @@ public class MDPAdditionalChoices<Value> extends MDPView<Value>
 	public BitSet getLabelStates(final String name)
 	{
 		return model.getLabelStates(name);
+	}
+
+	@Override
+	public Rewards<Value> getRewardsByName(String name)
+	{
+		return model.getRewardsByName(name);
+	}
+
+	@Override
+	public Rewards<Value> getRewardsByPosition(int r)
+	{
+		return model.getRewardsByPosition(r);
+	}
+
+	@Override
+	public int getNumRewards()
+	{
+		return model.getNumRewards();
+	}
+
+	@Override
+	public Rewards<Value> getRewards(int i)
+	{
+		return model.getRewards(i);
+	}
+
+	@Override
+	public String getRewardName(int i)
+	{
+		return model.getRewardName(i);
+	}
+
+	@Override
+	public Integer getRewardPosition(int i)
+	{
+		return model.getRewardPosition(i);
 	}
 
 	@Override

--- a/prism/src/explicit/modelviews/MDPDroppedAllChoices.java
+++ b/prism/src/explicit/modelviews/MDPDroppedAllChoices.java
@@ -35,6 +35,7 @@ import java.util.Set;
 
 import common.iterable.EmptyIterator;
 import explicit.MDP;
+import explicit.rewards.Rewards;
 import parser.State;
 import parser.Values;
 import parser.VarList;
@@ -129,6 +130,42 @@ public class MDPDroppedAllChoices<Value> extends MDPView<Value>
 	public BitSet getLabelStates(final String name)
 	{
 		return model.getLabelStates(name);
+	}
+
+	@Override
+	public Rewards<Value> getRewardsByName(String name)
+	{
+		return model.getRewardsByName(name);
+	}
+
+	@Override
+	public Rewards<Value> getRewardsByPosition(int r)
+	{
+		return model.getRewardsByPosition(r);
+	}
+
+	@Override
+	public int getNumRewards()
+	{
+		return model.getNumRewards();
+	}
+
+	@Override
+	public Rewards<Value> getRewards(int i)
+	{
+		return model.getRewards(i);
+	}
+
+	@Override
+	public String getRewardName(int i)
+	{
+		return model.getRewardName(i);
+	}
+
+	@Override
+	public Integer getRewardPosition(int i)
+	{
+		return model.getRewardPosition(i);
 	}
 
 	@Override

--- a/prism/src/explicit/modelviews/MDPDroppedChoicesCached.java
+++ b/prism/src/explicit/modelviews/MDPDroppedChoicesCached.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import common.functions.PairPredicateInt;
 import explicit.Distribution;
 import explicit.MDP;
+import explicit.rewards.Rewards;
 import parser.State;
 import parser.Values;
 import parser.VarList;
@@ -150,6 +151,42 @@ public class MDPDroppedChoicesCached<Value> extends MDPView<Value>
 	public BitSet getLabelStates(final String name)
 	{
 		return model.getLabelStates(name);
+	}
+
+	@Override
+	public Rewards<Value> getRewardsByName(String name)
+	{
+		return model.getRewardsByName(name);
+	}
+
+	@Override
+	public Rewards<Value> getRewardsByPosition(int r)
+	{
+		return model.getRewardsByPosition(r);
+	}
+
+	@Override
+	public int getNumRewards()
+	{
+		return model.getNumRewards();
+	}
+
+	@Override
+	public Rewards<Value> getRewards(int i)
+	{
+		return model.getRewards(i);
+	}
+
+	@Override
+	public String getRewardName(int i)
+	{
+		return model.getRewardName(i);
+	}
+
+	@Override
+	public Integer getRewardPosition(int i)
+	{
+		return model.getRewardPosition(i);
 	}
 
 	@Override

--- a/prism/src/explicit/modelviews/MDPEquiv.java
+++ b/prism/src/explicit/modelviews/MDPEquiv.java
@@ -42,6 +42,7 @@ import common.IterableStateSet;
 import common.iterable.Reducible;
 import explicit.BasicModelTransformation;
 import explicit.MDP;
+import explicit.rewards.Rewards;
 import parser.State;
 import parser.Values;
 import parser.VarList;
@@ -181,6 +182,42 @@ public class MDPEquiv<Value> extends MDPView<Value>
 	public BitSet getLabelStates(String name)
 	{
 		return model.getLabelStates(name);
+	}
+
+	@Override
+	public Rewards<Value> getRewardsByName(String name)
+	{
+		return model.getRewardsByName(name);
+	}
+
+	@Override
+	public Rewards<Value> getRewardsByPosition(int r)
+	{
+		return model.getRewardsByPosition(r);
+	}
+
+	@Override
+	public int getNumRewards()
+	{
+		return model.getNumRewards();
+	}
+
+	@Override
+	public Rewards<Value> getRewards(int i)
+	{
+		return model.getRewards(i);
+	}
+
+	@Override
+	public String getRewardName(int i)
+	{
+		return model.getRewardName(i);
+	}
+
+	@Override
+	public Integer getRewardPosition(int i)
+	{
+		return model.getRewardPosition(i);
 	}
 
 	@Override

--- a/prism/src/explicit/modelviews/MDPFromDTMC.java
+++ b/prism/src/explicit/modelviews/MDPFromDTMC.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import explicit.DTMC;
 import explicit.DTMCSimple;
 import explicit.MDP;
+import explicit.rewards.Rewards;
 import parser.State;
 import parser.Values;
 import parser.VarList;
@@ -128,6 +129,42 @@ public class MDPFromDTMC<Value> extends MDPView<Value>
 	public BitSet getLabelStates(final String name)
 	{
 		return model.getLabelStates(name);
+	}
+
+	@Override
+	public Rewards<Value> getRewardsByName(String name)
+	{
+		return model.getRewardsByName(name);
+	}
+
+	@Override
+	public Rewards<Value> getRewardsByPosition(int r)
+	{
+		return model.getRewardsByPosition(r);
+	}
+
+	@Override
+	public int getNumRewards()
+	{
+		return model.getNumRewards();
+	}
+
+	@Override
+	public Rewards<Value> getRewards(int i)
+	{
+		return model.getRewards(i);
+	}
+
+	@Override
+	public String getRewardName(int i)
+	{
+		return model.getRewardName(i);
+	}
+
+	@Override
+	public Integer getRewardPosition(int i)
+	{
+		return model.getRewardPosition(i);
 	}
 
 	@Override

--- a/prism/src/explicit/rewards/ConstructRewards.java
+++ b/prism/src/explicit/rewards/ConstructRewards.java
@@ -31,9 +31,11 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.WeakHashMap;
 
 import common.Interval;
 import explicit.DTMC;
@@ -99,7 +101,7 @@ public class ConstructRewards extends PrismComponent
 		// If the RewardGenerator already has the rewards built, use this (after checking)
 		if (rewardGen.isRewardLookupSupported(RewardLookup.BY_REWARD_OBJECT)) {
 			Rewards<Value> rewardsObj = rewardGen.getRewardObject(r);
-			rewardsObj = checkRewardObject(rewardsObj, rewardGen.getRewardObjectModel(), rewardGen.getRewardEvaluator());
+			rewardsObj = getExpectedRewards(rewardsObj, rewardGen.getRewardObjectModel(), rewardGen.getRewardEvaluator(), expectedRewards, allowNegative);
 			return rewardsObj;
 		}
 		// Extract some model info
@@ -466,6 +468,21 @@ public class ConstructRewards extends PrismComponent
 	 */
 	private <Value> void checkStateReward(Value rew, Evaluator<Value> eval, Object stateIndex, ASTElement ast) throws PrismException
 	{
+		checkStateReward(rew, eval, stateIndex, ast, allowNegative);
+	}
+
+	/**
+	 * Check that a state reward is legal. Throw an exception if not.
+	 * Optionally, provide a state where the error occurs (as an Object),
+	 * and/or a pointer to where the error occurs syntactically (as an ASTElement)
+	 * @param rew The reward value
+	 * @param eval Evaluator matching the type {@code Value} of the reward value
+	 * @param stateIndex The index of the state, for error reporting (optional)
+	 * @param ast Where the error occurred, for error reporting (optional)
+	 * @param allowNegative Whether negative rewards (i.e., weights) are allowed
+	 */
+	private static <Value> void checkStateReward(Value rew, Evaluator<Value> eval, Object stateIndex, ASTElement ast, boolean allowNegative) throws PrismException
+	{
 		String error = null;
 		// We omit the check in symbolic (parametric) cases - too expensive
 		if (!eval.isSymbolic()) {
@@ -498,6 +515,21 @@ public class ConstructRewards extends PrismComponent
 	 */
 	private <Value> void checkTransitionReward(Value rew, Evaluator<Value> eval, Object stateIndex, ASTElement ast) throws PrismException
 	{
+		checkTransitionReward(rew, eval, stateIndex, ast, allowNegative);
+	}
+
+	/**
+	 * Check that a transition reward is legal. Throw an exception if not.
+	 * Optionally, provide a state where the error occurs (as an Object),
+	 * and/or a pointer to where the error occurs syntactically (as an ASTElement)
+	 * @param rew The reward value
+	 * @param eval Evaluator matching the type {@code Value} of the reward value
+	 * @param stateIndex The index of the state, for error reporting (optional)
+	 * @param ast Where the error occurred, for error reporting (optional)
+	 * @param allowNegative Whether negative rewards (i.e., weights) are allowed
+	 */
+	private static <Value> void checkTransitionReward(Value rew, Evaluator<Value> eval, Object stateIndex, ASTElement ast, boolean allowNegative) throws PrismException
+	{
 		String error = null;
 		// We omit the check in symbolic (parametric) cases - too expensive
 		if (!eval.isSymbolic()) {
@@ -520,14 +552,67 @@ public class ConstructRewards extends PrismComponent
 	}
 
 	/**
+	 * Caches of the result of {@link #getExpectedRewards}, keyed on the identity of the
+	 * {@code rewards} object passed in (weakly, so entries disappear once that object is
+	 * no longer referenced elsewhere). A separate cache is kept for each combination of
+	 * the {@code expectedRewards}/{@code allowNegative} flags, since the result differs.
+	 * <br>
+	 * This exists because a {@link Rewards} object obtained from an external source
+	 * (e.g., imported from file, or attached directly to a {@link Model}) may be checked
+	 * and/or converted repeatedly for the same underlying object - e.g., once per property
+	 * checked against the same model - and both the legality checks and the (Markov chain)
+	 * transition-to-expected-state-reward conversion are otherwise redone from scratch
+	 * (an O(number of states/transitions) pass) every time.
+	 */
+	private static final Map<Rewards<?>, Rewards<?>> expectedRewardsCacheFF = Collections.synchronizedMap(new WeakHashMap<>());
+	private static final Map<Rewards<?>, Rewards<?>> expectedRewardsCacheFT = Collections.synchronizedMap(new WeakHashMap<>());
+	private static final Map<Rewards<?>, Rewards<?>> expectedRewardsCacheTF = Collections.synchronizedMap(new WeakHashMap<>());
+	private static final Map<Rewards<?>, Rewards<?>> expectedRewardsCacheTT = Collections.synchronizedMap(new WeakHashMap<>());
+
+	/**
+	 * Get a version of {@code rewards} that is safe to pass to the (explicit engine)
+	 * solution methods, i.e., with all state/transition rewards checked for legality
+	 * and, if {@code expectedRewards} is true, with any (Markov chain) transition
+	 * rewards converted to expected state rewards (since solution methods for
+	 * Markov chains do not read transition rewards directly).
+	 * <br>
+	 * Use this (rather than constructing rewards afresh) for any {@link Rewards} object
+	 * that was not just built by this class, e.g., one obtained directly from a model
+	 * (see {@link Model#getRewards}) or from a {@link RewardGenerator} that supplies
+	 * rewards objects directly (see {@link RewardGenerator.RewardLookup#BY_REWARD_OBJECT}).
+	 * The result is cached against the identity of {@code rewards}.
+	 * @param rewards The rewards to check/convert
+	 * @param model The model that the rewards are for
+	 * @param eval Evaluator matching the type {@code Value} of the reward value
+	 * @param expectedRewards Whether to convert (Markov chain) transition rewards to expected state rewards
+	 * @param allowNegative Whether negative rewards (i.e., weights) are allowed
+	 */
+	@SuppressWarnings("unchecked")
+	public static <Value> Rewards<Value> getExpectedRewards(Rewards<Value> rewards, Model<Value> model, Evaluator<Value> eval, boolean expectedRewards, boolean allowNegative) throws PrismException
+	{
+		Map<Rewards<?>, Rewards<?>> cache = expectedRewards
+				? (allowNegative ? expectedRewardsCacheTT : expectedRewardsCacheTF)
+				: (allowNegative ? expectedRewardsCacheFT : expectedRewardsCacheFF);
+		Rewards<Value> cached = (Rewards<Value>) cache.get(rewards);
+		if (cached != null) {
+			return cached;
+		}
+		Rewards<Value> result = checkRewardObject(rewards, model, eval, expectedRewards, allowNegative);
+		cache.put(rewards, result);
+		return result;
+	}
+
+	/**
 	 * Check that all state/transition rewards in a Rewards object are legal. Throw an exception if not.
-	 * Optionally, provide a state where the error occurs (as an Object),
-	 * and/or a pointer to where the error occurs syntactically (as an ASTElement)
+	 * If {@code expectedRewards} is true, also convert any (Markov chain) transition rewards to
+	 * expected state rewards.
 	 * @param rewards The rewards
 	 * @param model The model for the rewards
 	 * @param eval Evaluator matching the type {@code Value} of the reward value
+	 * @param expectedRewards Whether to convert (Markov chain) transition rewards to expected state rewards
+	 * @param allowNegative Whether negative rewards (i.e., weights) are allowed
 	 */
-	private <Value> Rewards<Value> checkRewardObject(Rewards<Value> rewards, Model<Value> model, Evaluator<Value> eval) throws PrismException
+	private static <Value> Rewards<Value> checkRewardObject(Rewards<Value> rewards, Model<Value> model, Evaluator<Value> eval, boolean expectedRewards, boolean allowNegative) throws PrismException
 	{
 		int numStates = model.getNumStates();
 		// In some cases, we need to create a new Rewards object
@@ -541,7 +626,7 @@ public class ConstructRewards extends PrismComponent
 		// State rewards
 		for (int s = 0; s < numStates; s++) {
 			Value rew = rewards.getStateReward(s);
-			checkStateReward(rew, eval, s, null);
+			checkStateReward(rew, eval, s, null, allowNegative);
 			if (convertToExpected) {
 				rewardsRet.setStateReward(s, rew);
 			}
@@ -551,7 +636,7 @@ public class ConstructRewards extends PrismComponent
 			for (int s = 0; s < numStates; s++) {
 				int numChoices = ((NondetModel<?>) model).getNumChoices(s);
 				for (int i = 0; i < numChoices; i++) {
-					checkTransitionReward(rewards.getTransitionReward(s, i), eval, s, null);
+					checkTransitionReward(rewards.getTransitionReward(s, i), eval, s, null, allowNegative);
 				}
 			}
 		}
@@ -561,7 +646,7 @@ public class ConstructRewards extends PrismComponent
 				if (!convertToExpected) {
 					int numTrans = model.getNumTransitions(s);
 					for (int i = 0; i < numTrans; i++) {
-						checkTransitionReward(rewards.getTransitionReward(s, i), eval, s, null);
+						checkTransitionReward(rewards.getTransitionReward(s, i), eval, s, null, allowNegative);
 					}
 				} else {
 					DTMC<Value> mcModel = (DTMC<Value>) model;
@@ -570,7 +655,7 @@ public class ConstructRewards extends PrismComponent
 					while (iter.hasNext()) {
 						Map.Entry<Integer, Value> e = iter.next();
 						Value rew = rewards.getTransitionReward(s, i);
-						checkTransitionReward(rew, eval, s, null);
+						checkTransitionReward(rew, eval, s, null, allowNegative);
 						if (rewards.getEvaluator().isZero(rew)) {
 							i++;
 							continue;

--- a/prism/src/explicit/rewards/ConstructRewards.java
+++ b/prism/src/explicit/rewards/ConstructRewards.java
@@ -554,8 +554,15 @@ public class ConstructRewards extends PrismComponent
 	/**
 	 * Caches of the result of {@link #getExpectedRewards}, keyed on the identity of the
 	 * {@code rewards} object passed in (weakly, so entries disappear once that object is
-	 * no longer referenced elsewhere). A separate cache is kept for each combination of
-	 * the {@code expectedRewards}/{@code allowNegative} flags, since the result differs.
+	 * no longer referenced elsewhere), and then, within that, on the identity of the
+	 * {@code model} passed in (also weakly). The per-model level is needed because the
+	 * same {@link Rewards} object can be checked/converted against different models
+	 * (e.g., a model view such as {@code DTMCAlteredDistributions} delegates
+	 * {@code getRewards*()} to an underlying model while presenting different transitions
+	 * of its own), and the (Markov chain) transition-to-expected-state-reward conversion
+	 * depends on the transition structure of the model passed in, not just the rewards.
+	 * A separate cache is kept for each combination of the {@code expectedRewards}/
+	 * {@code allowNegative} flags, since the result differs.
 	 * <br>
 	 * This exists because a {@link Rewards} object obtained from an external source
 	 * (e.g., imported from file, or attached directly to a {@link Model}) may be checked
@@ -564,10 +571,10 @@ public class ConstructRewards extends PrismComponent
 	 * transition-to-expected-state-reward conversion are otherwise redone from scratch
 	 * (an O(number of states/transitions) pass) every time.
 	 */
-	private static final Map<Rewards<?>, Rewards<?>> expectedRewardsCacheFF = Collections.synchronizedMap(new WeakHashMap<>());
-	private static final Map<Rewards<?>, Rewards<?>> expectedRewardsCacheFT = Collections.synchronizedMap(new WeakHashMap<>());
-	private static final Map<Rewards<?>, Rewards<?>> expectedRewardsCacheTF = Collections.synchronizedMap(new WeakHashMap<>());
-	private static final Map<Rewards<?>, Rewards<?>> expectedRewardsCacheTT = Collections.synchronizedMap(new WeakHashMap<>());
+	private static final Map<Rewards<?>, Map<Model<?>, Rewards<?>>> expectedRewardsCacheFF = Collections.synchronizedMap(new WeakHashMap<>());
+	private static final Map<Rewards<?>, Map<Model<?>, Rewards<?>>> expectedRewardsCacheFT = Collections.synchronizedMap(new WeakHashMap<>());
+	private static final Map<Rewards<?>, Map<Model<?>, Rewards<?>>> expectedRewardsCacheTF = Collections.synchronizedMap(new WeakHashMap<>());
+	private static final Map<Rewards<?>, Map<Model<?>, Rewards<?>>> expectedRewardsCacheTT = Collections.synchronizedMap(new WeakHashMap<>());
 
 	/**
 	 * Get a version of {@code rewards} that is safe to pass to the (explicit engine)
@@ -580,7 +587,7 @@ public class ConstructRewards extends PrismComponent
 	 * that was not just built by this class, e.g., one obtained directly from a model
 	 * (see {@link Model#getRewards}) or from a {@link RewardGenerator} that supplies
 	 * rewards objects directly (see {@link RewardGenerator.RewardLookup#BY_REWARD_OBJECT}).
-	 * The result is cached against the identity of {@code rewards}.
+	 * The result is cached against the identity of {@code rewards} and {@code model}.
 	 * @param rewards The rewards to check/convert
 	 * @param model The model that the rewards are for
 	 * @param eval Evaluator matching the type {@code Value} of the reward value
@@ -590,15 +597,16 @@ public class ConstructRewards extends PrismComponent
 	@SuppressWarnings("unchecked")
 	public static <Value> Rewards<Value> getExpectedRewards(Rewards<Value> rewards, Model<Value> model, Evaluator<Value> eval, boolean expectedRewards, boolean allowNegative) throws PrismException
 	{
-		Map<Rewards<?>, Rewards<?>> cache = expectedRewards
+		Map<Rewards<?>, Map<Model<?>, Rewards<?>>> cache = expectedRewards
 				? (allowNegative ? expectedRewardsCacheTT : expectedRewardsCacheTF)
 				: (allowNegative ? expectedRewardsCacheFT : expectedRewardsCacheFF);
-		Rewards<Value> cached = (Rewards<Value>) cache.get(rewards);
+		Map<Model<?>, Rewards<?>> modelCache = cache.computeIfAbsent(rewards, k -> Collections.synchronizedMap(new WeakHashMap<>()));
+		Rewards<Value> cached = (Rewards<Value>) modelCache.get(model);
 		if (cached != null) {
 			return cached;
 		}
 		Rewards<Value> result = checkRewardObject(rewards, model, eval, expectedRewards, allowNegative);
-		cache.put(rewards, result);
+		modelCache.put(model, result);
 		return result;
 	}
 

--- a/prism/src/parser/ast/ExpressionReward.java
+++ b/prism/src/parser/ast/ExpressionReward.java
@@ -135,6 +135,18 @@ public class ExpressionReward extends ExpressionQuant
 	}
 
 	/**
+	 * Get the index of a reward structure (within a model) corresponding to the index of this R operator.
+	 * This is 0-indexed (as used e.g. in ModulesFile), not 1-indexed (as seen by user)
+	 * @param rewardStructNames List of reward struct names
+	 * @param constantValues Values of constants which may be needed to evaluate the index
+	 * @param errorIfAbsent Whether to throw an error if the reward structure is not found (true) or return -1 (false)
+	 */
+	public int getRewardStructIndexByIndexObject(List<String> rewardStructNames, Values constantValues, boolean errorIfAbsent) throws PrismException
+	{
+		return getRewardStructIndexByIndexObject(rewardStructIndex, rewardStructNames, constantValues, errorIfAbsent);
+	}
+
+	/**
 	 * Get the index of a reward structure (within a model) corresponding to the rsi reward structure index object.
 	 * This is 0-indexed (as used e.g. in ModulesFile), not 1-indexed (as seen by user)
 	 * Throws an exception (with explanatory message) if it cannot be found.
@@ -162,8 +174,25 @@ public class ExpressionReward extends ExpressionQuant
 	 */
 	public static int getRewardStructIndexByIndexObject(Object rsi, List<String> rewardStructNames, Values constantValues) throws PrismException
 	{
-		if (rewardStructNames.size() == 0) {
-			throw new PrismException("Model has no rewards specified");
+		return getRewardStructIndexByIndexObject(rsi, rewardStructNames, constantValues, true);
+	}
+
+	/**
+	 * Get the index of a reward structure (within a model) corresponding to the rsi reward structure index object.
+	 * This is 0-indexed (as used e.g. in ModulesFile), not 1-indexed (as seen by user)
+	 * @param rsi The reward structure index: Expression (evaluating to index, starting from 1) or String (name)
+	 * @param rewardStructNames List of reward struct names
+	 * @param constantValues Values of constants which may be needed to evaluate the index
+	 * @param errorIfAbsent Whether to throw an error if the reward structure is not found (true) or return -1 (false)
+	 */
+	public static int getRewardStructIndexByIndexObject(Object rsi, List<String> rewardStructNames, Values constantValues, boolean errorIfAbsent) throws PrismException
+	{
+		if (rewardStructNames.isEmpty()) {
+			if (errorIfAbsent) {
+				throw new PrismException("Model has no rewards specified");
+			} else {
+				return -1;
+			}
 		}
 		// Recall: the index is an Object which is either an Integer, denoting the index (starting from 0) directly,
 		// or an expression, which can be evaluated (possibly using the passed in constants) to an index. 
@@ -183,7 +212,7 @@ public class ExpressionReward extends ExpressionQuant
 		else if (rsi instanceof String) {
 			rewStruct = rewardStructNames.indexOf((String) rsi);
 		}
-		if (rewStruct == -1) {
+		if (rewStruct == -1 && errorIfAbsent) {
 			throw new PrismException("Invalid reward structure index \"" + rsi + "\"");
 		}
 		return rewStruct;

--- a/prism/src/prism/Prism.java
+++ b/prism/src/prism/Prism.java
@@ -3000,6 +3000,12 @@ public class Prism extends PrismComponent implements PrismSettingsListener
 				labelNames.add("deadlock");
 			}
 			labelNames.addAll(getModelInfo().getLabelNames());
+			// Also include any labels attached directly to the built model
+			for (String name : (getBuiltModelType() != ModelBuildType.SYMBOLIC ? getBuiltModelExplicit().getLabels() : getBuiltModelSymbolic().getLabels())) {
+				if (!labelNames.contains(name)) {
+					labelNames.add(name);
+				}
+			}
 		}
 		if (exportTask.getLabelExportSet() == ModelExportTask.LabelExportSet.EXTRA || exportTask.getLabelExportSet() == ModelExportTask.LabelExportSet.ALL) {
 			LabelList ll = exportTask.getExtraLabelsSource().getLabelList();

--- a/prism/src/prism/PrismFileLog.java
+++ b/prism/src/prism/PrismFileLog.java
@@ -128,6 +128,14 @@ public class PrismFileLog extends PrismPrintStreamLog
 	}
 
 	/**
+	 * Is this log writing to standard output (rather than a file)?
+	 */
+	public boolean isStdout()
+	{
+		return stdout;
+	}
+
+	/**
 	 * Is this log using native code to write to the file?
 	 */
 	public boolean isNative()


### PR DESCRIPTION
Allows attaching, managing, and copying reward structures in explicit-state models. The changes unify the handling of rewards across the model hierarchy, provide new APIs for accessing rewards by name or position, and ensure that reward structures are consistently copied and exported. Additionally, model checking now resolves reward structures directly from models when possible, improving flexibility and reusability. Also updates similar existing functionality for labels.
